### PR TITLE
Corrected wrong DFS implementation

### DIFF
--- a/graphs/DFS.py
+++ b/graphs/DFS.py
@@ -16,7 +16,6 @@ def dfs(graph, start):
       to the node's children onto the iterator stack. When the iterator at the top of the stack terminates, we'll pop
        it off the stack."""
     explored, stack = set(), [start]
-    explored.add(start)
     while stack:
         v = stack.pop()  # one difference from BFS is to pop last element here instead of first one
         


### PR DESCRIPTION
explored set should not append the root/start outside of the while loop because the root/start is already in explored set and stack would be empty after the first pop. The "if v in explored" statement then triggers "continue" then it would exit the loop. As a result, this implementation would always return {'A'}.