### PR TITLE
Add a new problem of grouping anagram among a list of strings with case sensitive and case insensitive feature

### DIFF
--- a/strings/group_anagrams.py
+++ b/strings/group_anagrams.py
@@ -16,7 +16,7 @@ def modify_word_and_get_offset(word: str, alphabet: int) -> tuple:
 def get_key(word: str, alphabet: int) -> tuple:
     """ If case sensitive feature is on, then the alphabet size is 52 : A-Z, a-z (26+26=52).
         For case sensitive feature, first 26 positions are for uppercase characters and next 
-        26 positions are for lowercase characters. So `offset` denotes that if case sensitive 
+        26 positions are for lowercase characters. So `offset` denotes that if case sensitive
         feaure is on, then the lower case characters will be shifted 26 positions from the 
         starting of the `alphabet_list`. If you are wondering why is that, it's because 
         `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
@@ -43,9 +43,10 @@ def group_anagrams(words: str, case_sensitive=False) -> list:
     >>> group_anagrams([''], False)
     [['']]
 
-    By default all the strings will be in lower case. If you want uppercase sensitive feature, 
-    pass an optional parameter `case_sensitive` with the value `True`. Default value of `case_sensitive` 
-    is False. So `cat` and `cAt` will be treated as the same strings.
+    By default all the strings will be in lower case. If you want uppercase sensitive 
+    feature, pass an optional parameter `case_sensitive` with the value `True`. 
+    Default value of `case_sensitive` is False. So `cat` and `cAt` will be treated 
+    as the same strings.
 
     >>> group_anagrams(['cat', 'cAt', 'nat', 'Nat', 'tac'], True)
     [['cat', 'tac'], ['cAt'], ['nat'], ['Nat']]

--- a/strings/group_anagrams.py
+++ b/strings/group_anagrams.py
@@ -1,0 +1,75 @@
+"""
+wiki: https://en.wikipedia.org/wiki/Anagram
+"""
+
+
+from collections import defaultdict
+
+
+def modify_word_and_get_offset(word: str, alphabet: int) -> tuple:
+    """ If alphabet is 26 meaning case sensitive feature is off, the string is converted to lowercase and
+        the offset is set to 0
+    """
+    return (word.lower(), 0) if alphabet == 26 else (word, 25)
+
+
+def get_key(word: str, alphabet: int) -> tuple:
+    """ If case sensitive feature is on, then the alphabet size is 52 : A-Z, a-z (26+26=52).
+        For case sensitive feature, first 26 positions are for uppercase characters and next 26 positions are 
+        for lowercase characters. So `offset` denotes that if case sensitive feaure is on, then the lower case
+        characters will be shifted 26 positions from the starting of the `alphabet_list`. If you are wondering 
+        why is that, it's because `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
+    """
+    alphabet_lists = [0 for i in range(alphabet)]
+    word, offset = modify_word_and_get_offset(word, alphabet)
+
+    for char in word:
+        if char.isupper():
+                alphabet_lists[ord(char) - ord('A')] += 1
+        else:
+            alphabet_lists[ord(char) - ord('a') + offset] += 1
+
+    return tuple(alphabet_lists)
+
+
+def group_anagrams(words: str, case_sensitive=False) -> list:
+    """
+    A list of strings `words` is given. Group the strings as anagram together. 
+    >>> group_anagrams(['cat', 'bat', 'nat', 'tac', 'tab'], False)
+    [['cat', 'tac'], ['bat', 'tab'], ['nat']]
+    >>> group_anagrams(['a'], False)
+    [['a']]
+    >>> group_anagrams([''], False)
+    [['']]
+
+    By default all the strings will be in lower case. If you want uppercase sensitive feature, pass an optional 
+    parameter `case_sensitive` with the value `True`. Default value of `case_sensitive` is False. So `cat` and
+    `cAt` will be treated as the same strings.
+
+    >>> group_anagrams(['cat', 'cAt', 'nat', 'Nat', 'tac'], True)
+    [['cat', 'tac'], ['cAt'], ['nat'], ['Nat']]
+    """
+    anagram_lists = defaultdict(list)
+
+    for word in words:
+        alphabet = 26 if not case_sensitive else 52
+        
+        key = get_key(word, alphabet)
+        anagram_lists[key].append(word)
+
+    return [anagrams for anagrams in anagram_lists.values()]
+
+
+def is_case_sensitive(case_sensitive: str) -> bool:
+    return case_sensitive == 'y' or case_sensitive == "Y"
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    words = input("Enter the strings ").strip().split(' ')
+    case_sensitive = input("Do you want case sensitive feature in the Anagram? y/n: ").strip()
+
+    ans = group_anagrams([word for word in words], is_case_sensitive(case_sensitive))
+    print(f"Group Anagrams lists {ans}")

--- a/strings/group_anagrams.py
+++ b/strings/group_anagrams.py
@@ -7,18 +7,19 @@ from collections import defaultdict
 
 
 def modify_word_and_get_offset(word: str, alphabet: int) -> tuple:
-    """ If alphabet is 26 meaning case sensitive feature is off, the string is converted to lowercase and
-        the offset is set to 0
+    """ If alphabet is 26 meaning case sensitive feature is off, the string is 
+        converted to lowercase and the offset is set to 0
     """
     return (word.lower(), 0) if alphabet == 26 else (word, 25)
 
 
 def get_key(word: str, alphabet: int) -> tuple:
     """ If case sensitive feature is on, then the alphabet size is 52 : A-Z, a-z (26+26=52).
-        For case sensitive feature, first 26 positions are for uppercase characters and next 26 positions are 
-        for lowercase characters. So `offset` denotes that if case sensitive feaure is on, then the lower case
-        characters will be shifted 26 positions from the starting of the `alphabet_list`. If you are wondering 
-        why is that, it's because `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
+        For case sensitive feature, first 26 positions are for uppercase characters and next 
+        26 positions are for lowercase characters. So `offset` denotes that if case sensitive 
+        feaure is on, then the lower case characters will be shifted 26 positions from the 
+        starting of the `alphabet_list`. If you are wondering why is that, it's because 
+        `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
     """
     alphabet_lists = [0 for i in range(alphabet)]
     word, offset = modify_word_and_get_offset(word, alphabet)
