### PR TITLE
Modernize Python 2 code to work for Python 3

### DIFF
--- a/Project Euler/Problem 01/sol2.py
+++ b/Project Euler/Problem 01/sol2.py
@@ -11,10 +11,10 @@ except NameError:
     raw_input = input  # Python 3
 n = int(raw_input().strip())
 sum = 0
-terms = (n-1)/3
-sum+= ((terms)*(6+(terms-1)*3))/2 #sum of an A.P.
-terms = (n-1)/5
-sum+= ((terms)*(10+(terms-1)*5))/2
-terms = (n-1)/15
-sum-= ((terms)*(30+(terms-1)*15))/2
+terms = (n-1)//3
+sum+= ((terms)*(6+(terms-1)*3))//2 #sum of an A.P.
+terms = (n-1)//5
+sum+= ((terms)*(10+(terms-1)*5))//2
+terms = (n-1)//15
+sum-= ((terms)*(30+(terms-1)*15))//2
 print(sum)


### PR DESCRIPTION
Fixes #289 which occurred because of difference in operation of `/` in Python 2 and Python 3 by replacing `/` with `//`.