### PR TITLE
math/fermat_little_theorem: update proof statement

### DIFF
--- a/maths/fermat_little_theorem.py
+++ b/maths/fermat_little_theorem.py
@@ -2,7 +2,7 @@
 Python program to show the usage of Fermat's little theorem in a division
 
 If p is a prime number, then given any integer a,
-(a raised to the power of p) is congruent to (a) modulo the prime p.
+(a**p) is congruent to (a) modulo the prime p.
 
 Wikipedia reference: https://en.wikipedia.org/wiki/Fermat%27s_little_theorem
 """
@@ -34,14 +34,14 @@ def check_fermat_little_thm(a: int, p: int) -> bool:
     """
     Verifies the fermat little theorem
 
-    # Example prime: 13
+    Example prime: 13
     >>> check_fermat_little_thm(400, 13)
     True
 
     >>> check_fermat_little_thm(22, 13)
     True
 
-    # Example prime: 701
+    Example prime: 701
     >>> check_fermat_little_thm(13, 701)
     True
 
@@ -52,3 +52,38 @@ def check_fermat_little_thm(a: int, p: int) -> bool:
     a_mod_p = binary_exponentiation(a, 1, p)  # or just a % p
 
     return a_power_p == a_mod_p
+
+
+def check_fermat_little_thm_indivisible(a: int, p: int) -> bool:
+    """
+    If a is indivisible by p, then the special case holds:
+
+    a**(p-1) = 1 (mod p)
+
+    >>> check_fermat_little_thm_indivisible(400, 13)
+    True
+
+    >>> check_fermat_little_thm_indivisible(13, 2)
+    True
+
+    """
+    assert a % p != 0
+
+    a_power_p_minus_one = binary_exponentiation(a, p - 1, p)
+    return a_power_p_minus_one == 1
+
+
+if __name__ == "__main__":
+    # Test 1: Generic Case
+    fermat_result = check_fermat_little_thm(183, 17)
+    print(
+        f"Checking fermat little thm with a = 183 and p = 17, result:\
+    {fermat_result}"
+    )
+
+    # Test 2: Special Case
+    fermat_special_result = check_fermat_little_thm_indivisible(19, 4)
+    print(
+        f"Checking fermat little thm special case with a = 19 and p = 4,\
+    result: {fermat_special_result}"
+    )

--- a/maths/fermat_little_theorem.py
+++ b/maths/fermat_little_theorem.py
@@ -1,12 +1,24 @@
-# Python program to show the usage of Fermat's little theorem in a division
-# According to Fermat's little theorem, (a / b) mod p always equals
-# a * (b ^ (p - 2)) mod p
-# Here we assume that p is a prime number, b divides a, and p doesn't divide b
-# Wikipedia reference: https://en.wikipedia.org/wiki/Fermat%27s_little_theorem
+"""
+Python program to show the usage of Fermat's little theorem in a division
+
+If p is a prime number, then given any integer a,
+(a raised to the power of p) is congruent to (a) modulo the prime p.
+
+Wikipedia reference: https://en.wikipedia.org/wiki/Fermat%27s_little_theorem
+"""
 
 
-def binary_exponentiation(a, n, mod):
+def binary_exponentiation(a: int, n: int, mod: int) -> int:
+    """
+    Find a to the power of n, modulo mod.
 
+    >>> binary_exponentiation(4, 3, 7)
+    1
+
+    >>> binary_exponentiation(2, 9, 9)
+    8
+
+    """
     if n == 0:
         return 1
 
@@ -18,14 +30,25 @@ def binary_exponentiation(a, n, mod):
         return (b * b) % mod
 
 
-# a prime number
-p = 701
+def check_fermat_little_thm(a: int, p: int) -> bool:
+    """
+    Verifies the fermat little theorem
 
-a = 1000000000
-b = 10
+    # Example prime: 13
+    >>> check_fermat_little_thm(400, 13)
+    True
 
-# using binary exponentiation function, O(log(p)):
-print((a / b) % p == (a * binary_exponentiation(b, p - 2, p)) % p)
+    >>> check_fermat_little_thm(22, 13)
+    True
 
-# using Python operators:
-print((a / b) % p == (a * b ** (p - 2)) % p)
+    # Example prime: 701
+    >>> check_fermat_little_thm(13, 701)
+    True
+
+    >>> check_fermat_little_thm(22, 701)
+    True
+    """
+    a_power_p = binary_exponentiation(a, p, p)
+    a_mod_p = binary_exponentiation(a, 1, p)  # or just a % p
+
+    return a_power_p == a_mod_p


### PR DESCRIPTION
### **Describe your change:**

From wikipedia, the definition of fermat little theorem is that a**p = a (mod p)

In the old code, the author checked if:
(a/b) == a * (b**(p-2)) (mod p)

This is a rather convoluted way of expressing the fermat little theorem, which only involves two params a and p in the first place. The equivalent transformation was to do b**2/a to the original LHS and RHS.

I have also added the demonstration code for the special case when a is not divisible by p, then:
a**(p-1) = 1 (mod p)

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
