### PR TITLE
[FIX] maths/PrimeCheck

### DIFF
--- a/maths/PrimeCheck.py
+++ b/maths/PrimeCheck.py
@@ -1,13 +1,54 @@
 import math
-def primeCheck(number):
-    if number % 2 == 0 and number > 2: 
-        return False
-    return all(number % i for i in range(3, int(math.sqrt(number)) + 1, 2))
+import unittest
 
-def main():
-    print(primeCheck(37))
-    print(primeCheck(100))
-    print(primeCheck(77))
+
+def primeCheck(number):
+    """
+    A number is prime if it has exactly two dividers: 1 and itself.
+    """
+    if number < 2:
+        # Negatives, 0 and 1 are not primes
+        return False
+    if number < 4:
+        # 2 and 3 are primes
+        return True
+    if number % 2 == 0:
+        # Even values are not primes
+        return False
+
+    # Except 2, all primes are odd. If any odd value divide
+    # the number, then that number is not prime.
+    odd_numbers = range(3, int(math.sqrt(number)) + 1, 2)
+    return not any(number % i == 0 for i in odd_numbers)
+
+
+class Test(unittest.TestCase):
+    def test_primes(self):
+        self.assertTrue(primeCheck(2))
+        self.assertTrue(primeCheck(3))
+        self.assertTrue(primeCheck(5))
+        self.assertTrue(primeCheck(7))
+        self.assertTrue(primeCheck(11))
+        self.assertTrue(primeCheck(13))
+        self.assertTrue(primeCheck(17))
+        self.assertTrue(primeCheck(19))
+        self.assertTrue(primeCheck(23))
+        self.assertTrue(primeCheck(29))
+
+    def test_not_primes(self):
+        self.assertFalse(primeCheck(-19),
+                "Negative numbers are not prime.")
+        self.assertFalse(primeCheck(0),
+                "Zero doesn't have any divider, primes must have two")
+        self.assertFalse(primeCheck(1),
+                "One just have 1 divider, primes must have two.")
+        self.assertFalse(primeCheck(2 * 2))
+        self.assertFalse(primeCheck(2 * 3))
+        self.assertFalse(primeCheck(3 * 3))
+        self.assertFalse(primeCheck(3 * 5))
+        self.assertFalse(primeCheck(3 * 5 * 7))
+
 
 if __name__ == '__main__':
-	main()
+    unittest.main()
+


### PR DESCRIPTION
Current implementation is buggy and hard to read.

* Negative values were raising a TypeError due to `math.sqrt`
* 1 was considered prime, it is not.
* 2 was considered not prime, it is.

The implementation has been corrected to fix the bugs and to enhance
readability.

A docstring has been added with the definition of a prime number.

A complete test suite has been written, it tests the 10 first primes, a
negative value, 0, 1 and some not prime numbers.

closes #795