### PR TITLE
Updated Rabin-Karp algorithm to use a rolling hash

### DIFF
--- a/strings/rabin-karp.py
+++ b/strings/rabin-karp.py
@@ -1,29 +1,52 @@
-def rabin_karp(pattern, text):
+def rabin_karp(pattern, text, base=128, mod=997):
     """
 
     The Rabin-Karp Algorithm for finding a pattern within a piece of text
-    with complexity O(nm), most efficient when it is used with multiple patterns
-    as it is able to check if any of a set of patterns match a section of text in o(1) given the precomputed hashes.
+    with average complexity O(n+m), most efficient when it is used with multiple patterns
+    because you can put all hashed patterns in, e.g. a Bloom filter to see if hash of current window
+    matches any pattern in O(1).
 
     This will be the simple version which only assumes one pattern is being searched for but it's not hard to modify
 
     1) Calculate pattern hash
 
-    2) Step through the text one character at a time passing a window with the same length as the pattern
-        calculating the hash of the text within the window compare it with the hash of the pattern. Only testing
-        equality if the hashes match
+    2) Step through the text one character at a time as a sliding window, and update the
+       hash (rolling hash) in O(1) time. Hash function used is:
+              hash(a_1 ... a_k) = a_k * b^(k-1) + a_(k-1) * b^(k-2)) + ... a_1 modulo m
+
+              Where b is a multiplicative base,
+              and m is a number to keep hash size reasonable (use prime for best performance)
+
+    3) Compare if rolled text hash matches pre-computed pattern hash. If so, do actual string comparison
+       in case this is just a hash collision. The check against entire string means the worst-case
+       running-time is O(nm) if every hash collides.
 
     """
     p_len = len(pattern)
-    p_hash = hash(pattern)
+    p_hash = 0
+    text_hash = 0
+    highest_multiplier = base ** (p_len - 1) % mod
 
-    for i in range(0, len(text) - (p_len - 1)):
+    # Compute initial hash values for pattern and text
+    multiplier = 1
+    for i in range(p_len):
+        p_hash = (p_hash * base + ord(pattern[i])) % mod
+        text_hash = (text_hash * base + ord(text[i])) % mod
+        multiplier *= base
 
-        # written like this t
-        text_hash = hash(text[i:i + p_len])
+    for i in range(0, len(text) - p_len + 1):
         if text_hash == p_hash and \
                 text[i:i + p_len] == pattern:
             return True
+
+        # Last iteration should only compare pattern and not compute next hash (out of range)
+        if i < len(text) - p_len:
+            # Remove leftmost character from hash
+            text_hash -= ord(text[i]) * highest_multiplier
+            # Shift all characters left by 1
+            text_hash *= base
+            # Add new character to hash
+            text_hash = (text_hash + ord(text[i + p_len])) % mod
     return False
 
 
@@ -47,4 +70,9 @@ if __name__ == '__main__':
     # Test 4)
     pattern = "abcdabcy"
     text = "abcxabcdabxabcdabcdabcy"
+    assert rabin_karp(pattern, text)
+
+    # Test 5)
+    pattern = "blah"
+    text = "blahgobbledigook"
     assert rabin_karp(pattern, text)


### PR DESCRIPTION
The previous implementation was no better than a brute-force comparison in the best case, and didn't really highlight the point of the Rabin-Karp algorithm.

Now it uses a basic rolling hash so the average-case running-time is O(n+m), rather than O(nm).