### PR TITLE
Travis CI: Run each failing pytest in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,24 @@ matrix:
     # The following files currently fail pytests.  See issues: #1016, #1044, #1080
     # Here they are run allow_failures mode and when each passes pytest, it can be
     # removed BOTH lists below.  Complex now but simple once all files pass pytest.
+    # - env: FILE=pytest file_transfer_protocol/ftp_client_server.py
     #   before_script: true
-    #   script: pytest file_transfer_protocol/ftp_client_server.py --doctest-modules
-    - before_script: true
-      script: pytest file_transfer_protocol/ftp_send_receive.py --doctest-modules
-    - before_script: true
-      script: pytest machine_learning/linear_regression.py --doctest-modules
-    - before_script: true
-      script: pytest machine_learning/perceptron.py --doctest-modules
-    - before_script: true
-      script: pytest machine_learning/random_forest_classification/random_forest_classification.py --doctest-modules
-    - before_script: true
-      script: pytest machine_learning/random_forest_regression/random_forest_regression.py --doctest-modules
+    #   script: pytest ${FILE} --doctest-modules
+    - env: FILE=pytest file_transfer_protocol/ftp_send_receive.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=pytest machine_learning/linear_regression.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=pytest machine_learning/perceptron.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=pytest machine_learning/random_forest_classification/random_forest_classification.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=pytest machine_learning/random_forest_regression/random_forest_regression.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
   allow_failures:
     - before_script: true
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,30 +10,18 @@ matrix:
     # The following files currently fail pytests.  See issues: #1016, #1044, #1080
     # Here they are run allow_failures mode and when each passes pytest, it can be
     # removed BOTH lists below.  Complex now but simple once all files pass pytest.
-    - env: FILE=data_structures/stacks/balanced_parentheses.py
-      before_script: true  # override main
-      script: pytest ${FILE} --doctest-modules
-    - env: FILE=data_structures/stacks/infix_to_postfix_conversion.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
-    # - env: FILE=file_transfer_protocol/ftp_client_server.py
     #   before_script: true
-    #   script: pytest ${FILE} --doctest-modules
-    - env: FILE=file_transfer_protocol/ftp_send_receive.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
-    - env: FILE=machine_learning/linear_regression.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
-    - env: FILE=machine_learning/perceptron.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
-    - env: FILE=machine_learning/random_forest_classification/random_forest_classification.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
-    - env: FILE=machine_learning/random_forest_regression/random_forest_regression.py
-      before_script: true
-      script: pytest ${FILE} --doctest-modules
+    #   script: pytest file_transfer_protocol/ftp_client_server.py --doctest-modules
+    - before_script: true
+      script: pytest file_transfer_protocol/ftp_send_receive.py --doctest-modules
+    - before_script: true
+      script: pytest machine_learning/linear_regression.py --doctest-modules
+    - before_script: true
+      script: pytest machine_learning/perceptron.py --doctest-modules
+    - before_script: true
+      script: pytest machine_learning/random_forest_classification/random_forest_classification.py --doctest-modules
+    - before_script: true
+      script: pytest machine_learning/random_forest_regression/random_forest_regression.py --doctest-modules
   allow_failures:
     - before_script: true
 before_script:
@@ -49,7 +37,6 @@ script:
       --ignore=machine_learning/perceptron.py
       --ignore=machine_learning/random_forest_classification/random_forest_classification.py
       --ignore=machine_learning/random_forest_regression/random_forest_regression.py
-
 after_success:
   - scripts/build_directory_md.py > DIRECTORY.md
   - cat DIRECTORY.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,43 @@ python: 3.7
 cache: pip
 before_install: pip install --upgrade pip setuptools
 install: pip install -r requirements.txt
+matrix:
+  include:
+    - name: "Main tests"
+    # The following files currently fail pytests.  See issues: #1016, #1044, #1080
+    # Here they are run allow_failures mode and when each passes pytest, it can be
+    # removed BOTH lists below.  Complex now but simple once all files pass pytest.
+    - env: FILE=data_structures/stacks/balanced_parentheses.py
+      before_script: true  # override main
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=data_structures/stacks/infix_to_postfix_conversion.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    # - env: FILE=file_transfer_protocol/ftp_client_server.py
+    #   before_script: true
+    #   script: pytest ${FILE} --doctest-modules
+    - env: FILE=file_transfer_protocol/ftp_send_receive.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=machine_learning/linear_regression.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=machine_learning/perceptron.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=machine_learning/random_forest_classification/random_forest_classification.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+    - env: FILE=machine_learning/random_forest_regression/random_forest_regression.py
+      before_script: true
+      script: pytest ${FILE} --doctest-modules
+  allow_failures:
+    - before_script: true
 before_script:
   - black --check . || true
   - flake8 . --count --select=E9,F401,F63,F7,F82 --show-source --statistics
 script:
-  - scripts/validate_filenames.py  # no uppercase and no spaces
+  - scripts/validate_filenames.py  # no uppercase, no spaces, in a directory
   - mypy --ignore-missing-imports .
   - pytest . --doctest-modules
       --ignore=data_structures/stacks/balanced_parentheses.py
@@ -19,6 +51,7 @@ script:
       --ignore=machine_learning/perceptron.py
       --ignore=machine_learning/random_forest_classification/random_forest_classification.py
       --ignore=machine_learning/random_forest_regression/random_forest_regression.py
+
 after_success:
   - scripts/build_directory_md.py > DIRECTORY.md
   - cat DIRECTORY.md


### PR DESCRIPTION
This PR allows us to see which of our files are still fail pytests.  As we fix each file so that it passes pytest, we can remove the custom configuration to simplify our testing script.  This PR replaces #1055 by running each of our currently failing pytests in __allow_failures__ mode so that we can see them fail without failing the entire Travis CI run.

## Complex now but simple once all files pass pytest.
