### PR TITLE
Fixed recursion error in binary_search_by_recursion

### DIFF
--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -110,6 +110,9 @@ def binary_search_by_recursion(sorted_collection, item, left, right):
     >>> binary_search_std_lib([0, 5, 7, 10, 15], 6)
 
     """
+    if (right < left):
+        return None
+    
     midpoint = left + (right - left) // 2
 
     if sorted_collection[midpoint] == item:


### PR DESCRIPTION
In binary_search_by_recursion, if you search array for a value that does not exist, you will get this error:

RecursionError: maximum recursion depth exceeded in comparison

To fix this, first check to make sure that the value is between left and right points like this:

    if (right < left):
        return None

A similar construct has already been applied to binary_search, but did not exist in the recursive alternative. 