### PR TITLE
added tox to handle virtual environment automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: focal
 language: python
 python: 3.8
 cache: pip
-before_install: pip install --upgrade pip setuptools six
-install: pip install black flake8
+before_install: pip install --upgrade pip
+install: pip install black flake8 mypy tox
 notifications:
     webhooks: https://www.travisbuddy.com/
     on_success: never
@@ -12,9 +12,9 @@ before_script:
   - black --check . || true
   - flake8 --ignore=E203,W503 --max-complexity=25 --max-line-length=88 --statistics --count .
   - scripts/validate_filenames.py  # no uppercase, no spaces, in a directory
-  - pip install -r requirements.txt  # fast fail on black, flake8, validate_filenames
+
 script:
   - mypy --ignore-missing-imports .
-  - pytest --doctest-modules --durations=10 --cov-report=term-missing:skip-covered --cov=. .
+  - tox
 after_success:
   - scripts/build_directory_md.py 2>&1 | tee DIRECTORY.md

--- a/ciphers/hill_cipher.py
+++ b/ciphers/hill_cipher.py
@@ -155,8 +155,8 @@ class HillCipher:
         """
         >>> hill_cipher = HillCipher(numpy.array([[2, 5], [1, 6]]))
         >>> hill_cipher.make_decrypt_key()
-        array([[ 6., 25.],
-               [ 5., 26.]])
+        array([[ 6, 25],
+               [ 5, 26]])
         """
         det = round(numpy.linalg.det(self.encrypt_key))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,11 @@
 beautifulsoup4
-black
 fake_useragent
-flake8
 keras
 matplotlib
-mypy
 numpy
 opencv-python
 pandas
 pillow
-pytest
-pytest-cov
 requests
 scikit-fuzzy
 sklearn

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py38
+
+[testenv]
+skip_install = true
+deps = 
+    coverage
+    pytest
+    -rrequirements.txt
+commands = 
+    coverage run -m pytest --doctest-modules .
+    coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     coverage
     pytest
     -rrequirements.txt
+
 commands = 
-    coverage run -m pytest --doctest-modules .
-    coverage report -m
+    coverage run -m pytest --doctest-modules {posargs}
+    coverage report -m --omit='.tox/*'


### PR DESCRIPTION
### **Describe your change:**

I have modified travis config a little bit to avoid unnecessary installing of libraries and instead added [tox](https://tox.readthedocs.io/) with a clean configuration that calculates coverage as well.

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
