### PR TITLE
Fix Travis CI slow build on Project Euler Solution job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
       script:
         - pytest --doctest-modules --durations=10 --cov-report=term-missing:skip-covered --cov=project_euler/ project_euler/
     - name: Project Euler Solution
+      install:
+        - pip install pytest
       script:
         - pytest --tb=short --durations=10 project_euler/validate_solutions.py
 after_success:

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -648,6 +648,8 @@
     * [Sol1](https://github.com/TheAlgorithms/Python/blob/master/project_euler/problem_48/sol1.py)
   * Problem 49
     * [Sol1](https://github.com/TheAlgorithms/Python/blob/master/project_euler/problem_49/sol1.py)
+  * Problem 51
+    * [Sol1](https://github.com/TheAlgorithms/Python/blob/master/project_euler/problem_51/sol1.py)
   * Problem 52
     * [Sol1](https://github.com/TheAlgorithms/Python/blob/master/project_euler/problem_52/sol1.py)
   * Problem 53


### PR DESCRIPTION
I just noticed how long it is taking for Travis CI to run `Project Euler Solution` job and saw this:
- Without the latest change in `validate_solutions`: https://travis-ci.com/github/TheAlgorithms/Python/jobs/398271059#L213
- With the latest change in `validate_solutions`: https://travis-ci.com/github/TheAlgorithms/Python/jobs/398769857#L218

I think that after the [latest change](https://github.com/TheAlgorithms/Python/pull/3253), Travis used `pip install -r requirements.txt` to install `pytest`. This is to test whether that is true or not. If it is then the changes made in this PR should fix that.

#### Update: Installing `pytest` in the `install` step of the job fixes it.

### **Describe your change:**

* [x] Fix a bug or typo in an existing algorithm?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.