### PR TITLE
Atbash.py: Both raw_input() and unichr() were removed in Python 3

### DIFF
--- a/ciphers/Atbash.py
+++ b/ciphers/Atbash.py
@@ -1,14 +1,21 @@
+try:               # Python 2
+    raw_input
+    unichr
+except NameError:  # Python 3
+    raw_input = input
+    unichr = chr
+
+
 def Atbash():
-    inp=raw_input("Enter the sentence to be encrypted  ")
     output=""
-    for i in inp:
-        extract=ord(i)
-        if extract>=65 and extract<=90:
-            output+=(unichr(155-extract))
-        elif extract>=97 and extract<=122:
-            output+=(unichr(219-extract))
+    for i in raw_input("Enter the sentence to be encrypted "):
+        extract = ord(i)
+        if 65 <= extract <= 90:
+            output += unichr(155-extract)
+        elif 97 <= extract <= 122:
+            output += unichr(219-extract)
         else:
             output+=i
-    print (output)
+    print(output)
 
-Atbash()   ;
+Atbash()

--- a/ciphers/Atbash.py
+++ b/ciphers/Atbash.py
@@ -8,7 +8,7 @@ except NameError:  # Python 3
 
 def Atbash():
     output=""
-    for i in raw_input("Enter the sentence to be encrypted "):
+    for i in raw_input("Enter the sentence to be encrypted ").strip():
         extract = ord(i)
         if 65 <= extract <= 90:
             output += unichr(155-extract)


### PR DESCRIPTION
@sateslayer and @AnupKumarPanwar your reviews please.

LGTM tests are failing because of the Python syntax error in #425