### PR TITLE
Add prefix-matching function to trie.py

### DIFF
--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -79,20 +79,28 @@ class TrieNode:
                 curr = curr.nodes[char]
             return curr
 
-        def depth_first_search(root: TrieNode, s: str, prefix: str, lst):
-            """Returns a list with prefixes and their TrieNode"""
-            for i in root.nodes:
-                if root.is_leaf:
-                    lst.append((prefix + s, root.nodes[i]))
-                else:
-                    dfs(root.nodes[i], s + i, prefix, lst)
+        def depth_first_search(node: TrieNode, word: str, lst):
+            """
+            resturns a list of all the nodes in a trie
+            :param node: root node of Trie
+            :param word: prefix
+            :return: list of strings
+            """
+            if node.is_leaf:
+                lst.append(word)
+
+            for key, value in node.nodes.items():
+                print_words(value, word + key, lst)
+
             return lst
 
         sub_trie= get_trie_for_prefix(self, prefix)
         if sub_trie==False:
             return False
         else:
-            print_words(sub_trie, prefix)
+            lst=[]
+            depth_first_search(sub_trie, prefix, lst)
+            return lst
 
 
 
@@ -157,7 +165,7 @@ def test_trie():
     root.delete("banana")
     assert not root.find("banana")
     assert root.find("bananas")
-    root.get_words_starting_with("ban")
+    assert root.get_words_starting_with("ban")
     return True
 
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -46,10 +46,10 @@ class TrieNode:
             curr = curr.nodes[char]
         return curr.is_leaf
 
-    def match(self, prefix: str) -> [str]:
+    def get_words_starting_with(self, prefix: str) -> [str]:
         """
         gets the list of all the words that
-        are followed by certain prefix.
+        are followed by a certain prefix.
     
         long-url: https://www.geeksforgeeks.org/prefix-matching-python-using-pytrie-module/
         :param prefix: the prefix to be matched
@@ -156,7 +156,7 @@ def test_trie():
     root.delete("banana")
     assert not root.find("banana")
     assert root.find("bananas")
-    assert root.match("ban")
+    assert root.get_words_starting_with("ban")
     return True
 
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -1,9 +1,11 @@
 """
 A Trie/Prefix Tree is a kind of search tree used to provide quick lookup
 of words/patterns in a set of words. A basic Trie however has O(n^2) space complexity
-making it impractical in practice. It however provides O(max(search_string, length of longest word))
-lookup time making it an optimal approach when space is not an issue.
+making it impractical in practice. It however provides
+O(max(search_string, length of longest word)) lookup time making it an optimal approach
+when space is not an issue.
 """
+from typing import List
 
 
 class TrieNode:
@@ -11,18 +13,18 @@ class TrieNode:
         self.nodes = dict()  # Mapping from char to TrieNode
         self.is_leaf = False
 
-    def insert_many(self, words: [str]):
+    def insert_many(self, words: List[str]) -> None:
         """
-        Inserts a list of words into the Trie
+        Insert a list of words into the Trie
         :param words: list of string words
         :return: None
         """
         for word in words:
             self.insert(word)
 
-    def insert(self, word: str):
+    def insert(self, word: str) -> None:
         """
-        Inserts a word into the Trie
+        Insert a word into the Trie
         :param word: word to be inserted
         :return: None
         """
@@ -46,7 +48,7 @@ class TrieNode:
             curr = curr.nodes[char]
         return curr.is_leaf
 
-    def get_words_starting_with(self, prefix: str) -> [str]:
+    def get_words_starting_with(self, prefix: str) -> List[str]:
         """
         return a list of all words that start with the given prefix.
         are followed by a certain prefix.
@@ -78,7 +80,7 @@ class TrieNode:
                 curr = curr.nodes[char]
             return curr
 
-        def depth_first_search(node: TrieNode, word: str, lst):
+        def depth_first_search(node: TrieNode, word: str, lst: List[str]) -> List[str]:
             """
             returns a list of all the nodes in a trie
             :param node: root node of Trie
@@ -101,14 +103,14 @@ class TrieNode:
             depth_first_search(sub_trie, prefix, lst)
             return lst
 
-    def delete(self, word: str):
+    def delete(self, word: str) -> None:
         """
         Deletes a word in a Trie
         :param word: word to delete
         :return: None
         """
 
-        def _delete(curr: TrieNode, word: str, index: int):
+        def _delete(curr: TrieNode, word: str, index: int) -> bool:
             if index == len(word):
                 # If word does not exist
                 if not curr.is_leaf:
@@ -130,7 +132,7 @@ class TrieNode:
         _delete(self, word, 0)
 
 
-def print_words(node: TrieNode, word: str):
+def print_words(node: TrieNode, word: str) -> None:
     """
     Prints all the words in a Trie
     :param node: root node of Trie
@@ -144,7 +146,7 @@ def print_words(node: TrieNode, word: str):
         print_words(value, word + key)
 
 
