### PR TITLE
fix division by float issue in range heap.py

### DIFF
--- a/data_structures/heap/heap.py
+++ b/data_structures/heap/heap.py
@@ -40,7 +40,7 @@ class Heap:
 	def buildHeap(self,a):
 		self.currsize = len(a)
 		self.h = list(a)
-		for i in range(self.currsize/2,-1,-1):
+		for i in range(self.currsize//2,-1,-1):
 			self.maxHeapify(i)
 
 	def getMax(self):


### PR DESCRIPTION
Fix for dividing by float:
python3 error: TypeError: 'float' object cannot be interpreted as an integer 
python2 error: TypeError: range() integer start argument expected, got float.