### PR TITLE
Adds operations for circular linked list

### DIFF
--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any
 
 
 class Node:

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -171,14 +171,13 @@ class CircularLinkedList:
         """
         Removes the 1st node from the CircularLinkedList
         >>> cll = CircularLinkedList()
-        >>> for i in range(5)
-        ...     cll.append(i)
-        ...
+        >>> cll.append(1)
+        >>> cll.append(2)
         >>> print(cll)
-        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
+        <Node data=1> => <Node data=2>
         >>> cll.delete_front()
         >>> print(cll)
-        <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
+        <Node data=2>
         """
         if self.head is None:
             raise IndexError()
@@ -200,14 +199,13 @@ class CircularLinkedList:
         """
         Removes the last node from the CircularLinkedList
         >>> cll = CircularLinkedList()
-        >>> for i in range(5)
-        ...     cll.append(i)
-        ...
+        >>> cll.append(1)
+        >>> cll.append(2)
         >>> print(cll)
-        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
+        <Node data=1> => <Node data=2>
         >>> cll.delete_rear()
         >>> print(cll)
-        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3>
+        <Node data=1>
         """
         if self.head is None:
             raise IndexError()

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,3 +1,6 @@
+import typing
+
+
 class Node:
     """
     Class to represent a single node.
@@ -7,37 +10,54 @@ class Node:
     * next_ptr
     """
 
-    def __init__(self, data):
+    def __init__(self, data: typing.Any):
         self.data = data
         self.next_ptr = None
 
-    def set_data(self, value):
+    def set_data(self, value: typing.Any):
         """
         Set the data field of the node to given value.
+        >>> node = Node(1)
+        >>> node.set_data(2)
+        >>> node.get_data()
+        2
         """
         self.data = value
 
-    def get_data(self):
+    def get_data(self) -> typing.Any:
         """
-        Returns the data field of the current node,
+        Returns the data field of the current node.
+        >>> node = Node(1)
+        >>> node.get_data()
+        1
         """
         return self.data
 
-    def set_next(self, value):
+    def set_next(self, value: typing.Type['Node']):
         """
         Sets the next pointer of the current node.
+        >>> node, node1 = Node(1), Node(2)
+        >>> node.set_next(node1)
+        >>> node.get_next().get_data()
+        2
         """
         self.next_ptr = value
 
-    def get_next(self):
+    def get_next(self) -> typing.Type['Node']:
         """
         Returns the next pointer of the current node.
+        >>> node = Node(1)
+        >>> node.get_next() is None
+        True
         """
         return self.next_ptr
 
-    def has_next(self):
+    def has_next(self) -> bool:
         """
         Checks if the current node has a valid next node.
+        >>> node = Node(1)
+        >>> node.has_next()
+        False
         """
         return self.next_ptr is not None
 
@@ -55,15 +75,28 @@ class CircularLinkedList:
         self.head = None
         self.length = 0
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Dunder method to return length of the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> len(cll)
+        0
+        >>> cll.append(1)
+        >>> len(cll)
+        1
         """
         return self.length
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Dunder method to represent the string representation of the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> print(cll)
+        Empty linked list
+        >>> cll.append(1)
+        >>> cll.append(2)
+        >>> print(cll)
+        <Node data=1> => <Node data=2>
         """
         current_node = self.head
         if not current_node:
@@ -78,9 +111,16 @@ class CircularLinkedList:
 
         return " => ".join(result)
 
-    def append(self, data):
+    def append(self, data: typing.Any):
         """
         Adds a node with given data to the end of the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> cll.append(1)
+        >>> cll.append(2)
+        >>> len(cll)
+        2
+        >>> print(cll)
+        <Node data=1> => <Node data=2>
         """
         current_node = self.head
 
@@ -98,9 +138,16 @@ class CircularLinkedList:
 
         self.length += 1
 
-    def prepend(self, data):
+    def prepend(self, data: typing.Any):
         """
         Adds a ndoe with given data to the front of the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> cll.prepend(1)
+        >>> cll.prepend(2)
+        >>> len(cll)
+        2
+        >>> print(cll)
+        <Node data=2> => <Node data=1>
         """
         current_node = self.head
 
@@ -123,6 +170,15 @@ class CircularLinkedList:
     def delete_front(self):
         """
         Removes the 1st node from the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> for i in range(5)
+        ...     cll.append(i)
+        ...
+        >>> print(cll)
+        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
+        >>> cll.delete_front()
+        >>> print(cll)
+        <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
         """
         if self.head is None:
             raise IndexError()
