### PR TITLE
Removed rank

### DIFF
--- a/data_structures/disjoint_set/disjoint_set.py
+++ b/data_structures/disjoint_set/disjoint_set.py
@@ -13,25 +13,15 @@ def make_set(x):
     """
     make x as a set.
     """
-    # rank is the distance from x to its' parent
-    # root's rank is 0
-    x.rank = 0
     x.parent = x
 
 
 def union_set(x, y):
     """
     union two sets.
-    set with bigger rank should be parent, so that the
-    disjoint set tree will be more flat.
     """
     x, y = find_set(x), find_set(y)
-    if x.rank > y.rank:
-        y.parent = x
-    else:
-        x.parent = y
-        if x.rank == y.rank:
-            y.rank += 1
+    y.parent = x
 
 
 def find_set(x):


### PR DESCRIPTION
Since any union_set operation on x connects x to root, rank of both x and y are always equal to 1
Removed rank for simplicity and fewer operations

### **Describe your change:**



* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
