### PR TITLE
Removed Unused Variables

### DIFF
--- a/sorts/Odd-Even_transposition_parallel.py
+++ b/sorts/Odd-Even_transposition_parallel.py
@@ -70,13 +70,11 @@ arr = the list to be sorted
 def OddEvenTransposition(arr):
 
     processArray = []
-    tempRrcv = None
-    tempLrcv = None
 
     resultPipe = []
 
     #initialize the list of pipes where the values will be retrieved
-    for a in arr:
+    for _ in arr:
         resultPipe.append(Pipe())
 
     #creates the processes


### PR DESCRIPTION
- Removed two unused variables.
- Changed `a` to `_` since the `a` variable is never used.

This addresses [3 alerts from lgtm](https://lgtm.com/projects/g/TheAlgorithms/Python/snapshot/d55bbcd204dfbd436914a5f9031a6a8fdf22f6f4/files/sorts/Odd-Even_transposition_parallel.py?sort=name&dir=ASC&mode=heatmap).