### PR TITLE
Change_method_name

### DIFF
--- a/data_structures/queue/queue_on_list.py
+++ b/data_structures/queue/queue_on_list.py
@@ -43,7 +43,7 @@ class Queue:
     """Enqueues {@code item}
     @return item at front of self.entries"""
 
-    def front(self):
+    def first(self):
         return self.entries[0]
 
     """Returns the length of this.entries"""


### PR DESCRIPTION
Fixes #1926 
Change method name because it's the same name as an attribute.