@@ -42,9 +43,9 @@ def group_anagrams(words: str, case_sensitive=False) -> list:
     >>> group_anagrams([''], False)
     [['']]
 
-    By default all the strings will be in lower case. If you want uppercase sensitive feature, pass an optional 
-    parameter `case_sensitive` with the value `True`. Default value of `case_sensitive` is False. So `cat` and
-    `cAt` will be treated as the same strings.
+    By default all the strings will be in lower case. If you want uppercase sensitive feature, 
+    pass an optional parameter `case_sensitive` with the value `True`. Default value of `case_sensitive` 
+    is False. So `cat` and `cAt` will be treated as the same strings.
 
     >>> group_anagrams(['cat', 'cAt', 'nat', 'Nat', 'tac'], True)
     [['cat', 'tac'], ['cAt'], ['nat'], ['Nat']]

--- a/strings/group_anagrams.py
+++ b/strings/group_anagrams.py
@@ -7,35 +7,35 @@ from collections import defaultdict
 
 
 def modify_word_and_get_offset(word: str, alphabet: int) -> tuple:
-    """ If alphabet is 26 meaning case sensitive feature is off, the string is 
-        converted to lowercase and the offset is set to 0
+    """If alphabet is 26 meaning case sensitive feature is off, the string is
+    converted to lowercase and the offset is set to 0
     """
     return (word.lower(), 0) if alphabet == 26 else (word, 25)
 
 
 def get_key(word: str, alphabet: int) -> tuple:
-    """ If case sensitive feature is on, then the alphabet size is 52 : A-Z, a-z (26+26=52).
-        For case sensitive feature, first 26 positions are for uppercase characters and next 
-        26 positions are for lowercase characters. So `offset` denotes that if case sensitive
-        feaure is on, then the lower case characters will be shifted 26 positions from the 
-        starting of the `alphabet_list`. If you are wondering why is that, it's because 
-        `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
+    """If case sensitive feature is on, then the alphabet size is 52 : A-Z, a-z (26+26=52).
+    For case sensitive feature, first 26 positions are for uppercase characters and next
+    26 positions are for lowercase characters So `offset` denotes that if case sensitive
+    feaure is on, then the lower case characters will be shifted 26 positions from the
+    starting of the `alphabet_list`. If you are wondering why is that, it's because
+    `ord('A')-ord('A') and ord('a') - ord('a')` gives the same value.
     """
     alphabet_lists = [0 for i in range(alphabet)]
     word, offset = modify_word_and_get_offset(word, alphabet)
 
     for char in word:
         if char.isupper():
-                alphabet_lists[ord(char) - ord('A')] += 1
+            alphabet_lists[ord(char) - ord("A")] += 1
         else:
-            alphabet_lists[ord(char) - ord('a') + offset] += 1
+            alphabet_lists[ord(char) - ord("a") + offset] += 1
 
     return tuple(alphabet_lists)
 
 
 def group_anagrams(words: str, case_sensitive=False) -> list:
     """
-    A list of strings `words` is given. Group the strings as anagram together. 
+    A list of strings `words` is given. Group the strings as anagram together.
     >>> group_anagrams(['cat', 'bat', 'nat', 'tac', 'tab'], False)
     [['cat', 'tac'], ['bat', 'tab'], ['nat']]
     >>> group_anagrams(['a'], False)
@@ -43,9 +43,9 @@ def group_anagrams(words: str, case_sensitive=False) -> list:
     >>> group_anagrams([''], False)
     [['']]
 
-    By default all the strings will be in lower case. If you want uppercase sensitive 
-    feature, pass an optional parameter `case_sensitive` with the value `True`. 
-    Default value of `case_sensitive` is False. So `cat` and `cAt` will be treated 
+    By default all the strings will be in lower case. If you want uppercase sensitive
+    feature, pass an optional parameter `case_sensitive` with the value `True`.
+    Default value of `case_sensitive` is False. So `cat` and `cAt` will be treated
     as the same strings.
 
     >>> group_anagrams(['cat', 'cAt', 'nat', 'Nat', 'tac'], True)
@@ -55,7 +55,7 @@ def group_anagrams(words: str, case_sensitive=False) -> list:
 
     for word in words:
         alphabet = 26 if not case_sensitive else 52
-        
+
         key = get_key(word, alphabet)
         anagram_lists[key].append(word)
 
@@ -63,15 +63,17 @@ def group_anagrams(words: str, case_sensitive=False) -> list:
 
 
 def is_case_sensitive(case_sensitive: str) -> bool:
-    return case_sensitive == 'y' or case_sensitive == "Y"
+    return case_sensitive == "y" or case_sensitive == "Y"
 
 
 if __name__ == "__main__":
     from doctest import testmod
 
     testmod()
-    words = input("Enter the strings ").strip().split(' ')
-    case_sensitive = input("Do you want case sensitive feature in the Anagram? y/n: ").strip()
+    words = input("Enter the strings ").strip().split(" ")
+    case_sensitive = input(
+        "Do you want case sensitive feature in the Anagram? y/n: "
+    ).strip()
 
     ans = group_anagrams([word for word in words], is_case_sensitive(case_sensitive))
     print(f"Group Anagrams lists {ans}")


### PR DESCRIPTION

- Added a new problem in the `strings` category. `Group anagrams among a list of strings`.
- The problem is a common one. But I tried to provide a solution in my own way.
-  I also added one extra feature to this problem. My solution supports both `case sensitive` and `case insensitive` feature. If a user wants to group anagram from a list of strings with the`case sensitive` feature, she/he can.

Example: 
```
>>> group_anagrams(['cat', 'cAt', 'nat', 'Nat', 'tac'], case_sensitive=True)
[['cat', 'tac'], ['cAt'], ['nat'], ['Nat']]

>>> group_anagrams(['cat', 'bat', 'nat', 'cAt', 'tab'], case_sensitive=False)
[['cat', 'cAt'], ['bat', 'tab'], ['nat']]
```
### **Changes**
* [X] Add an algorithm

### **Checklist:**
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request algorithm problem exists. But I tried to provide the solution with my own implementation with an extra feature.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
