### PR TITLE
Zeller's Congruence Algorithm

### DIFF
--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -68,7 +68,7 @@ def zeller(date_input: str) -> str:
 """
 
     # Days of the week for response
-    days: Dict[str, str] = {
+    days = {
         '0': 'Sunday',
         '1': 'Monday',
         '2': 'Tuesday',
@@ -78,7 +78,7 @@ def zeller(date_input: str) -> str:
         '6': 'Saturday'
     }
 
-    convert_datetime_days: Dict[int,int] = {
+    convert_datetime_days = {
         0:1,
         1:2,
         2:3,
@@ -87,6 +87,7 @@ def zeller(date_input: str) -> str:
         5:6,
         6:0
     }
+
     # Validate
     if not 0 < len(date_input) < 11:
         raise ValueError("Must be 10 characters long")
@@ -120,7 +121,7 @@ def zeller(date_input: str) -> str:
     if not 45 < y < 8500:
         raise ValueError("Year out of range. There has to be some sort of limit...right?")
 
-    # Get datetime obj
+    # Get datetime obj for validation
     dt_ck = datetime.date(int(y), int(m), int(d))
 
     # Start math

--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -1,5 +1,4 @@
 import argparse
-import math
 
 def zeller(date_input):
 

--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+import datetime
 import argparse
 
-def zeller(date_input):
+
+def zeller(date_input: str) -> str:
 
     """
     Zellers Congruence Algorithm
     Find the day of the week for nearly any Gregorian or Julian calendar date 
 
     >>> zeller('01-31-2010')
-    Your date 01-31-2010, is a Sunday!
+    'Your date 01-31-2010, is a Sunday!'
 
     Validate out of range month
     >>> zeller('13-31-2010')
