### PR TITLE
Added solution for Project Euler problem 113

### DIFF
--- a/project_euler/problem_113/sol1.py
+++ b/project_euler/problem_113/sol1.py
@@ -1,4 +1,6 @@
 """
+Project Euler Problem 113: https://projecteuler.net/problem=113
+
 Working from left-to-right if no digit is exceeded by the digit to its left it is
 called an increasing number; for example, 134468.
 
@@ -58,12 +60,16 @@ def non_bouncy_upto(n: int) -> int:
     return sum(non_bouncy_exact(i) for i in range(1, n + 1))
 
 
-def solution() -> int:
+def solution(num_digits: int = 100) -> int:
     """
     Caclulate the number of non-bouncy numbers less than a googol.
+    >>> solution(6)
+    12951
+    >>> solution(10)
+    277032
     """
-    return non_bouncy_upto(100)
+    return non_bouncy_upto(num_digits)
 
 
 if __name__ == "__main__":
-    print(solution())
+    print(f"{solution() = }")

--- a/project_euler/problem_113/sol1.py
+++ b/project_euler/problem_113/sol1.py
@@ -1,0 +1,69 @@
+"""
+Working from left-to-right if no digit is exceeded by the digit to its left it is
+called an increasing number; for example, 134468.
+
+Similarly if no digit is exceeded by the digit to its right it is called a decreasing
+number; for example, 66420.
+
+We shall call a positive integer that is neither increasing nor decreasing a
+"bouncy" number; for example, 155349.
+
+As n increases, the proportion of bouncy numbers below n increases such that there
+are only 12951 numbers below one-million that are not bouncy and only 277032
+non-bouncy numbers below 10^10.
+
+How many numbers below a googol (10^100) are not bouncy?
+"""
+
+
+def choose(n: int, r: int) -> int:
+    """
+    Calculate the binomial coefficient c(n,r) using the multiplicative formula.
+    >>> choose(4,2)
+    6
+    >>> choose(5,3)
+    10
+    >>> choose(20,6)
+    38760
+    """
+    ret = 1.0
+    for i in range(1, r + 1):
+        ret *= (n + 1 - i) / i
+    return round(ret)
+
+
+def non_bouncy_exact(n: int) -> int:
+    """
+    Calculate the number of non-bouncy numbers with at most n digits.
+    >>> non_bouncy_exact(1)
+    9
+    >>> non_bouncy_exact(6)
+    7998
+    >>> non_bouncy_exact(10)
+    136126
+    """
+    return choose(8 + n, n) + choose(9 + n, n) - 10
+
+
+def non_bouncy_upto(n: int) -> int:
+    """
+    Calculate the number of non-bouncy numbers with at most n digits.
+    >>> non_bouncy_upto(1)
+    9
+    >>> non_bouncy_upto(6)
+    12951
+    >>> non_bouncy_upto(10)
+    277032
+    """
+    return sum(non_bouncy_exact(i) for i in range(1, n + 1))
+
+
+def solution() -> int:
+    """
+    Caclulate the number of non-bouncy numbers less than a googol.
+    """
+    return non_bouncy_upto(100)
+
+
+if __name__ == "__main__":
+    print(solution())


### PR DESCRIPTION
Name : Non-bouncy numbers

Working from left-to-right if no digit is exceeded by the digit to its left it is called an increasing number; for example, 134468.

Similarly if no digit is exceeded by the digit to its right it is called a decreasing number; for example, 66420.

We shall call a positive integer that is neither increasing nor decreasing a "bouncy" number; for example, 155349.

As n increases, the proportion of bouncy numbers below n increases such that there are only 12951 numbers below one-million that are not bouncy and only 277032 non-bouncy numbers below 10^10.

How many numbers below a googol (10^100) are not bouncy?

Reference: [https://projecteuler.net/problem=113](url)
Reference: #2695

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
