### PR TITLE
Simplify the pytest command by using --ignore options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,33 +7,27 @@ install: pip install -r requirements.txt
 before_script:
   - black --check . || true
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+#matrix:
+#  include:
+#    - script: pytest --doctest-modules -v data_structures         # These tests currently fail.  See: #989
+#    - script: pytest --doctest-modules -v file_transfer_protocol  # These tests currently fail.  See: #983
+#    - script: pytest --doctest-modules -v machine_learning        # These tests currently fail.  See: #985
+#    - script: pytest --doctest-modules -v maths                   # These tests currently fail.  See: #986
 script:
   - mypy --ignore-missing-imports .
-  #- IGNORE="data_structures,file_transfer_protocol,graphs,machine_learning,maths,neural_network,project_euler"
-  #- pytest . --doctest-modules --ignore=${IGNORE}
-  - pytest --doctest-modules
-      arithmetic_analysis
-      backtracking
-      boolean_algebra
-      ciphers
-      compression
-      conversions
-      digital_image_processing
-      divide_and_conquer
-      dynamic_programming
-      graphs
-      hashes
-      linear_algebra_python
-      matrix
-      networking_flow
-      neural_network
-      other
-      project_euler
-      searches
-      sorts
-      strings
-      traversals
-
+  - pytest . --doctest-modules
+      --ignore=data_structures/stacks/balanced_parentheses.py
+      --ignore=data_structures/stacks/infix_to_postfix_conversion.py
+      --ignore=file_transfer_protocol/ftp_send_receive.py
+      --ignore=file_transfer_protocol/ftp_client_server.py
+      --ignore=machine_learning/linear_regression.py
+      --ignore=machine_learning/perceptron.py
+      --ignore=machine_learning/random_forest_classification/random_forest_classification.py
+      --ignore=machine_learning/random_forest_regression/random_forest_regression.py
+      --ignore=maths/abs_min.py
+      --ignore=maths/binary_exponentiation.py
+      --ignore=maths/lucas_series.py
+      --ignore=maths/sieve_of_eratosthenes.py
 after_success:
   - python scripts/build_directory_md.py
   - cat DIRECTORY.md


### PR DESCRIPTION
Let's see where our doctests are still broken... 12 files must currently be ignored.

Switch pytest from a whitelist to a blacklist...

@poyea I would be very interested to get your review on this PR so that we can make sure that we progress thru these remaining 12 files and so that new pull requests do not add new issues for running doctests.

We are now have [> 125 doctest tests](https://travis-ci.org/TheAlgorithms/Python/builds/561236433#L750) that run on each pull request.  I would like us to be able to do that with just __pytest . --doctest-modules__