### PR TITLE
from IPython import get_ipython

### DIFF
--- a/machine_learning/logistic_regression.py
+++ b/machine_learning/logistic_regression.py
@@ -16,6 +16,10 @@
 #importing all the required libraries
 import numpy as np
 import matplotlib.pyplot as plt
+try:
+     get_ipython
+except NameError:
+     from IPython import get_ipython
 get_ipython().run_line_magic('matplotlib', 'inline')
 from sklearn import datasets
 


### PR DESCRIPTION
@harshildarji  Help linters (and humans) understand where __get_ipython()__ comes from.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./machine_learning/logistic_regression.py:19:1: F821 undefined name 'get_ipython'
get_ipython().run_line_magic('matplotlib', 'inline')
^
1    F821 undefined name 'get_ipython'
1
```