### PR TITLE
Capitalizing Caesar in documentation

### DIFF
--- a/ciphers/caesar_cipher.py
+++ b/ciphers/caesar_cipher.py
@@ -5,7 +5,7 @@ def encrypt(input_string: str, key: int, alphabet=None) -> str:
     """
     encrypt
     =======
-    Encodes a given string with the caesar cipher and returns the encoded
+    Encodes a given string with the Caesar cipher and returns the encoded
     message
 
     Parameters:
@@ -21,9 +21,9 @@ def encrypt(input_string: str, key: int, alphabet=None) -> str:
     Returns:
     *   A string containing the encoded cipher-text
 
-    More on the caesar cipher
+    More on the Caesar cipher
     =========================
-    The caesar cipher is named after Julius Caesar who used it when sending
+    The Caesar cipher is named after Julius Caesar who used it when sending
     secret military messages to his troops. This is a simple substitution cipher
     where very character in the plain-text is shifted by a certain number known
     as the "key" or "shift".
@@ -98,9 +98,9 @@ def decrypt(input_string: str, key: int, alphabet=None) -> str:
     Returns:
     *   A string containing the decoded plain-text
 
-    More on the caesar cipher
+    More on the Caesar cipher
     =========================
-    The caesar cipher is named after Julius Caesar who used it when sending
+    The Caesar cipher is named after Julius Caesar who used it when sending
     secret military messages to his troops. This is a simple substitution cipher
     where very character in the plain-text is shifted by a certain number known
     as the "key" or "shift". Please keep in mind, here we will be focused on
@@ -163,7 +163,7 @@ def brute_force(input_string: str, alphabet=None) -> dict:
     More about brute force
     ======================
     Brute force is when a person intercepts a message or password, not knowing
-    the key and tries every single combination. This is easy with the caesar
+    the key and tries every single combination. This is easy with the Caesar
     cipher since there are only all the letters in the alphabet. The more
     complex the cipher, the larger amount of time it will take to do brute force
 


### PR DESCRIPTION
### **Describe your change:**
Fix captilazitaion of Caesar encryption from "caesar" to "Caesar" in documentation


* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
