### PR TITLE
Changes data type from set to list for correct return result

### DIFF
--- a/graphs/bfs.py
+++ b/graphs/bfs.py
@@ -17,12 +17,15 @@ while Q is non-empty:
 """
 
 G = {
-    "A": ["B", "C"],
-    "B": ["A", "D", "E"],
-    "C": ["A", "F"],
-    "D": ["B"],
-    "E": ["B", "F"],
-    "F": ["C", "E"],
+    "A": ["B", "E", "C"],
+    "B": ["A", "F", "C"],
+    "C": ["A", "B", "E", "I", "H"],
+    "D": ["F"],
+    "E": ["A", "C"],
+    "F": ["G", "D", "B"],
+    "G": ["F"],
+    "H": ["I", "C"],
+    "I": ["H", "C"]
 }
 
 
@@ -31,13 +34,12 @@ def bfs(graph, start):
     >>> ''.join(sorted(bfs(G, 'A')))
     'ABCDEF'
     """
-    explored, queue = set(), [start]  # collections.deque([start])
-    explored.add(start)
+    explored, queue = [start], [start]
     while queue:
-        v = queue.pop(0)  # queue.popleft()
+        v = queue.pop(0)
         for w in graph[v]:
             if w not in explored:
-                explored.add(w)
+                explored.append(w)
                 queue.append(w)
     return explored
 


### PR DESCRIPTION
It seems, saving 'explored' in a set returns wrong results. During traversal, the order of the entries in  var 'explored' are changed by python (by version 2 AND 3).

Result during iteration with data type 'set':

```
set(['A', 'B'])
set(['A', 'C', 'B'])
set(['A', 'C', 'B', 'D'])
set(['A', 'C', 'B', 'E', 'D'])
set(['A', 'C', 'B', 'E', 'D', 'F'])
set(['A', 'C', 'B', 'E', 'D', 'F'])
```


For comparison, here's the result with data type 'list':

```
['A', 'B']
['A', 'B', 'C']
['A', 'B', 'C', 'D']
['A', 'B', 'C', 'D', 'E']
['A', 'B', 'C', 'D', 'E', 'F']
['A', 'B', 'C', 'D', 'E', 'F']
```


The result is for the old example-graph essentially the same, but for more complex graphs it will be wrong.

I added a slightly more complex graph:

```
G = {
    "A": ["B", "E", "C"],
    "B": ["A", "F", "C"],
    "C": ["A", "B", "E", "I", "H"],
    "D": ["F"],
    "E": ["A", "C"],
    "F": ["G", "D", "B"],
    "G": ["F"],
    "H": ["I", "C"],
    "I": ["H", "C"]
}
```

Here's the wrong result with data type 'set' - note how the order changes:

```
set(['A', 'B'])
set(['A', 'B', 'E'])
set(['A', 'C', 'B', 'E'])
set(['A', 'C', 'B', 'E', 'F'])
set(['A', 'C', 'B', 'E', 'F', 'I'])
set(['A', 'C', 'B', 'E', 'F', 'I', 'H'])
set(['A', 'C', 'B', 'E', 'G', 'F', 'I', 'H'])
set(['A', 'C', 'B', 'E', 'D', 'G', 'F', 'I', 'H'])
set(['A', 'C', 'B', 'E', 'D', 'G', 'F', 'I', 'H'])
```

What should be the result? (order of vertices on every level does not matter)

Level 0: A
Level 1: B,C,E
Level 2: F,I,H
Level 3: G,D

If you take a close look above, e.g. D is returned on the wrong level. 


Here's the correct result with data type 'list':

```
['A', 'B']
['A', 'B', 'E']
['A', 'B', 'E', 'C']
['A', 'B', 'E', 'C', 'F']
['A', 'B', 'E', 'C', 'F', 'I']
['A', 'B', 'E', 'C', 'F', 'I', 'H']
['A', 'B', 'E', 'C', 'F', 'I', 'H', 'G']
['A', 'B', 'E', 'C', 'F', 'I', 'H', 'G', 'D']
['A', 'B', 'E', 'C', 'F', 'I', 'H', 'G', 'D']
```

I suggest to include the more complex graph for testing purposes. 



* [ ] Add an algorithm?
* [x ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?
