### PR TITLE
Fix bug doubly_linked_list.py

### DIFF
--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -24,16 +24,17 @@ class LinkedList:           #making main class named linked list
     def deleteHead(self):
         temp = self.head
         self.head = self.head.next                   # oldHead <--> 2ndElement(head) 
-        self.head.previous = None                    # oldHead --> 2ndElement(head) nothing pointing at it so the old head will be removed
         if(self.head is None):
-            self.tail = None                         #if empty linked list
+            self.tail = None                         # if empty linked list
+        else:                                        # the following is required only the list still contains something
+            self.head.previous = None                # oldHead --> 2ndElement(head) nothing pointing at it so the old head will be removed
         return temp
     
     def insertTail(self, x):
         newLink = Link(x)
         newLink.next = None                         # currentTail(tail)    newLink -->
         self.tail.next = newLink                    # currentTail(tail) --> newLink -->
-        newLink.previous = self.tail                #currentTail(tail) <--> newLink -->
+        newLink.previous = self.tail                # currentTail(tail) <--> newLink -->
         self.tail = newLink                         # oldTail <--> newLink(tail) -->
     
     def deleteTail(self):


### PR DESCRIPTION
If I were to use deleteHead with a list containing only one node I would get an error when trying to access "previous" of a None object. Added a test case that breaks the old code but works fine with the new one