### PR TITLE
Added solution for Project Euler problem 174.

### DIFF
--- a/project_euler/problem_174/sol1.py
+++ b/project_euler/problem_174/sol1.py
@@ -1,0 +1,47 @@
+"""
+We shall define a square lamina to be a square outline with a square "hole" so that
+the shape possesses vertical and horizontal symmetry.
+
+Given eight tiles it is possible to form a lamina in only one way: 3x3 square with a
+1x1 hole in the middle. However, using thirty-two tiles it is possible to form two
+distinct laminae.
+
+If t represents the number of tiles used, we shall say that t = 8 is type L(1) and
+t = 32 is type L(2).
+
+Let N(n) be the number of t ≤ 1000000 such that t is type L(n); for example,
+N(15) = 832.
+
+What is ∑ N(n) for 1 ≤ n ≤ 10?
+"""
+
+
+from math import ceil, sqrt
+from collections import defaultdict
+
+
+def solution():
+    """
+    Return the sum of N(n) for 1 <= n <= 10.
+    """
+    LIMIT = 10 ** 6
+    count = defaultdict(int)
+
+    for outer_width in range(3, (LIMIT // 4) + 2):
+        if outer_width * outer_width > LIMIT:
+            hole_width_lower_bound = max(
+                ceil(sqrt(outer_width * outer_width - LIMIT)), 1
+            )
+        else:
+            hole_width_lower_bound = 1
+
+        hole_width_lower_bound += (outer_width - hole_width_lower_bound) % 2
+
+        for hole_width in range(hole_width_lower_bound, outer_width - 1, 2):
+            count[outer_width * outer_width - hole_width * hole_width] += 1
+
+    return sum(1 for n in count.values() if 1 <= n <= 10)
+
+
+if __name__ == "__main__":
+    print(solution())

--- a/project_euler/problem_174/sol1.py
+++ b/project_euler/problem_174/sol1.py
@@ -23,7 +23,7 @@ from math import ceil, sqrt
 
 def solution(t_limit: int = 1000000, n_limit: int = 10) -> int:
     """
-    Return the sum of N(n) for 1 <= n <= 10.
+    Return the sum of N(n) for 1 <= n <= n_limit.
     >>> solution(1000,5)
     249
     >>> solution(10000,10)

--- a/project_euler/problem_174/sol1.py
+++ b/project_euler/problem_174/sol1.py
@@ -16,8 +16,8 @@ What is ∑ N(n) for 1 ≤ n ≤ 10?
 """
 
 
-from math import ceil, sqrt
 from collections import defaultdict
+from math import ceil, sqrt
 
 
 def solution():

--- a/project_euler/problem_174/sol1.py
+++ b/project_euler/problem_174/sol1.py
@@ -24,6 +24,7 @@ from math import ceil, sqrt
 def solution(t_limit: int = 1000000, n_limit: int = 10) -> int:
     """
     Return the sum of N(n) for 1 <= n <= n_limit.
+
     >>> solution(1000,5)
     249
     >>> solution(10000,10)

--- a/project_euler/problem_174/sol1.py
+++ b/project_euler/problem_174/sol1.py
@@ -1,4 +1,6 @@
 """
+Project Euler Problem 174: https://projecteuler.net/problem=174
+
 We shall define a square lamina to be a square outline with a square "hole" so that
 the shape possesses vertical and horizontal symmetry.
 
@@ -15,22 +17,24 @@ N(15) = 832.
 What is ∑ N(n) for 1 ≤ n ≤ 10?
 """
 
-
 from collections import defaultdict
 from math import ceil, sqrt
 
 
-def solution():
+def solution(t_limit: int = 1000000, n_limit: int = 10) -> int:
     """
     Return the sum of N(n) for 1 <= n <= 10.
+    >>> solution(1000,5)
+    249
+    >>> solution(10000,10)
+    2383
     """
-    LIMIT = 10 ** 6
-    count = defaultdict(int)
+    count: defaultdict = defaultdict(int)
 
-    for outer_width in range(3, (LIMIT // 4) + 2):
-        if outer_width * outer_width > LIMIT:
+    for outer_width in range(3, (t_limit // 4) + 2):
+        if outer_width * outer_width > t_limit:
             hole_width_lower_bound = max(
-                ceil(sqrt(outer_width * outer_width - LIMIT)), 1
+                ceil(sqrt(outer_width * outer_width - t_limit)), 1
             )
         else:
             hole_width_lower_bound = 1
@@ -44,4 +48,4 @@ def solution():
 
 
 if __name__ == "__main__":
-    print(solution())
+    print(f"{solution() = }")


### PR DESCRIPTION
Counting the number of "hollow" square laminae that can form one, two, three, ... distinct arrangements

We shall define a square lamina to be a square outline with a square "hole" so that the shape possesses vertical and horizontal symmetry.

Given eight tiles it is possible to form a lamina in only one way: 3x3 square with a 1x1 hole in the middle. However, using thirty-two tiles it is possible to form two distinct laminae.

If t represents the number of tiles used, we shall say that t = 8 is type L(1) and t = 32 is type L(2).

Let N(n) be the number of t ≤ 1000000 such that t is type L(n); for example, N(15) = 832.

What is ∑ N(n) for 1 ≤ n ≤ 10?

Reference: [https://projecteuler.net/problem=174](url)
Reference: #2695


* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
