### PR TITLE
remove from __future__, propre filename

### DIFF
--- a/maths/quadratic_equations_complex_numbers.py
+++ b/maths/quadratic_equations_complex_numbers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import math
 
 def QuadraticEquation(a,b,c):


### PR DESCRIPTION
The original file name was `Create Quadratic Equations(Complexes Numbers)`, not only improper filename but also without `.py` extension.
So in this commit, I changed the filename and also removed `from __future__ import print_function` as this repo no longer supports legacy python.