### PR TITLE
fix type error (except an int) in jumpmp_search line 7.

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 import math
 def jump_search(arr, x):
     n = len(arr)
-    step = math.floor(math.sqrt(n))
+    step = int(math.floor(math.sqrt(n)))
     prev = 0
     while arr[min(step, n)-1] < x:
         prev = step
-        step += math.floor(math.sqrt(n))
+        step += int(math.floor(math.sqrt(n)))
         if prev >= n:
             return -1
 


### PR DESCRIPTION
Try to run this on Python 2.7.10.
An error occurs, the error log like this:
_Traceback (most recent call last):
  File "jump_search.py", line 25, in <module>
    index = jump_search(arr, x)
  File "jump_search.py", line 7, in jump_search
    while arr[min(step, n)-1] < x:
TypeError: list indices must be integers, not float_

the fix make the code can be run under python2 & python3.