@@ -143,6 +199,15 @@ class CircularLinkedList:
     def delete_rear(self):
         """
         Removes the last node from the CircularLinkedList
+        >>> cll = CircularLinkedList()
+        >>> for i in range(5)
+        ...     cll.append(i)
+        ...
+        >>> print(cll)
+        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3> => <Node data=4>
+        >>> cll.delete_rear()
+        >>> print(cll)
+        <Node data=0> => <Node data=1> => <Node data=2> => <Node data=3>
         """
         if self.head is None:
             raise IndexError()

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Any, Type
 
 
 class Node:
@@ -10,56 +10,9 @@ class Node:
     * next_ptr
     """
 
-    def __init__(self, data: typing.Any):
+    def __init__(self, data: Any):
         self.data = data
         self.next_ptr = None
-
-    def set_data(self, value: typing.Any):
-        """
-        Set the data field of the node to given value.
-        >>> node = Node(1)
-        >>> node.set_data(2)
-        >>> node.get_data()
-        2
-        """
-        self.data = value
-
-    def get_data(self) -> typing.Any:
-        """
-        Returns the data field of the current node.
-        >>> node = Node(1)
-        >>> node.get_data()
-        1
-        """
-        return self.data
-
-    def set_next(self, value: typing.Type['Node']):
-        """
-        Sets the next pointer of the current node.
-        >>> node, node1 = Node(1), Node(2)
-        >>> node.set_next(node1)
-        >>> node.get_next().get_data()
-        2
-        """
-        self.next_ptr = value
-
-    def get_next(self) -> typing.Type['Node']:
-        """
-        Returns the next pointer of the current node.
-        >>> node = Node(1)
-        >>> node.get_next() is None
-        True
-        """
-        return self.next_ptr
-
-    def has_next(self) -> bool:
-        """
-        Checks if the current node has a valid next node.
-        >>> node = Node(1)
-        >>> node.has_next()
-        False
-        """
-        return self.next_ptr is not None
 
 
 class CircularLinkedList:
@@ -67,7 +20,7 @@ class CircularLinkedList:
     Class to represent the CircularLinkedList.
 
     CircularLinkedList has following attributes.
-    * HEAD
+    * head
     * length
     """
 
@@ -102,43 +55,43 @@ class CircularLinkedList:
         if not current_node:
             return "Empty linked list"
 
-        result = [f"<Node data={current_node.get_data()}>"]
-        current_node = current_node.get_next()
+        result = [f"<Node data={current_node.data}>"]
+        current_node = current_node.next_ptr
 
         while current_node != self.head:
-            result.append(f"<Node data={current_node.get_data()}>")
-            current_node = current_node.get_next()
+            result.append(f"<Node data={current_node.data}>")
+            current_node = current_node.next_ptr
 
         return " => ".join(result)
 
-    def append(self, data: typing.Any):
+    def append(self, data: Any):
         """
         Adds a node with given data to the end of the CircularLinkedList
         >>> cll = CircularLinkedList()
         >>> cll.append(1)
+        >>> print(f"{len(cll)}: {cll}")
+        1: <Node data=1>
         >>> cll.append(2)
-        >>> len(cll)
-        2
-        >>> print(cll)
-        <Node data=1> => <Node data=2>
+        >>> print(f"{len(cll)}: {cll}")
+        2: <Node data=1> => <Node data=2>
         """
         current_node = self.head
 
         new_node = Node(data)
-        new_node.set_next(new_node)
+        new_node.next_ptr = new_node
 
         if current_node is None:
             self.head = new_node
         else:
-            while current_node.get_next() != self.head:
-                current_node = current_node.get_next()
+            while current_node.next_ptr != self.head:
+                current_node = current_node.next_ptr
 
-            current_node.set_next(new_node)
-            new_node.set_next(self.head)
+            current_node.next_ptr = new_node
+            new_node.next_ptr = self.head
 
         self.length += 1
 
-    def prepend(self, data: typing.Any):
+    def prepend(self, data: Any):
         """
         Adds a ndoe with given data to the front of the CircularLinkedList
         >>> cll = CircularLinkedList()
@@ -152,16 +105,16 @@ class CircularLinkedList:
         current_node = self.head
 
         new_node = Node(data)
-        new_node.set_next(new_node)
+        new_node.next_ptr = new_node
 
         if current_node is None:
             self.head = new_node
         else:
-            while current_node.get_next() != self.head:
-                current_node = current_node.get_next()
+            while current_node.next_ptr != self.head:
+                current_node = current_node.next_ptr
 
-            current_node.set_next(new_node)
-            new_node.set_next(self.head)
+            current_node.next_ptr = new_node
+            new_node.next_ptr = self.head
 
             self.head = new_node
 
@@ -171,6 +124,10 @@ class CircularLinkedList:
         """
         Removes the 1st node from the CircularLinkedList
         >>> cll = CircularLinkedList()
