### PR TITLE
Simplify cfgs for tools

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-sort = Cover
-omit =
-    .env/*

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E203,W503
+max-complexity = 25
+max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,6 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-        args:
-          - --ignore=E203,W503
-          - --max-complexity=25
-          - --max-line-length=88
 #     FIXME: fix mypy errors and then uncomment this
 #    - repo: https://github.com/pre-commit/mirrors-mypy
 #      rev: v0.782

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,6 @@ repos:
     rev: 5.5.3
     hooks:
       - id: isort
-        args:
-          - --profile=black
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = 'black'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.isort]
 profile = 'black'
 
+[tool.coverage.report]
+sort = 'Cover'
+omit = ['.env/*']
+
 [tool.pytest.ini_options]
 markers = ['mat_ops: mark a test as utilizing matrix operations.']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.isort]
 profile = 'black'
+
+[tool.pytest.ini_options]
+markers = ['mat_ops: mark a test as utilizing matrix operations.']

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-# Setup for pytest
-[pytest]
-markers =
-    mat_ops: mark a test as utilizing matrix operations.


### PR DESCRIPTION
### Description
* mv cfg for flake8 and isort out of .pre-commit for consistent experience when running tools w/o precommit.
* mv cfg for pytest and converage into `pyproject.toml` to reduces file clutter. (Unfortunately flake8 does not support `pyproject.toml`)

Does this PR qualify for Hacktoberfest?
