### PR TITLE
quicksort_3_partition

### DIFF
--- a/sorts/quick_sort_3partition.py
+++ b/sorts/quick_sort_3partition.py
@@ -1,13 +1,11 @@
 from __future__ import print_function
 
 def quick_sort_3partition(sorting, left, right):
-
     if right <= left:
         return
-    a = left
+    a = i = left
     b = right
     pivot = sorting[left]
-    i = left
     while i <= b:
         if sorting[i] < pivot:
             sorting[a], sorting[i] = sorting[i], sorting[a]

--- a/sorts/quick_sort_3partition.py
+++ b/sorts/quick_sort_3partition.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+
+def quick_sort_3partition(sorting, left, right):
+
+    if right <= left:
+        return
+    a = left
+    b = right
+    pivot = sorting[left]
+    i = left
+    while i <= b:
+        if sorting[i] < pivot:
+            sorting[a], sorting[i] = sorting[i], sorting[a]
+            a += 1
+            i += 1
+        elif sorting[i] > pivot:
+            sorting[b], sorting[i] = sorting[i], sorting[b]
+            b -= 1
+        else:
+            i += 1
+    quick_sort_3partition(sorting, left, a - 1)
+    quick_sort_3partition(sorting, b + 1, right)
+
+if __name__ == '__main__':
+    try:
+        raw_input          # Python 2
+    except NameError:
+        raw_input = input  # Python 3
+
+    user_input = raw_input('Enter numbers separated by a comma:\n').strip()
+    unsorted = [ int(item) for item in user_input.split(',') ]
+    quick_sort_3partition(unsorted,0,len(unsorted)-1)
+    print(unsorted)


### PR DESCRIPTION
When I study about sorting algorithm, I saw another version of quick-sort which is called 3-way quicksort.
In that site, 3-way quicksort is explained as 

"The 3-way partition variation of quick sort has slightly higher overhead compared to the standard 2-way partition version. Both have the same best, typical, and worst case time bounds, but this version is highly adaptive in the very common case of sorting with few unique keys."

I create pull request, just because other students like me notice that there is other version of quick-sort.