+        >>> cll.delete_rear()
+        Traceback
+        ...
+        IndexError: Deleting from an empty list
         >>> cll.append(1)
         >>> cll.append(2)
         >>> print(cll)
@@ -180,18 +137,18 @@ class CircularLinkedList:
         <Node data=2>
         """
         if self.head is None:
-            raise IndexError()
+            raise IndexError("Deleting from an empty list")
 
         current_node = self.head
 
-        if current_node.get_next() == current_node:
+        if current_node.next_ptr == current_node:
             self.head, self.length = None, 0
         else:
-            while current_node.get_next() != self.head:
-                current_node = current_node.get_next()
+            while current_node.next_ptr != self.head:
+                current_node = current_node.next_ptr
 
-            current_node.set_next(self.head.get_next())
-            self.head = self.head.get_next()
+            current_node.next_ptr = self.head.next_ptr
+            self.head = self.head.next_ptr
 
         self.length -= 1
 
@@ -199,6 +156,10 @@ class CircularLinkedList:
         """
         Removes the last node from the CircularLinkedList
         >>> cll = CircularLinkedList()
+        >>> cll.delete_rear()
+        Traceback
+        ...
+        IndexError: Deleting from an empty list
         >>> cll.append(1)
         >>> cll.append(2)
         >>> print(cll)
