### PR TITLE
Percentual proximity scoring algorithm added

### DIFF
--- a/other/scoring_algorithm.py
+++ b/other/scoring_algorithm.py
@@ -1,0 +1,89 @@
+'''
+developed by: markmelnic
+original repo: https://github.com/markmelnic/Scoring-Algorithm
+
+Analyse data using a range based percentual proximity algorithm
+and calculate the linear maximum likelihood estimation.
+The basic principle is that all values supplied will be broken
+down to a range from 0 to 1 and each column's score will be added
+up to get the total score.
+
+==========
+Example for data of vehicles
+price|mileage|registration_year
+20k  |60k    |2012
+22k  |50k    |2011
+23k  |90k    |2015
+16k  |210k   |2010
+
+We want the vehicle with the lowest price,
+lowest mileage but newest registration year.
+Thus the weights for each column are as follows:
+[0, 0, 1]
+
+>>> scalg([[20, 60, 2012],[23, 90, 2015],[22, 50, 2011]], [0, 0, 1])
+[[20, 60, 2012, 2.0], [23, 90, 2015, 1.0], [22, 50, 2011, 1.3333333333333335]]
+'''
+
+
+def scalg(source_data : list, weights : list):
+
+    '''
+    weights - int list
+    possible values - 0 / 1
+    0 if lower values have higher weight in the data set
+    1 if higher values have higher weight in the data set
+    '''
+
+    # getting data
+    data_lists = []
+    for item in source_data:
+        for i in range(len(item)):
+            try:
+                data_lists[i].append(float(item[i]))
+            except IndexError:
+                # generate corresponding number of lists
+                data_lists.append([])
+                data_lists[i].append(float(item[i]))
+
+    score_lists = []
+    # calculating each score
+    for dlist, weight in zip(data_lists, weights):
+        mind = min(dlist)
+        maxd = max(dlist)
+
+        score = []
+        # for weight 0 score is 1 - actual score
+        if weight == 0:
+            for item in dlist:
+                try:
+                    score.append(1 - ((item - mind) / (maxd - mind)))
+                except ZeroDivisionError:
+                    score.append(1)
+
+        elif weight == 1:
+            for item in dlist:
+                try:
+                    score.append((item - mind) / (maxd - mind))
+                except ZeroDivisionError:
+                    score.append(0)
+
+        # weight not 0 or 1
+        else:
+            raise Exception("Invalid weight of %f provided" % (weight))
+
+        score_lists.append(score)
+
+    # initialize final scores
+    final_scores = [0 for i in range(len(score_lists[0]))]
+
+    # generate final scores
+    for i, slist in enumerate(score_lists):
+        for j, ele in enumerate(slist):
+            final_scores[j] = final_scores[j] + ele
+
+    # append scores to source data
+    for i, ele in enumerate(final_scores):
+        source_data[i].append(ele)
+
+    return source_data


### PR DESCRIPTION
This is an algorithm which works based on a range based percentual proximity scoring principle. Initially I developed it for a personal project, however later I found out it is a form of Newton's method used in statistics to solve maximum likelihood equations numerically.


* [x] Add an algorithm?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
