### PR TITLE
Avoid Overflow Errors

### DIFF
--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -47,7 +47,7 @@ def bisect_left(sorted_collection, item, lo=0, hi=None):
         hi = len(sorted_collection)
 
     while lo < hi:
-        mid = (lo + hi) // 2
+        mid = (lo + (hi-low)//2)
         if sorted_collection[mid] < item:
             lo = mid + 1
         else:
@@ -90,7 +90,7 @@ def bisect_right(sorted_collection, item, lo=0, hi=None):
         hi = len(sorted_collection)
 
     while lo < hi:
-        mid = (lo + hi) // 2
+        mid = (lo + (hi-lo)//2)
         if sorted_collection[mid] <= item:
             lo = mid + 1
         else:

--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -47,7 +47,7 @@ def bisect_left(sorted_collection, item, lo=0, hi=None):
         hi = len(sorted_collection)
 
     while lo < hi:
-        mid = (lo + (hi-low)//2)
+        mid = (lo + (hi-lo)//2)
         if sorted_collection[mid] < item:
             lo = mid + 1
         else:


### PR DESCRIPTION
Adding two large integers then dividing the sum, (a+b)/2 ,might end up creating a sum that can't fit in memory. However this overflow can be avoided by never adding the numbers first instead, adding the difference of the two numbers to the least i.e (a+b)/2 == a+(b-a)/2 == b-(b-a)/2 ... Please comment or ask for further clarification instead of just rejecting the proposal. Thanks

### **Describe your change:**



* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
