### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/Project Euler/Problem 10/sol1.py
+++ b/Project Euler/Problem 10/sol1.py
@@ -1,6 +1,12 @@
 from __future__ import print_function
 from math import sqrt
 
+try:
+	xrange          # Python 2
+except NameError:
+	xrange = range  # Python 3
+
+
 def is_prime(n):
 	for i in xrange(2, int(sqrt(n))+1):
 		if n%i == 0:


### PR DESCRIPTION
@daniel-s-ingram Similar changes needed on Problems 25 and 28 so they can run on Python 3.

flake8 testing of https://github.com/TheAlgorithms/Python on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Project Euler/Problem 10/sol1.py:5:11: F821 undefined name 'xrange'
	for i in xrange(2, int(sqrt(n))+1):
          ^
./Project Euler/Problem 10/sol1.py:17:11: F821 undefined name 'xrange'
	for i in xrange(3, n, 2):
          ^
./Project Euler/Problem 25/sol1.py:10:12: F821 undefined name 'xrange'
		for i in xrange(2, n+1):
           ^
./Project Euler/Problem 28/sol1.py:7:11: F821 undefined name 'xrange'
	for i in xrange(1, int(ceil(n/2.0))):
          ^
4     F821 undefined name 'xrange'
```