### PR TITLE
fix small error in project Euler problem 12 sol1.py

### DIFF
--- a/project_euler/problem_12/sol1.py
+++ b/project_euler/problem_12/sol1.py
@@ -30,7 +30,9 @@ def count_divisors(n):
 	for i in xrange(1, int(sqrt(n))+1):
 		if n%i == 0:
 			nDivisors += 2
-
+	#check if n is perfect square 
+	if n**0.5 == int(n**0.5): 
+        	nDivisors -= 1
 	return nDivisors
 
 tNum = 1


### PR DESCRIPTION
although this script outputs the correct answer for the project Euler task,  `count_divisors(4)` returns 4 which is not correct. The reason is for prefect squares, its square root get counted twice, Note that for my simple hack, precision is lost once your numbers get truly large due to float point operations begin limited in precision.