### PR TITLE
Added front to indicate the starting of the Queue

### DIFF
--- a/data_structures/Queue/QueueOnList.py
+++ b/data_structures/Queue/QueueOnList.py
@@ -3,6 +3,7 @@ class Queue():
     def __init__(self):
         self.entries = []
         self.length = 0
+        self.front=0
 
     def __str__(self):
         printed = '<' + str(self.entries)[1:-1] + '>'
@@ -22,8 +23,9 @@ class Queue():
         item that was dequeued"""
     def get(self):
         self.length = self.length - 1
-        dequeued = self.entries[0]
-        self.entries = self.entries[1:]
+        dequeued = self.entries[self.front]
+        self.front-=1
+        self.entries = self.entries[self.front:]
         return dequeued
 
     """Rotates the queue {@code rotation} times


### PR DESCRIPTION
`front` is added so that dequeue can be done any number of times.Without `front`,it displays only `self.entries[0]` as _dequeued._