### PR TITLE
.travis.yml: Revert to using autoblack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: pip
 before_install: pip install --upgrade pip setuptools six
 install: pip install black flake8
 before_script:
-  - black --check .
+  - black --check . || true
   - flake8 --ignore=E203,W503 --max-complexity=25 --max-line-length=120 --statistics --count .
   - scripts/validate_filenames.py  # no uppercase, no spaces, in a directory
   - pip install -r requirements.txt  # fast fail on black, flake8, validate_filenames

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -575,6 +575,7 @@
   * [Ternary Search](https://github.com/TheAlgorithms/Python/blob/master/searches/ternary_search.py)
 
 ## Sorts
+  * [Bead Sort](https://github.com/TheAlgorithms/Python/blob/master/sorts/bead_sort.py)
   * [Bitonic Sort](https://github.com/TheAlgorithms/Python/blob/master/sorts/bitonic_sort.py)
   * [Bogo Sort](https://github.com/TheAlgorithms/Python/blob/master/sorts/bogo_sort.py)
   * [Bubble Sort](https://github.com/TheAlgorithms/Python/blob/master/sorts/bubble_sort.py)


### PR DESCRIPTION
Our autoblack GitHub Action will get us to black compliance without forcing each contributor to learn about, install, and use psf/black on every pull request.

### **Describe your change:**



* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
