### PR TITLE
fix: replaced outdated url

### DIFF
--- a/other/sierpinski_triangle.py
+++ b/other/sierpinski_triangle.py
@@ -21,7 +21,7 @@ Python:
 Usage:
   - $python sierpinski_triangle.py <int:depth_for_fractal>
 
-Credits: This code was written by editing the code from http://www.lpb-riannetrujillo.com/blog/python-fractal/
+Credits: This code was written by editing the code from http://www.riannetrujillo.com/blog/python-fractal/
 
 '''
 import turtle


### PR DESCRIPTION
http://www.lpb-riannetrujillo.com/blog/python-fractal/ moved to http://www.riannetrujillo.com/blog/python-fractal/