### PR TITLE
Removed Unused `import sys`

### DIFF
--- a/ciphers/caesar_cipher.py
+++ b/ciphers/caesar_cipher.py
@@ -1,4 +1,3 @@
-import sys
 def encrypt(strng, key):
     encrypted = ''
     for x in strng:


### PR DESCRIPTION
I removed `import sys` because it is not used in the program.
This addresses a [recommendation from lgtm](https://lgtm.com/projects/g/TheAlgorithms/Python/snapshot/66c4afbd0f28f9989f35ddbeb5c9263390c5d192/files/ciphers/caesar_cipher.py?sort=name&dir=ASC&mode=heatmap)