### PR TITLE
Check initial grid availability for backtracking/sudoku.py

### DIFF
--- a/backtracking/sudoku.py
+++ b/backtracking/sudoku.py
@@ -61,10 +61,8 @@ def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
     It returns False if it is not 'safe' (a duplicate digit
     is found) else returns True if it is 'safe'
     """
-    if n == 0:
-        return True
 
-    elif n < 0 or n > 9 or (not isinstance(n, int)):
+    if n < 0 or n > 9 or (not isinstance(n, int)):
         return False
 
     for i in range(9):

--- a/backtracking/sudoku.py
+++ b/backtracking/sudoku.py
@@ -26,6 +26,21 @@ initial_grid = [
     [0, 0, 5, 2, 0, 6, 3, 0, 0],
 ]
 
+
+initial_not_solvable_grid = [
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [3, 0, 0, 0, 0, 0, 0, 0, 0],
+    [3, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+]
+
+
+
 # a grid with no solution
 no_solution = [
     [5, 0, 6, 5, 0, 8, 4, 0, 3],
@@ -39,7 +54,6 @@ no_solution = [
     [0, 0, 5, 2, 0, 6, 3, 0, 0],
 ]
 
-
 def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
     """
     This function checks the grid to see if each row,
@@ -47,14 +61,23 @@ def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
     It returns False if it is not 'safe' (a duplicate digit
     is found) else returns True if it is 'safe'
     """
+    if n == 0:
+        return True
+
+    elif n < 0 or n > 9 or (not isinstance(n, int)):
+        return False
+
     for i in range(9):
-        if grid[row][i] == n or grid[i][column] == n:
+        if (grid[row][i] == n and i !=column) or (grid[i][column] == n and i !=row) :
             return False
+        
 
     for i in range(3):
-        for j in range(3):
-            if grid[(row - row % 3) + i][(column - column % 3) + j] == n:
-                return False
+        for j in range(3):             
+            new_row = (row - row % 3) + i
+            new_column = (column - column % 3) + j
+            if new_row != row and new_column != column and grid[new_row][new_column] == n:
+                return False             
 
     return True
 
@@ -90,8 +113,17 @@ def find_empty_location(grid: Matrix) -> Tuple[int, int]:
             if grid[i][j] == 0:
                 return i, j
 
+def check_original_solvable() -> bool:
+    for original_row in range(9):
+        for origin_col in range(9):
+            origin_digit = grid[original_row][origin_col]
+            if origin_digit:
+                if not is_safe(grid, original_row, origin_col, origin_digit):
+                    return False 
+    return True 
 
-def sudoku(grid: Matrix) -> Union[Matrix, bool]:
+
+def sudoku_solve(grid: Matrix) -> Union[Matrix, bool]:
     """
     Takes a partially filled-in grid and attempts to assign values to
     all unassigned locations in such a way to meet the requirements
@@ -109,10 +141,11 @@ def sudoku(grid: Matrix) -> Union[Matrix, bool]:
      [7, 4, 5, 2, 8, 6, 3, 1, 9]]
      >>> sudoku(no_solution)
      False
-    """
-
+    """   
+    
     if is_completed(grid):
-        return grid
+        return grid   
+
 
     row, column = find_empty_location(grid)
 
@@ -120,7 +153,7 @@ def sudoku(grid: Matrix) -> Union[Matrix, bool]:
         if is_safe(grid, row, column, digit):
             grid[row][column] = digit
 
-            if sudoku(grid):
+            if sudoku_solve(grid):
                 return grid
 
             grid[row][column] = 0
@@ -139,9 +172,16 @@ def print_solution(grid: Matrix) -> None:
         print()
 
 
+
+def sudoku(grid:Matrix) -> Union[Matrix, bool]:
+    if not check_original_solvable():
+        return False
+    return sudoku_solve(grid)
+
+
 if __name__ == "__main__":
     # make a copy of grid so that you can compare with the unmodified grid
-    for grid in (initial_grid, no_solution):
+    for grid in (initial_grid, no_solution, initial_not_solvable_grid, ):
         grid = list(map(list, grid))
         solution = sudoku(grid)
         if solution:

