### PR TITLE
Removed arrLen argument

### DIFF
--- a/dynamic_programming/sum_of_subset.py
+++ b/dynamic_programming/sum_of_subset.py
@@ -1,10 +1,12 @@
-def isSumSubset(arr, arrLen, requiredSum):
+def isSumSubset(arr, requiredSum):
     """
-    >>> isSumSubset([2, 4, 6, 8], 4, 5)
+    >>> isSumSubset([2, 4, 6, 8], 5)
     False
-    >>> isSumSubset([2, 4, 6, 8], 4, 14)
+    >>> isSumSubset([2, 4, 6, 8], 14)
     True
     """
+    # get array length 
+    arrLen = len(arr)
     # a subset value says 1 if that subset sum can be formed else 0
     # initially no subsets can be formed hence False/0
     subset = [[False for i in range(requiredSum + 1)] for i in range(arrLen + 1)]


### PR DESCRIPTION
Length of the passed array can be evaluated by len(arr) which is more succinct and precise

### **Describe your change:**



* [ ] Add an algorithm?
* [x ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [x ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
