### PR TITLE
Removed Unnecessary Assignment for 'error' Var

### DIFF
--- a/maths/newton_raphson.py
+++ b/maths/newton_raphson.py
@@ -29,7 +29,6 @@ def newton_raphson(f, x0=0, maxiter=100, step=0.0001, maxerror=1e-6,logsteps=Fal
         a = a - f(a)/f1(a) #Calculate the next estimate
         if logsteps:
             steps.append(a)
-        error = abs(f(a))
         if error < maxerror:
             break
     else:


### PR DESCRIPTION
`error = abs(f(a))` was declared on line 24 and line 32. It is unnecessary to have in both places.
I removed the second instance since it wastes resources to keep redefining the variable inside the for loop.
This fixes an [issue found by lgtm](https://lgtm.com/projects/g/TheAlgorithms/Python/snapshot/66c4afbd0f28f9989f35ddbeb5c9263390c5d192/files/maths/newton_raphson.py?sort=name&dir=ASC&mode=heatmap)