### PR TITLE
Fix Timsort Omitting 2nd last run

### DIFF
--- a/sorts/timsort.py
+++ b/sorts/timsort.py
@@ -72,11 +72,17 @@ def timsort(lst):
     return sorted_array
 
 
+test_lists = [
+  [],
+  [1],
+  [5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7],
+  [1, 2, 5, 8, 3, 6, 9, 4, 7],
+]
+
+
 def main():
-    assert timsort([]) == []
-    assert timsort([1]) == [1]
-    assert timsort([5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7]) == sorted([5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7])
-    assert timsort([1, 2, 5, 8, 3, 6, 9, 4, 7]) == sorted([1, 2, 5, 8, 3, 6, 9, 4, 7])
+    for test_list in test_lists:
+        assert timsort(test_list) == sorted(test_list)
     lst = [5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7]
     sorted_lst = timsort(lst)
     print(sorted_lst)

--- a/sorts/timsort.py
+++ b/sorts/timsort.py
@@ -54,7 +54,7 @@ def timsort(lst):
             break
 
         if lst[i] < lst[i - 1]:
-            if not len(new_run) == 1:
+            if len(new_run) != 1:
                 runs.append([lst[i - 1]])
                 new_run.append(lst[i])
             else:
@@ -73,6 +73,10 @@ def timsort(lst):
 
 
 def main():
+    assert timsort([]) == []
+    assert timsort([1]) == [1]
+    assert timsort([5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7]) == sorted([5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7])
+    assert timsort([1, 2, 5, 8, 3, 6, 9, 4, 7]) == sorted([1, 2, 5, 8, 3, 6, 9, 4, 7])
     lst = [5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7]
     sorted_lst = timsort(lst)
     print(sorted_lst)

--- a/sorts/timsort.py
+++ b/sorts/timsort.py
@@ -54,12 +54,12 @@ def timsort(lst):
             break
 
         if lst[i] < lst[i - 1]:
-            if not new_run:
+            if not len(new_run) == 1:
                 runs.append([lst[i - 1]])
                 new_run.append(lst[i])
             else:
                 runs.append(new_run)
-                new_run = []
+                new_run = [lst[i]]
         else:
             new_run.append(lst[i])
 
@@ -73,10 +73,10 @@ def timsort(lst):
 
 
 def main():
-
-    lst = [5,9,10,3,-4,5,178,92,46,-18,0,7]
+    lst = [5, 9, 10, 3, -4, 5, 178, 92, 46, -18, 0, 7]
     sorted_lst = timsort(lst)
     print(sorted_lst)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previous version would drop 2nd last run when sorting, test case would omit -18