### PR TITLE
Fixed typo in linear_search.py

### DIFF
--- a/searches/linear_search.py
+++ b/searches/linear_search.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 
 
 def linear_search(sequence, target):
-    """Pure implementation of binary search algorithm in Python
+    """Pure implementation of linear search algorithm in Python
 
     :param sequence: some sorted collection with comparable items
     :param target: item value to search


### PR DESCRIPTION
The documentation comment said "binary search" when it should say "linear search".