### PR TITLE
Update infix_to_postfix_conversion.py

### DIFF
--- a/data_structures/stacks/infix_to_postfix_conversion.py
+++ b/data_structures/stacks/infix_to_postfix_conversion.py
@@ -38,7 +38,7 @@ def infix_to_postfix(expression):
             postfix.append(char)
         elif char not in {'(', ')'}:
             while (not stack.is_empty()
-                    and precedence(char) <= precedence(stack.peek())):
+                    and precedence(char) <= precedence(stack.peek()) and stack.peek()!='('):
                 postfix.append(stack.pop())
             stack.push(char)
         elif char == '(':


### PR DESCRIPTION
If any other operator is encountered, such as ("+", "*", "("), etc., the element is popped from the stack until it encounters a lower priority element (or the stack is empty). After these elements, the operators encountered are pushed onto the stack. One thing to note is that we only pop up "(" in case of ")", we will not pop up in other cases (".