### PR TITLE
 fix incorrect rounding in sieve of Eratosthenes

### DIFF
--- a/other/finding_primes.py
+++ b/other/finding_primes.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 from math import sqrt, ceil
 
 def SOE(n):
-    check = ceil(sqrt(n)) #Need not check for multiples past the square root of n
+    check = int(ceil(sqrt(n))) #Need not check for multiples past the square root of n
     
     sieve = [False if i <2 else True for i in range(n+1)] #Set every index to False except for index 0 and 1
     

--- a/other/finding_primes.py
+++ b/other/finding_primes.py
@@ -5,9 +5,10 @@
 from __future__ import print_function
 
 
-from math import sqrt
+from math import sqrt, ceil
+
 def SOE(n):
-    check = round(sqrt(n)) #Need not check for multiples past the square root of n
+    check = ceil(sqrt(n)) #Need not check for multiples past the square root of n
     
     sieve = [False if i <2 else True for i in range(n+1)] #Set every index to False except for index 0 and 1
     


### PR DESCRIPTION
Hello!

Just discovered that there is an error in sieve of Eratosthenes. Value from sqrt was rounded to floor but it has to be rounded to ceil. 
Simple example: implementation without provided fix will count 9 as prime number while finding prime numbers less than 10. So this is incorrect and should be fixed. 

Thanks!