--- a/backtracking/sudoku.py
+++ b/backtracking/sudoku.py
@@ -40,7 +40,6 @@ initial_not_solvable_grid = [
 ]
 
 
-
 # a grid with no solution
 no_solution = [
     [5, 0, 6, 5, 0, 8, 4, 0, 3],
@@ -53,6 +52,7 @@ no_solution = [
     [0, 0, 0, 0, 0, 0, 0, 7, 4],
     [0, 0, 5, 2, 0, 6, 3, 0, 0],
 ]
+
 
 def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
     """
@@ -68,16 +68,19 @@ def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
         return False
 
     for i in range(9):
-        if (grid[row][i] == n and i !=column) or (grid[i][column] == n and i !=row) :
+        if (grid[row][i] == n and i != column) or (grid[i][column] == n and i != row):
             return False
-        
 
     for i in range(3):
-        for j in range(3):             
+        for j in range(3):
             new_row = (row - row % 3) + i
             new_column = (column - column % 3) + j
-            if new_row != row and new_column != column and grid[new_row][new_column] == n:
-                return False             
+            if (
+                new_row != row
+                and new_column != column
+                and grid[new_row][new_column] == n
+            ):
+                return False
 
     return True
 
@@ -113,14 +116,15 @@ def find_empty_location(grid: Matrix) -> Tuple[int, int]:
             if grid[i][j] == 0:
                 return i, j
 
-def check_original_solvable() -> bool:
+
+def check_original_solvable(grid) -> bool:
     for original_row in range(9):
         for origin_col in range(9):
             origin_digit = grid[original_row][origin_col]
             if origin_digit:
                 if not is_safe(grid, original_row, origin_col, origin_digit):
-                    return False 
-    return True 
+                    return False
+    return True
 
 
 def sudoku_solve(grid: Matrix) -> Union[Matrix, bool]:
@@ -141,11 +145,12 @@ def sudoku_solve(grid: Matrix) -> Union[Matrix, bool]:
      [7, 4, 5, 2, 8, 6, 3, 1, 9]]
      >>> sudoku(no_solution)
      False
-    """   
-    
-    if is_completed(grid):
-        return grid   
+     >>> sudoku(initial_not_solvable_grid)
+     False
+    """
 
+    if is_completed(grid):
+        return grid
 
     row, column = find_empty_location(grid)
 
@@ -172,16 +177,19 @@ def print_solution(grid: Matrix) -> None:
         print()
 
 
-
-def sudoku(grid:Matrix) -> Union[Matrix, bool]:
-    if not check_original_solvable():
+def sudoku(grid: Matrix) -> Union[Matrix, bool]:
+    if not check_original_solvable(grid):
         return False
     return sudoku_solve(grid)
 
 
 if __name__ == "__main__":
     # make a copy of grid so that you can compare with the unmodified grid
-    for grid in (initial_grid, no_solution, initial_not_solvable_grid, ):
+    for grid in (
+        initial_grid,
+        no_solution,
+        initial_not_solvable_grid,
+    ):
         grid = list(map(list, grid))
         solution = sudoku(grid)
         if solution:


### PR DESCRIPTION

```python
initial_grid = [
    [3, 0, 6, 5, 0, 8, 4, 0, 0],
    [5, 2, 0, 0, 0, 0, 0, 0, 0],
    [0, 8, 7, 0, 0, 0, 0, 3, 1],
    [0, 0, 3, 0, 1, 0, 0, 8, 0],
    [9, 0, 0, 8, 6, 3, 0, 0, 5],
    [0, 5, 0, 0, 9, 0, 6, 0, 0],
    [1, 3, 0, 0, 0, 0, 2, 5, 0],
    [0, 0, 0, 0, 0, 0, 0, 7, 4],
    [0, 0, 5, 2, 0, 6, 3, 0, 0],
]
```
In the original code above if you change the number 9 in the fifth line to 5, you will have a solution. But that is not a valid sudoku according to the definition. That means it's not validating whether the origingal sudoku can be solved. Not to mention to put a 10 anywhere or a minus number or a float at initial matrix. In the current request, this bug is fixed.