@@ -208,17 +169,17 @@ class CircularLinkedList:
         <Node data=1>
         """
         if self.head is None:
-            raise IndexError()
+            raise IndexError("Deleting from an empty list")
 
         temp_node, current_node = self.head, self.head
 
-        if current_node.get_next() == current_node:
+        if current_node.next_ptr == current_node:
             self.head, self.length = None, 0
         else:
-            while current_node.get_next() != self.head:
+            while current_node.next_ptr != self.head:
                 temp_node = current_node
-                current_node = current_node.get_next()
+                current_node = current_node.next_ptr
 
-            temp_node.set_next(current_node.get_next())
+            temp_node.next_ptr = current_node.next_ptr
 
         self.length -= 1

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -125,7 +125,7 @@ class CircularLinkedList:
         Removes the 1st node from the CircularLinkedList
         >>> cll = CircularLinkedList()
         >>> cll.delete_rear()
-        Traceback
+        Traceback (most recent call last):
         ...
         IndexError: Deleting from an empty list
         >>> cll.append(1)
@@ -157,7 +157,7 @@ class CircularLinkedList:
         Removes the last node from the CircularLinkedList
         >>> cll = CircularLinkedList()
         >>> cll.delete_rear()
-        Traceback
+        Traceback (most recent call last):
         ...
         IndexError: Deleting from an empty list
         >>> cll.append(1)
@@ -183,3 +183,9 @@ class CircularLinkedList:
             temp_node.next_ptr = current_node.next_ptr
 
         self.length -= 1
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,0 +1,59 @@
+class Node:
+    def __init__(self, data):
+        self.data = data
+        self.next_ptr = None
+
+    def set_data(self, value):
+        self.data = value
+
+    def get_data(self):
+        return self.data
+
+    def set_next(self, value):
+        self.next_ptr = value
+
+    def get_next(self):
+        return self.next_ptr
+
+    def has_next(self):
+        return self.next_ptr is not None
+
+
+class CircularLinkedList:
+    def __init__(self):
+        self.head = None
+        self.length = 0
+
+    def __len__(self):
+        return self.length
+
+    def __str__(self):
+        current_node = self.head
+        if not current_node:
+            return "Empty linked list"
+
+        result = [f"<Node data={current_node.get_data()}>"]
+        current_node = current_node.get_next()
+
+        while current_node != self.head:
+            result.append(f"<Node data={current_node.get_data()}>")
+            current_node = current_node.get_next()
+
+        return " => ".join(result)
+
+    def append(self, data):
+        current_node = self.head
+
+        new_node = Node(data)
+        new_node.set_next(new_node)
+
+        if current_node is None:
+            self.head = new_node
+        else:
+            while current_node.get_next() != self.head:
+                current_node = current_node.get_next()
+
+            current_node.set_next(new_node)
+            new_node.set_next(self.head)
+
+        self.length += 1

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -94,12 +94,29 @@ class CircularLinkedList:
 
         self.length -= 1
 
+    def delete_rear(self):
+        if self.head is None:
+            raise IndexError()
+
+        temp_node, current_node = self.head, self.head
+
+        if current_node.get_next() == current_node:
+            self.head, self.length = None, 0
+        else:
+            while current_node.get_next() != self.head:
+                temp_node = current_node
+                current_node = current_node.get_next()
+
+            temp_node.set_next(current_node.get_next())
+
+        self.length -= 1
+
 
 if __name__ == "__main__":
     temp = CircularLinkedList()
-    for i in range(1):
+    for i in range(10):
         temp.prepend(i)
     print(temp)
 
-    temp.delete_front()
+    temp.delete_rear()
     print(temp)

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -77,9 +77,29 @@ class CircularLinkedList:
 
         self.length += 1
 
+    def delete_front(self):
+        if self.head is None:
+            raise IndexError()
+
+        current_node = self.head
+
+        if current_node.get_next() == current_node:
+            self.head, self.length = None, 0
+        else:
+            while current_node.get_next() != self.head:
+                current_node = current_node.get_next()
+
+            current_node.set_next(self.head.get_next())
+            self.head = self.head.get_next()
+
+        self.length -= 1
+
 
 if __name__ == "__main__":
     temp = CircularLinkedList()
-    for i in range(10):
+    for i in range(1):
         temp.prepend(i)
+    print(temp)
+
+    temp.delete_front()
     print(temp)

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,33 +1,70 @@
 class Node:
+    """
+    Class to represent a single node.
+
+    Each node has following attributes
+    * data
+    * next_ptr
+    """
+
     def __init__(self, data):
         self.data = data
         self.next_ptr = None
 
     def set_data(self, value):
+        """
+        Set the data field of the node to given value.
+        """
         self.data = value
 
     def get_data(self):
+        """
+        Returns the data field of the current node,
+        """
         return self.data
 
     def set_next(self, value):
+        """
+        Sets the next pointer of the current node.
+        """
         self.next_ptr = value
 
     def get_next(self):
+        """
+        Returns the next pointer of the current node.
+        """
         return self.next_ptr
 
     def has_next(self):
+        """
+        Checks if the current node has a valid next node.
+        """
         return self.next_ptr is not None
 
 
 class CircularLinkedList:
+    """
+    Class to represent the CircularLinkedList.
+
+    CircularLinkedList has following attributes.
+    * HEAD
+    * length
+    """
+
     def __init__(self):
         self.head = None
         self.length = 0
 
     def __len__(self):
+        """
+        Dunder method to return length of the CircularLinkedList
+        """
         return self.length
 
     def __str__(self):
+        """
+        Dunder method to represent the string representation of the CircularLinkedList
+        """
         current_node = self.head
         if not current_node:
             return "Empty linked list"
@@ -42,6 +79,9 @@ class CircularLinkedList:
         return " => ".join(result)
 
     def append(self, data):
+        """
+        Adds a node with given data to the end of the CircularLinkedList
+        """
         current_node = self.head
 
         new_node = Node(data)
@@ -59,6 +99,9 @@ class CircularLinkedList:
         self.length += 1
 
     def prepend(self, data):
+        """
+        Adds a ndoe with given data to the front of the CircularLinkedList
+        """
         current_node = self.head
 
         new_node = Node(data)
@@ -78,6 +121,9 @@ class CircularLinkedList:
         self.length += 1
 
     def delete_front(self):
+        """
+        Removes the 1st node from the CircularLinkedList
+        """
         if self.head is None:
             raise IndexError()
 
@@ -95,6 +141,9 @@ class CircularLinkedList:
         self.length -= 1
 
     def delete_rear(self):
+        """
+        Removes the last node from the CircularLinkedList
+        """
         if self.head is None:
             raise IndexError()
 
@@ -110,13 +159,3 @@ class CircularLinkedList:
             temp_node.set_next(current_node.get_next())
 
         self.length -= 1
-
-
-if __name__ == "__main__":
-    temp = CircularLinkedList()
-    for i in range(10):
-        temp.prepend(i)
-    print(temp)
-
-    temp.delete_rear()
-    print(temp)

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -57,3 +57,29 @@ class CircularLinkedList:
             new_node.set_next(self.head)
 
         self.length += 1
+
+    def prepend(self, data):
+        current_node = self.head
+
+        new_node = Node(data)
+        new_node.set_next(new_node)
+
+        if current_node is None:
+            self.head = new_node
+        else:
+            while current_node.get_next() != self.head:
+                current_node = current_node.get_next()
+
+            current_node.set_next(new_node)
+            new_node.set_next(self.head)
+
+            self.head = new_node
+
+        self.length += 1
+
+
+if __name__ == "__main__":
+    temp = CircularLinkedList()
+    for i in range(10):
+        temp.prepend(i)
+    print(temp)

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -55,16 +55,16 @@ class CircularLinkedList:
         if not current_node:
             return "Empty linked list"
 
-        result = [f"<Node data={current_node.data}>"]
+        results = [current_node.data]
         current_node = current_node.next_ptr
 
         while current_node != self.head:
-            result.append(f"<Node data={current_node.data}>")
+            results.append(current_node.data)
             current_node = current_node.next_ptr
 
-        return " => ".join(result)
+        return " => ".join(f"<Node data={result}>" for result in results)
 
-    def append(self, data: Any):
+    def append(self, data: Any) -> None:
         """
         Adds a node with given data to the end of the CircularLinkedList
         >>> cll = CircularLinkedList()
