### PR TITLE
Added travis notifications only on fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install: pip install --upgrade pip setuptools six
 install: pip install black flake8
 notifications:
     webhooks: https://www.travisbuddy.com/
+    on_success: never
 before_script:
   - black --check . || true
   - flake8 --ignore=E203,W503 --max-complexity=25 --max-line-length=120 --statistics --count .

--- a/greedy_method/test_knapsack.py
+++ b/greedy_method/test_knapsack.py
@@ -67,7 +67,9 @@ class TestClass(unittest.TestCase):
         # profit = [10, 20, 30, 40, 50]
         # weight = [2, 4, 6, 8, 10, 12]
         # max_weight = 100
-        self.assertRaisesRegex(IndexError, "The length of profit and weight must be same.")
+        self.assertRaisesRegex(
+            IndexError, "The length of profit and weight must be same."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **Describe your change:**
I noticed a little bit spam by Travis notifications so maybe changing them only on fail will be better.
https://github.com/bluzi/travis-buddy#disable-success-message

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
