### PR TITLE
Fix bug in coin problem: was not handling the case where 0 was a coin.

### DIFF
--- a/dynamic_programming/coin_change.py
+++ b/dynamic_programming/coin_change.py
@@ -9,6 +9,8 @@ https://www.hackerrank.com/challenges/coin-change/problem
 
 def dp_count(S, n):
     """
+    >>> dp_count([0], 0)
+    1
     >>> dp_count([1, 2, 3], 4)
     4
     >>> dp_count([1, 2, 3], 7)
@@ -34,6 +36,8 @@ def dp_count(S, n):
     # after the index greater than or equal to the value of the
     # picked coin
     for coin_val in S:
+        if coin_val == 0:
+            continue
         for j in range(coin_val, n + 1):
             table[j] += table[j - coin_val]
 


### PR DESCRIPTION
### **Describe your change:**

I found a bug while writing the rust version of the coin problem: a wrong result was returned when 0 is listed in the coin list.

Fixes: #3584

* [ ] Add an algorithm?
* [X] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [X] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
