### PR TITLE
extend estimation of area under curve of y=x using monte carlo simulation to any given lower and upper bound

### DIFF
--- a/maths/monte_carlo.py
+++ b/maths/monte_carlo.py
@@ -60,9 +60,6 @@ def area_under_line_estimator_check(iterations: int,
     1. Calls "area_under_line_estimator" function
     2. Compares with the expected value
     3. Prints estimated, expected and error value
-    
-    >>> area_under_line_estimator_check(100, 0, 2)
-    >>> area_under_line_estimator_check(100)
     """
     
     estimated_value = area_under_line_estimator(iterations, min_value, max_value)

--- a/maths/monte_carlo.py
+++ b/maths/monte_carlo.py
@@ -42,29 +42,37 @@ def area_under_line_estimator(iterations: int,
     An implementation of the Monte Carlo method to find area under
        y = x where x lies between min_value to max_value
     1. Let x be a uniformly distributed random variable between min_value to max_value
-    2. Expected value of x = integration of x from min_value to max_value
+    2. Expected value of x = (integration of x from min_value to max_value) / (max_value - min_value)
     3. Finding expected value of x:
         a. Repeatedly draw x from uniform distribution
         b. Expected value = average of those values
-    4. Actual value = 1/2
+    4. Actual value = (max_value^2 - min_value^2) / 2
     5. Returns estimated value
     """
-    return mean(uniform(min_value, max_value) for _ in range(iterations))
+    return mean(uniform(min_value, max_value) for _ in range(iterations)) * (max_value - min_value)
 
 
-def area_under_line_estimator_check(iterations: int) -> None:
+def area_under_line_estimator_check(iterations: int,
+                                    min_value: float=0.0,
+                                    max_value: float=1.0) -> None:
     """
     Checks estimation error for area_under_line_estimator func
     1. Calls "area_under_line_estimator" function
     2. Compares with the expected value
     3. Prints estimated, expected and error value
+    
+    >>> area_under_line_estimator_check(100, 0, 2)
+    >>> area_under_line_estimator_check(100)
     """
-    estimate = area_under_line_estimator(iterations)
+    
+    estimated_value = area_under_line_estimator(iterations, min_value, max_value)
+    expected_value = (max_value*max_value - min_value*min_value) / 2
+    
     print("******************")
-    print("Estimating area under y=x where x varies from 0 to 1")
-    print("Expected value is ", 0.5)
-    print("Estimated value is ", estimate)
-    print("Total error is ", abs(estimate - 0.5))
+    print("Estimating area under y=x where x varies from ",min_value, " to ",max_value)
+    print("Estimated value is ", estimated_value)
+    print("Expected value is ", expected_value)
+    print("Total error is ", abs(estimated_value - expected_value))
     print("******************")
 
 


### PR DESCRIPTION
extend estimation of area under curve of y=x using monte carlo simulation to any given lower and upper bound.


### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
