### PR TITLE
Validate only submitted Project Euler solution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,6 @@ jobs:
           python -m pip install --upgrade pip setuptools six wheel
           python -m pip install pytest-cov -r requirements.txt
       - name: Run tests
-        run: pytest --doctest-modules --ignore=project_euler/ --cov-report=term-missing:skip-covered --cov=. .
+        run: pytest --doctest-modules --ignore=project_euler/ --ignore=scripts/ --cov-report=term-missing:skip-covered --cov=. .
       - if: ${{ success() }}
         run: scripts/build_directory_md.py 2>&1 | tee DIRECTORY.md

--- a/.github/workflows/project_euler.yml
+++ b/.github/workflows/project_euler.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install pytest
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest pygithub
+          python -m pip install --upgrade pytest
       - run: pytest scripts/validate_solutions.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project_euler.yml
+++ b/.github/workflows/project_euler.yml
@@ -1,12 +1,14 @@
 on:
   pull_request:
-    # only check if a file is changed within the project_euler directory and related files
+    # Run only if a file is changed within the project_euler directory and related files
     paths:
-      - 'project_euler/**'
-      - '.github/workflows/project_euler.yml'
-      - 'scripts/validate_solutions.py'
+      - "project_euler/**"
+      - ".github/workflows/project_euler.yml"
+      - "scripts/validate_solutions.py"
+  schedule:
+    - cron: "0 0 * * *" # Run everyday
 
-name: 'Project Euler'
+name: "Project Euler"
 
 jobs:
   project-euler:
@@ -27,5 +29,7 @@ jobs:
       - name: Install pytest
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest
+          python -m pip install --upgrade pytest pygithub
       - run: pytest scripts/validate_solutions.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project_euler.yml
+++ b/.github/workflows/project_euler.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - name: Install pytest
+      - name: Install pytest and requests
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest
+          python -m pip install --upgrade pytest requests
       - run: pytest scripts/validate_solutions.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/validate_solutions.py
+++ b/scripts/validate_solutions.py
@@ -59,7 +59,11 @@ def added_solution_file_path() -> List[pathlib.Path]:
         pull = repo.get_pull(pull_number)
         for file in pull.get_files():
             file_path = pathlib.Path.cwd().joinpath(file.filename)
-            if file_path.suffix != ".py" or file_path.name.startswith(("_", "test")):
+            if (
+                file_path.suffix != ".py"
+                or file_path.name.startswith(("_", "test"))
+                or not file_path.name.startswith("sol")
+            ):
                 continue
             solution_file_paths.append(file_path)
     return solution_file_paths

--- a/scripts/validate_solutions.py
+++ b/scripts/validate_solutions.py
@@ -6,8 +6,12 @@ import pathlib
 from types import ModuleType
 from typing import Dict, List
 
-import github
 import pytest
+
+try:
+    import github
+except ImportError:
+    pass
 
 PROJECT_EULER_DIR_PATH = pathlib.Path.cwd().joinpath("project_euler")
 PROJECT_EULER_ANSWERS_PATH = pathlib.Path.cwd().joinpath(
@@ -82,7 +86,7 @@ def collect_solution_file_paths() -> List[pathlib.Path]:
     collect_solution_file_paths(),
     ids=lambda path: f"{path.parent.name}/{path.name}",
 )
-def test_project_euler(solution_path: pathlib.Path):
+def test_project_euler(solution_path: pathlib.Path) -> None:
     """Testing for all Project Euler solutions"""
     # problem_[extract this part] and pad it with zeroes for width 3
     problem_number: str = solution_path.parent.name[8:].zfill(3)


### PR DESCRIPTION
Messing around with GitHub Actions, trying to see if this is possible:
We will run checks only on the submitted Project Euler solution and not all.

### **Describe your change:**

* [x] Improve Project Euler validate solutions script
* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
