### PR TITLE
Small fix: arithmetic_analysis/newton_method.py

### DIFF
--- a/arithmetic_analysis/newton_method.py
+++ b/arithmetic_analysis/newton_method.py
@@ -36,7 +36,7 @@ def newton(
         try:
             next_guess = prev_guess - function(prev_guess) / derivative(prev_guess)
         except ZeroDivisionError:
-            raise ZeroDivisionError("Could not find root")
+            raise ZeroDivisionError("Could not find root") from None
         if abs(prev_guess - next_guess) < 10 ** -5:
             return next_guess
         prev_guess = next_guess


### PR DESCRIPTION
Small fix to arithmetic_analysis/newton_method.py

When you `raise` inside an `except` block you will get two traceback.
```python
>>> try:
...     a = 1/0
... except ZeroDivisionError:
...     raise ZeroDivisionError("Not possible")
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
ZeroDivisionError: Not possible
```
Why? the except block is used to handle the exceptions, if you want to raise an exception inside it you need to use the from clause like so:

```python
>>> try:
...     a = 1/0
... except ZeroDivisionError:
...     raise ZeroDivisionError("Not possible") from None
...
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
ZeroDivisionError: Not possible
```

### **Describe your change:**

* [x] Fix a bug or typo in an existing algorithm?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