@@ -65,7 +68,7 @@ def zeller(date_input):
 """
 
     # Days of the week for response
-    days = {
+    days: Dict[str, str] = {
         '0': 'Sunday',
         '1': 'Monday',
         '2': 'Tuesday',
@@ -75,57 +78,74 @@ def zeller(date_input):
         '6': 'Saturday'
     }
 
+    convert_datetime_days: Dict[int,int] = {
+        0:1,
+        1:2,
+        2:3,
+        3:4,
+        4:5,
+        5:6,
+        6:0
+    }
     # Validate
-    if len(date_input) >= 11 or len(date_input) <= 0:
+    if not 0 < len(date_input) < 11:
         raise ValueError("Must be 10 characters long")
 
     # Get month
-    m = int(date_input[0] + date_input[1])
+    m: int = int(date_input[0] + date_input[1])
     # Validate
-    if m >= 13 or m <= 0:
+    if not 0 < m < 13:
         raise ValueError("Month must be between 1 - 12")
 
-    sep_1 = str(date_input[2])
+    sep_1:str = date_input[2]
     # Validate
     if sep_1 not in ["-","/"]:
         raise ValueError("Date seperator must be '-' or '/'")
 
     # Get day
-    d = int(date_input[3] + date_input[4])
+    d: int = int(date_input[3] + date_input[4])
     # Validate
-    if d >= 32 or d <= 0:
+    if not 0 < d < 32:
         raise ValueError("Date must be between 1 - 31")
     
-    # Seperator 2
-    sep_2 = str(date_input[5])
+    # Get second seperator
+    sep_2: str = date_input[5]
     # Validate
     if sep_2 not in ["-","/"]:
         raise ValueError("Date seperator must be '-' or '/'")
 
     # Get year
-    y = int(date_input[6] + date_input[7] + date_input[8] + date_input[9])
+    y: int = int(date_input[6] + date_input[7] + date_input[8] + date_input[9])
     # Arbitrary year range
-    if y >= 8500 or y <= 45:
+    if not 45 < y < 8500:
         raise ValueError("Year out of range. There has to be some sort of limit...right?")
+
+    # Get datetime obj
+    dt_ck = datetime.date(int(y), int(m), int(d))
 
     # Start math
     if m <= 2:
         y = y - 1
         m = m + 12
-    c = int(str(y)[:2])
-    k = int(str(y)[2:])
-    t = int(2.6*m - 5.39)
-    u = int(c / 4)
-    v = int(k / 4)
-    x = d + k
-    z = t + u + v + x
-    w = z - (2 * c)
-    f = round(w%7)
+    # maths var
+    c: int = int(str(y)[:2])
+    k: int = int(str(y)[2:])
+    t: int = int(2.6*m - 5.39)
+    u: int = int(c / 4)
+    v: int = int(k / 4)
+    x: int = int(d + k)
+    z: int = int(t + u + v + x)
+    w: int = int(z - (2 * c))
+    f: int = round(w%7)
     # End math
 
-    for i in days:
-        if f == int(i):
-            print("Your date " + date_input + ", is a " + days[i] + "!")
+    # Validate math
+    if f != convert_datetime_days[dt_ck.weekday()]:
+        raise AssertionError("The date was evaluated incorrectly. Contact developer.")
+
+    # Response
+    response: str = f"Your date {date_input}, is a {days[str(f)]}!"
+    return response
 
 if __name__ == '__main__':
     import doctest

--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -1,0 +1,137 @@
+import argparse
+import math
+
+def zeller(date_input):
+
+    """
+    Zellers Congruence Algorithm
+    Find the day of the week for nearly any Gregorian or Julian calendar date 
+
+    >>> zeller('01-31-2010')
+    Your date 01-31-2010, is a Sunday!
+
+    Validate out of range month
+    >>> zeller('13-31-2010')
+    Traceback (most recent call last):
+    ...
+    ValueError: Month must be between 1 - 12
+    >>> zeller('.2-31-2010')
+    Traceback (most recent call last):
+    ...
+    ValueError: invalid literal for int() with base 10: '.2'
+
+    Validate out of range date:
+    >>> zeller('01-33-2010')
+    Traceback (most recent call last):
+        ...
+    ValueError: Date must be between 1 - 31
+    >>> zeller('01-.4-2010')
+    Traceback (most recent call last):
+        ...
+    ValueError: invalid literal for int() with base 10: '.4'
+
+    Validate second seperator:
+    >>> zeller('01-31*2010')
+    Traceback (most recent call last):
+        ...
+    ValueError: Date seperator must be '-' or '/'
+
+    Validate first seperator:
+    >>> zeller('01^31-2010')
+    Traceback (most recent call last):
+        ...
+    ValueError: Date seperator must be '-' or '/'
+
+    Validate out of range year:
+    >>> zeller('01-31-8999')
+    Traceback (most recent call last):
+        ...
+    ValueError: Year out of range. There has to be some sort of limit...right?
+
+    Test null input:
+    >>> zeller()
+    Traceback (most recent call last):
+        ...
+    TypeError: zeller() missing 1 required positional argument: 'date_input'
+
+    Test length fo date_input:
+    >>> zeller('')
+    Traceback (most recent call last):
+        ...
+    ValueError: Must be 10 characters long
+    >>> zeller('01-31-19082939')
+    Traceback (most recent call last):
+        ...
+    ValueError: Must be 10 characters long
+"""
+
+    # Days of the week for response
+    days = {
+        '0': 'Sunday',
+        '1': 'Monday',
+        '2': 'Tuesday',
+        '3': 'Wednesday',
+        '4': 'Thursday',
+        '5': 'Friday',
+        '6': 'Saturday'
+    }
+
+    # Validate
+    if len(date_input) >= 11 or len(date_input) <= 0:
+        raise ValueError("Must be 10 characters long")
+
+    # Get month
+    m = int(date_input[0] + date_input[1])
+    # Validate
+    if m >= 13 or m <= 0:
+        raise ValueError("Month must be between 1 - 12")
+
+    sep_1 = str(date_input[2])
+    # Validate
+    if sep_1 not in ["-","/"]:
+        raise ValueError("Date seperator must be '-' or '/'")
+
+    # Get day
+    d = int(date_input[3] + date_input[4])
+    # Validate
+    if d >= 32 or d <= 0:
+        raise ValueError("Date must be between 1 - 31")
+    
+    # Seperator 2
+    sep_2 = str(date_input[5])
+    # Validate
+    if sep_2 not in ["-","/"]:
+        raise ValueError("Date seperator must be '-' or '/'")
+
+    # Get year
+    y = int(date_input[6] + date_input[7] + date_input[8] + date_input[9])
+    # Arbitrary year range
+    if y >= 8500 or y <= 45:
+        raise ValueError("Year out of range. There has to be some sort of limit...right?")
+
+    # Start math
+    if m <= 2:
+        y = y - 1
+        m = m + 12
+    c = int(str(y)[:2])
+    k = int(str(y)[2:])
+    t = int(2.6*m - 5.39)
+    u = int(c / 4)
+    v = int(k / 4)
+    x = d + k
+    z = t + u + v + x
+    w = z - (2 * c)
+    f = round(w%7)
+    # End math
+
+    for i in days:
+        if f == int(i):
+            print("Your date " + date_input + ", is a " + days[i] + "!")
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()
+    parser = argparse.ArgumentParser(description='Find out what day of the week nearly any date is or was. Enter date as a string in the mm-dd-yyyy or mm/dd/yyyy format')
+    parser.add_argument('date_input', type=str, help='Date as a string (mm-dd-yyyy or mm/dd/yyyy)')
+    args = parser.parse_args()
+    zeller(args.date_input)


### PR DESCRIPTION
Let me know of any other improvements I can make. :+1: 

```shell
Marvins-MBP:maths marvinmichum$ python3 zellers_congruence.py --help
usage: zellers_congruence.py [-h] date_input

Find out what day of the week nearly any date is or was. Enter date as a
string in the mm-dd-yyyy or mm/dd/yyyy format

positional arguments:
  date_input  Date as a string (mm-dd-yyyy or mm/dd/yyyy)

optional arguments:
  -h, --help  show this help message and exit
```

```python
>>> import ZellersCongruence as z
>>> z.zeller('10/10/2018')
Your date 10/10/2018, is a Wednesday!
>>> z.zeller('04-23-1991')
Your date 04-23-1991, is a Tuesday!
>>> z.zeller('01-31-1976')
Your date 01-31-1976, is a Saturday!
```

```shell
Marvins-MBP:maths marvinmichum$ python3 zellers_congruence.py -v
Trying:
    zeller('01-31-2010')
Expecting:
    Your date 01-31-2010, is a Sunday!
ok
Trying:
    zeller('13-31-2010')
Expecting:
    Traceback (most recent call last):
    ...
    ValueError: Month must be between 1 - 12
ok
Trying:
    zeller('.2-31-2010')
Expecting:
    Traceback (most recent call last):
    ...
    ValueError: invalid literal for int() with base 10: '.2'
ok
Trying:
    zeller('01-33-2010')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Date must be between 1 - 31
ok
Trying:
    zeller('01-.4-2010')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: invalid literal for int() with base 10: '.4'
ok
Trying:
    zeller('01-31*2010')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Date seperator must be '-' or '/'
ok
Trying:
    zeller('01^31-2010')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Date seperator must be '-' or '/'
ok
Trying:
    zeller('01-31-8999')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Year out of range. There has to be some sort of limit...right?
ok
Trying:
    zeller()
Expecting:
    Traceback (most recent call last):
        ...
    TypeError: zeller() missing 1 required positional argument: 'date_input'
ok
Trying:
    zeller('')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Must be 10 characters long
ok
Trying:
    zeller('01-31-19082939')
Expecting:
    Traceback (most recent call last):
        ...
    ValueError: Must be 10 characters long
ok
1 items had no tests:
    __main__
1 items passed all tests:
  11 tests in __main__.zeller
11 tests in 2 items.
11 passed and 0 failed.
Test passed.
```