### PR TITLE
noqa to silence flake8 on Python 3 only syntax 

### DIFF
--- a/data_structures/Trie/Trie.py
+++ b/data_structures/Trie/Trie.py
@@ -12,7 +12,7 @@ class TrieNode:
         self.nodes = dict()  # Mapping from char to TrieNode
         self.is_leaf = False
 
-    def insert_many(self, words: [str]):
+    def insert_many(self, words: [str]):  # noqa: F821 This syntax is Python 3 only
         """
         Inserts a list of words into the Trie
         :param words: list of string words
@@ -34,7 +34,7 @@ class TrieNode:
             curr = curr.nodes[char]
         curr.is_leaf = True
 
-    def find(self, word: str) -> bool:
+    def find(self, word: str) -> bool:  # noqa: F821 This syntax is Python 3 only
         """
         Tries to find word in a Trie
         :param word: word to look for
@@ -48,7 +48,7 @@ class TrieNode:
         return curr.is_leaf
 
 
-def print_words(node: TrieNode, word: str):
+def print_words(node: TrieNode, word: str):  # noqa: F821 This syntax is Python 3 only
     """
     Prints all the words in a Trie
     :param node: root node of Trie

--- a/data_structures/Trie/Trie.py
+++ b/data_structures/Trie/Trie.py
@@ -21,7 +21,7 @@ class TrieNode:
         for word in words:
             self.insert(word)
 
-    def insert(self, word: str):
+    def insert(self, word: str):  # noqa: F821 This syntax is Python 3 only
         """
         Inserts a word into the Trie
         :param word: word to be inserted

--- a/dynamic_programming/fastfibonacci.py
+++ b/dynamic_programming/fastfibonacci.py
@@ -7,14 +7,14 @@ import sys
 
 
 # returns F(n)
-def fibonacci(n: int):
+def fibonacci(n: int):  # noqa: F821 This syntax is Python 3 only
     if n < 0:
         raise ValueError("Negative arguments are not supported")
     return _fib(n)[0]
 
 
 # returns (F(n), F(n-1))
-def _fib(n: int):
+def _fib(n: int):  # noqa: F821 This syntax is Python 3 only
     if n == 0:
         # (F(0), F(1))
         return (0, 1)


### PR DESCRIPTION
flake8 testing of https://github.com/TheAlgorithms/Python on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./data_structures/Trie/Trie.py:15:32: E999 SyntaxError: invalid syntax
    def insert_many(self, words: [str]):
                               ^
./dynamic_programming/fastfibonacci.py:10:16: E999 SyntaxError: invalid syntax
def fibonacci(n: int):
               ^
2     E999 SyntaxError: invalid syntax
```