### PR TITLE
Updated matrix_multiplication_addition.py-since currently matrix multiplication is only possible for square matrix

### DIFF
--- a/matrix/matrix_multiplication_addition.py
+++ b/matrix/matrix_multiplication_addition.py
@@ -15,12 +15,14 @@ def scalarMultiply(matrix , n):
 
 def multiply(matrix_a, matrix_b):
     matrix_c = []
-    n = len(matrix_a)
+    n = len(matrix_a)       #no of rows in Mat_a
+    l = len(matrix_b[0])    #no of cols in Mat_b
+    m = len(matrix_a[0])    #no of cols in Mat_a = no of rows in Mat b
     for i in range(n):
         list_1 = []
-        for j in range(n):
+        for j in range(l):
             val = 0
-            for k in range(n):
+            for k in range(m):
                 val = val + matrix_a[i][k] * matrix_b[k][j]
             list_1.append(val)
         matrix_c.append(list_1)

--- a/matrix/matrix_multiplication_addition.py
+++ b/matrix/matrix_multiplication_addition.py
@@ -15,9 +15,9 @@ def scalarMultiply(matrix , n):
 
 def multiply(matrix_a, matrix_b):
     matrix_c = []
-    n = len(matrix_a)       #no of rows in Mat_a
-    l = len(matrix_b[0])    #no of cols in Mat_b
-    m = len(matrix_a[0])    #no of cols in Mat_a = no of rows in Mat b
+    n = len(matrix_a)       #no of rows in matrix_a
+    l = len(matrix_b[0])    #no of cols in matrix_b
+    m = len(matrix_a[0])    #no of cols in matrix_a = no of rows in matrix_b
     for i in range(n):
         list_1 = []
         for j in range(l):


### PR DESCRIPTION
Currently The matrix multiplication method can only multiply square matrices since all three loops uses
n(no of rows of matrix a) .Which is now converted to handle matrices of different orders.