-def test_trie():
+def test_trie() -> bool:
     words = "banana bananas bandana band apple all beast".split()
     root = TrieNode()
     root.insert_many(words)
@@ -169,7 +171,7 @@ def print_results(msg: str, passes: bool) -> None:
     print(str(msg), "works!" if passes else "doesn't work :(")
 
 
-def pytests():
+def pytests() -> None:
     assert test_trie()
     import doctest
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -58,7 +58,7 @@ class TrieNode:
         """
 
 
-        def get_trie_for_prefix(t: TrieNode, prefix: str) -> TrieNode:
+        def get_trie_for_prefix(t: TrieNode, prefix: str):
 
             '''
             Different search function that returns the sub trie
@@ -72,7 +72,7 @@ class TrieNode:
             for char in prefix:
                 if char not in curr.nodes:
                     return False
-                    break
+                    
                 curr = curr.nodes[char]
             return curr
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -58,7 +58,7 @@ class TrieNode:
         """
 
 
-        def search(t: TrieNode, prefix: str) -> TrieNode:
+        def get_trie_for_prefix(t: TrieNode, prefix: str) -> TrieNode:
 
             '''
             Different search function that returns the sub trie
@@ -76,7 +76,7 @@ class TrieNode:
                 curr = curr.nodes[char]
             return curr
 
-        def dfs(root: TrieNode, s: str, prefix: str, lst):
+        def depth_first_search(root: TrieNode, s: str, prefix: str, lst):
             """Returns a list with prefixes and their TrieNode"""
             for i in root.nodes:
                 if root.is_leaf:
@@ -85,12 +85,12 @@ class TrieNode:
                     dfs(root.nodes[i], s + i, prefix, lst)
             return lst
 
-        sub_trie= search(self, prefix)
+        sub_trie= get_trie_for_prefix(self, prefix)
         if sub_trie==False:
             return False
         else:
             lst=[]
-            l= dfs(sub_trie, '', prefix, lst)
+            l= depth_first_search(sub_trie, '', prefix, lst)
             return l
 
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -96,7 +96,7 @@ class TrieNode:
 
         sub_trie= get_trie_for_prefix(self, prefix)
         if sub_trie==False:
-            return False
+            return []
         else:
             lst=[]
             depth_first_search(sub_trie, prefix, lst)

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -55,7 +55,7 @@ class TrieNode:
         :param prefix: the prefix to be matched
         :return: List of prefix-matched words.
         
-        >>> get_words_starting_with("a")
+        >>> t.get_words_starting_with("a")
         apple all
 
         """
@@ -176,7 +176,7 @@ def print_results(msg: str, passes: bool) -> None:
 def pytests():
     assert test_trie()
     import doctest
-    doctest.testmod()
+    doctest.testmod(extraglobs={'t': TrieNode()})
 
 
 def main():

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -1,7 +1,7 @@
 """
 A Trie/Prefix Tree is a kind of search tree used to provide quick lookup
 of words/patterns in a set of words. A basic Trie however has O(n^2) space complexity
-making it impractical in practice. It however provides O(max(search_string, length of longest word)) 
+making it impractical in practice. It however provides O(max(search_string, length of longest word))
 lookup time making it an optimal approach when space is not an issue.
 """
 
@@ -50,32 +50,31 @@ class TrieNode:
         """
         return a list of all words that start with the given prefix.
         are followed by a certain prefix.
-    
+
         long-url: https://www.geeksforgeeks.org/prefix-matching-python-using-pytrie-module/
         :param prefix: the prefix to be matched
         :return: List of prefix-matched words.
-        
+
         >>> t.get_words_starting_with("a")
         ['apple', 'all']
 
         """
 
-
         def get_trie_for_prefix(t: TrieNode, prefix: str):
 
-            '''
+            """
             Different search function that returns the sub trie
             instead of True or False
             :param t: self
             :param prefix: prefix to be searched
             :return: a new sub-trie
-            
-            '''
+
+            """
             curr = t
             for char in prefix:
                 if char not in curr.nodes:
                     return False
-                    
+
                 curr = curr.nodes[char]
             return curr
 
@@ -94,16 +93,13 @@ class TrieNode:
 
             return lst
 
-        sub_trie= get_trie_for_prefix(self, prefix)
-        if sub_trie==False:
+        sub_trie = get_trie_for_prefix(self, prefix)
+        if sub_trie == False:
             return []
         else:
-            lst=[]
+            lst = []
             depth_first_search(sub_trie, prefix, lst)
             return lst