@@ -80,63 +80,58 @@ class CircularLinkedList:
         new_node = Node(data)
         new_node.next_ptr = new_node
 
-        if current_node is None:
-            self.head = new_node
-        else:
+        if current_node:
             while current_node.next_ptr != self.head:
                 current_node = current_node.next_ptr
 
             current_node.next_ptr = new_node
             new_node.next_ptr = self.head
+        else:
+            self.head = new_node
 
         self.length += 1
 
-    def prepend(self, data: Any):
+    def prepend(self, data: Any) -> None:
         """
         Adds a ndoe with given data to the front of the CircularLinkedList
         >>> cll = CircularLinkedList()
         >>> cll.prepend(1)
         >>> cll.prepend(2)
-        >>> len(cll)
-        2
-        >>> print(cll)
-        <Node data=2> => <Node data=1>
+        >>> print(f"{len(cll)}: {cll}")
+        2: <Node data=2> => <Node data=1>
         """
         current_node = self.head
 
         new_node = Node(data)
         new_node.next_ptr = new_node
 
-        if current_node is None:
-            self.head = new_node
-        else:
+        if current_node:
             while current_node.next_ptr != self.head:
                 current_node = current_node.next_ptr
 
             current_node.next_ptr = new_node
             new_node.next_ptr = self.head
 
-            self.head = new_node
-
+        self.head = new_node
         self.length += 1
 
-    def delete_front(self):
+    def delete_front(self) -> None:
         """
         Removes the 1st node from the CircularLinkedList
         >>> cll = CircularLinkedList()
-        >>> cll.delete_rear()
+        >>> cll.delete_front()
         Traceback (most recent call last):
         ...
         IndexError: Deleting from an empty list
         >>> cll.append(1)
         >>> cll.append(2)
-        >>> print(cll)
-        <Node data=1> => <Node data=2>
+        >>> print(f"{len(cll)}: {cll}")
+        2: <Node data=1> => <Node data=2>
         >>> cll.delete_front()
-        >>> print(cll)
-        <Node data=2>
+        >>> print(f"{len(cll)}: {cll}")
+        1: <Node data=2>
         """
-        if self.head is None:
+        if not self.head:
             raise IndexError("Deleting from an empty list")
 
         current_node = self.head
@@ -152,7 +147,7 @@ class CircularLinkedList:
 
         self.length -= 1
 
-    def delete_rear(self):
+    def delete_rear(self) -> None:
         """
         Removes the last node from the CircularLinkedList
         >>> cll = CircularLinkedList()
@@ -162,13 +157,13 @@ class CircularLinkedList:
         IndexError: Deleting from an empty list
         >>> cll.append(1)
         >>> cll.append(2)
-        >>> print(cll)
-        <Node data=1> => <Node data=2>
+        >>> print(f"{len(cll)}: {cll}")
+        2: <Node data=1> => <Node data=2>
         >>> cll.delete_rear()
-        >>> print(cll)
-        <Node data=1>
+        >>> print(f"{len(cll)}: {cll}")
+        1: <Node data=1>
         """
-        if self.head is None:
+        if not self.head:
             raise IndexError("Deleting from an empty list")
 
         temp_node, current_node = self.head, self.head


### PR DESCRIPTION
Adds a definition for a `CircularLinkedList` that provides the following functionality.

- [x] `len(x)`
- [x] `print(x)` or `str(x)`
- [x] `x.append(item)`
- [x] `x.prepend(item)`
- [x] `x.delete_front()`
- [x] `x.delete_rear()`
- [x] Documentation
- [x] Type hints
- [x] `doctests`