### PR TITLE
Fix: typo in multiple files.

### DIFF
--- a/dynamic_programming/fibonacci.py
+++ b/dynamic_programming/fibonacci.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     import sys
 
     print("\n********* Fibonacci Series Using Dynamic Programming ************\n")
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -137,7 +137,7 @@ def __assert_sorted(collection):
 
 if __name__ == '__main__':
     import sys
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/searches/linear_search.py
+++ b/searches/linear_search.py
@@ -41,7 +41,7 @@ def linear_search(sequence, target):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/bogosort.py
+++ b/sorts/bogosort.py
@@ -41,7 +41,7 @@ def bogosort(collection):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/bubble_sort.py
+++ b/sorts/bubble_sort.py
@@ -41,7 +41,7 @@ def bubble_sort(collection):
 
 if __name__ == '__main__':
     import sys
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/cocktail_shaker_sort.py
+++ b/sorts/cocktail_shaker_sort.py
@@ -23,7 +23,7 @@ def cocktail_shaker_sort(unsorted):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -21,7 +21,7 @@ def gnome_sort(unsorted):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/insertion_sort.py
+++ b/sorts/insertion_sort.py
@@ -41,7 +41,7 @@ def insertion_sort(collection):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/merge_sort.py
+++ b/sorts/merge_sort.py
@@ -64,7 +64,7 @@ def merge_sort(collection):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/quick_sort.py
+++ b/sorts/quick_sort.py
@@ -42,7 +42,7 @@ def quick_sort(ARRAY):
 if __name__ == '__main__':
     import sys
 
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/selection_sort.py
+++ b/sorts/selection_sort.py
@@ -44,7 +44,7 @@ def selection_sort(collection):
 
 if __name__ == '__main__':
     import sys
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/sorts/shell_sort.py
+++ b/sorts/shell_sort.py
@@ -45,7 +45,7 @@ def shell_sort(collection):
 
 if __name__ == '__main__':
     import sys
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input

--- a/traverals/binary_tree_traversals.py
+++ b/traverals/binary_tree_traversals.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     import sys
 
     print("\n********* Binary Tree Traversals ************\n")
-    # For python 2.x and 3.x compatibility: 3.x has not raw_input builtin
+    # For python 2.x and 3.x compatibility: 3.x has no raw_input builtin
     # otherwise 2.x's input builtin function is too "smart"
     if sys.version_info.major < 3:
         input_function = raw_input


### PR DESCRIPTION
For python 2.x and 3.x compatibility: 3.x has **not** raw_input builtin
->
For python 2.x and 3.x compatibility: 3.x has **no** raw_input builtin