-
-
-
 
     def delete(self, word: str):
         """
@@ -152,7 +148,7 @@ def test_trie():
     words = "banana bananas bandana band apple all beast".split()
     root = TrieNode()
     root.insert_many(words)
-    
+
     # print_words(root, "")
     assert all(root.find(word) for word in words)
     assert root.find("banana")
@@ -176,7 +172,8 @@ def print_results(msg: str, passes: bool) -> None:
 def pytests():
     assert test_trie()
     import doctest
-    doctest.testmod(extraglobs={'t': TrieNode()})
+
+    doctest.testmod(TrieNode())
 
 
 def main():

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -56,7 +56,6 @@ class TrieNode:
         :return: List of prefix-matched words.
 
         """
-        pass
 
 
         def search(t: TrieNode, prefix: str) -> TrieNode:

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -46,6 +46,57 @@ class TrieNode:
             curr = curr.nodes[char]
         return curr.is_leaf
 
+    def match(self, prefix: str) -> [str]:
+        """
+        gets the list of all the words that
+        are followed by certain prefix.
+    
+        long-url: https://www.geeksforgeeks.org/prefix-matching-python-using-pytrie-module/
+        :param prefix: the prefix to be matched
+        :return: List of prefix-matched words.
+
+        """
+        pass
+
+
+        def search(t: TrieNode, prefix: str) -> TrieNode:
+
+            '''
+            Different search function that returns the sub trie
+            instead of True or False
+            :param t: self
+            :param prefix: prefix to be searched
+            :return: a new sub-trie
+            
+            '''
+            curr = t
+            for char in prefix:
+                if char not in curr.nodes:
+                    return False
+                    break
+                curr = curr.nodes[char]
+            return curr
+
+        def dfs(root: TrieNode, s: str, prefix: str, lst):
+            """Returns a list with prefixes and their TrieNode"""
+            for i in root.nodes:
+                if root.is_leaf:
+                    lst.append((prefix + s, root.nodes[i]))
+                else:
+                    dfs(root.nodes[i], s + i, prefix, lst)
+            return lst
+
+        sub_trie= search(self, prefix)
+        if sub_trie==False:
+            return False
+        else:
+            lst=[]
+            l= dfs(sub_trie, '', prefix, lst)
+            return l
+
+
+
+
     def delete(self, word: str):
         """
         Deletes a word in a Trie
@@ -105,6 +156,7 @@ def test_trie():
     root.delete("banana")
     assert not root.find("banana")
     assert root.find("bananas")
+    assert root.match("ban")
     return True
 
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -90,7 +90,7 @@ class TrieNode:
                 lst.append(word)
 
             for key, value in node.nodes.items():
-                print_words(value, word + key, lst)
+                depth_first_search(value, word + key, lst)
 
             return lst
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -48,7 +48,7 @@ class TrieNode:
 
     def get_words_starting_with(self, prefix: str) -> [str]:
         """
-        gets the list of all the words that
+        return a list of all words that start with the given prefix.
         are followed by a certain prefix.
     
         long-url: https://www.geeksforgeeks.org/prefix-matching-python-using-pytrie-module/

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -56,7 +56,7 @@ class TrieNode:
         :return: List of prefix-matched words.
         
         >>> t.get_words_starting_with("a")
-        apple all
+        ['apple', 'all']
 
         """
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -54,6 +54,9 @@ class TrieNode:
         long-url: https://www.geeksforgeeks.org/prefix-matching-python-using-pytrie-module/
         :param prefix: the prefix to be matched
         :return: List of prefix-matched words.
+        
+        >>> get_words_starting_with("a")
+        apple all
 
         """
 
@@ -89,9 +92,7 @@ class TrieNode:
         if sub_trie==False:
             return False
         else:
-            lst=[]
-            l= depth_first_search(sub_trie, '', prefix, lst)
-            return l
+            print_words(sub_trie, prefix)
 
 
 
@@ -143,6 +144,7 @@ def test_trie():
     words = "banana bananas bandana band apple all beast".split()
     root = TrieNode()
     root.insert_many(words)
+    
     # print_words(root, "")
     assert all(root.find(word) for word in words)
     assert root.find("banana")
@@ -155,7 +157,7 @@ def test_trie():
     root.delete("banana")
     assert not root.find("banana")
     assert root.find("bananas")
-    assert root.get_words_starting_with("ban")
+    root.get_words_starting_with("ban")
     return True
 
 

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -167,6 +167,8 @@ def print_results(msg: str, passes: bool) -> None:
 
 def pytests():
     assert test_trie()
+    import doctest
+    doctest.testmod()
 
 
 def main():

--- a/data_structures/trie/trie.py
+++ b/data_structures/trie/trie.py
@@ -80,7 +80,7 @@ class TrieNode:
 
         def depth_first_search(node: TrieNode, word: str, lst):
             """
-            resturns a list of all the nodes in a trie
+            returns a list of all the nodes in a trie
             :param node: root node of Trie
             :param word: prefix
             :return: list of strings


### PR DESCRIPTION
Added a new function match to trie.py. This function takes a prefix as an argument, traces that prefix in a trie and then iterates through all the succeeding letters in the sub-trie such that a list of words containing that prefix is returned. 

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
