### PR TITLE
Change Declaration of Var 'j' to None

### DIFF
--- a/other/primelib.py
+++ b/other/primelib.py
@@ -283,7 +283,7 @@ def goldbach(number):
 
     # run variable for while-loops.
     i = 0
-    j = 1
+    j = None
     
     # exit variable. for break up the loops
     loop = True


### PR DESCRIPTION
Since `j` is redefined before it is used, it makes more sense to declare it with the value `None` instead of `1`.

This fixes a [warning from lgtm](https://lgtm.com/projects/g/TheAlgorithms/Python/snapshot/66c4afbd0f28f9989f35ddbeb5c9263390c5d192/files/other/primelib.py?sort=name&dir=ASC&mode=heatmap)