### PR TITLE
Add more details for the stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,23 +1,31 @@
-name: Mark stale issues and pull requests
+name: Mark/Close stale issues and pull requests
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 * * * *" # Run every hour
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: >
-          Please reopen this issue once you add more information and updates here.
-          If this is not the case and you need some help, feel free to seek help
-          from our [Gitter](https://gitter.im/TheAlgorithms) or ping one of the
-          reviewers. Thank you for your contributions!
-        stale-pr-message: >
-          Please reopen this pull request once you commit the changes requested
-          or make improvements on the code. If this is not the case and you need
-          some help, feel free to seek help from our [Gitter](https://gitter.im/TheAlgorithms)
-          or ping one of the reviewers. Thank you for your contributions!
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          close-issue-message: >
+            Please reopen this issue once you add more information and updates here.
+            If this is not the case and you need some help, feel free to seek help
+            from our [Gitter](https://gitter.im/TheAlgorithms) or ping one of the
+            reviewers. Thank you for your contributions!
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          close-pr-message: >
+            Please reopen this pull request once you commit the changes requested
+            or make improvements on the code. If this is not the case and you need
+            some help, feel free to seek help from our [Gitter](https://gitter.im/TheAlgorithms)
+            or ping one of the reviewers. Thank you for your contributions!


### PR DESCRIPTION
### **Describe your change:**

Changed configuration for the stale action:
- Run every hour: The action uses the search API and the limit for making the calls is 30 per hour. The default value for `operations-per-run` for the stale action is also 30. So, it makes sense to run this action every hour.
- Add the number of days before stale and close. ***Open to discussion to reduce the value***
- Add stale and close pr and issue message.

* [x] Improvements

### **Reason:**

I just noticed that our stale bot was configured to the default values which are 60 days until stale.

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.