### PR TITLE
Fix floor division

### DIFF
--- a/data_structures/heap/min_heap.py
+++ b/data_structures/heap/min_heap.py
@@ -40,7 +40,10 @@ class MinHeap:
         return self.get_value(key)
 
     def get_parent_idx(self, idx):
-        return (idx - 1) // 2
+        if len(self.heap_dict) % 2 == 0:
+            return idx // 2
+        else:
+            return (idx // 2) - 1
 
     def get_left_child_idx(self, idx):
         return idx * 2 + 1

--- a/data_structures/heap/min_heap.py
+++ b/data_structures/heap/min_heap.py
@@ -40,10 +40,10 @@ class MinHeap:
         return self.get_value(key)
 
     def get_parent_idx(self, idx):
-        if len(self.heap_dict) % 2 == 0:
-            return idx // 2
+        if (len(self.heap_dict) - 1) % 2 == 0:
+            return (idx - 1) // 2
         else:
-            return (idx // 2) - 1
+            return (idx // 2)
 
     def get_left_child_idx(self, idx):
         return idx * 2 + 1


### PR DESCRIPTION
Noticed floor division that calculates the parent index becomes inaccurate with bigger numbers (index will differ based on odd vs even number of elements), so I added this measure.