### PR TITLE
Lower barrier for contributions and learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # The Algorithms - Python <!-- [![Build Status](https://travis-ci.org/TheAlgorithms/Python.svg)](https://travis-ci.org/TheAlgorithms/Python) -->
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/TheAlgorithms/100) &nbsp; 
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/TheAlgorithms/100) &nbsp;
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/TheAlgorithms)
 
 
 ### All algorithms implemented in Python (for education)
 
 These implementations are for learning purposes. They may be efficient than the implementations in the Python standard library.
+
+Run, edit and contribute using Gitpod.io a free online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/TheAlgorithms/Python)
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
This PR adds a suggestion to use gitpod.io for contributing and generally playing around with the algorithms. 

We've developed Gitpod to lower friction for collaboration on GitHub and other code hosting platforms by skipping the local setup, maintenance of such and automating workflows. It's free for open-source.

We could configure Gitpod with a Dockerfile so it preinstalls certain tools or python packages, but it looked like most algorithms worked out of the box so I skipped additional configuration.
