### PR TITLE
[mypy] Add/fix type annotations for hashes. Fix for binary_tree_traversals

### DIFF
--- a/hashes/adler32.py
+++ b/hashes/adler32.py
@@ -9,7 +9,7 @@
 """
 
 
-def adler32(plain_text: str) -> str:
+def adler32(plain_text: str) -> int:
     """
     Function implements adler-32 hash.
     Itterates and evaluates new value for each character

--- a/hashes/chaos_machine.py
+++ b/hashes/chaos_machine.py
@@ -6,7 +6,8 @@ t = 3
 m = 5
 
 # Buffer Space (with Parameters Space)
-buffer_space, params_space = [], []
+buffer_space: list[int] = []
+params_space: list[int] = []
 
 # Machine Time
 machine_time = 0

--- a/hashes/md5.py
+++ b/hashes/md5.py
@@ -25,7 +25,7 @@ def rearrange(bitString32):
     return newString
 
 
-def reformatHex(i):
+def reformatHex(i: int) -> str:
     """[summary]
     Converts the given integer into 8-digit hex number.
 
@@ -81,7 +81,7 @@ def getBlock(bitString):
         currPos += 512
 
 
-def not32(i):
+def not32(i: int) -> int:
     """
     >>> not32(34)
     4294967261

--- a/hashes/sdbm.py
+++ b/hashes/sdbm.py
@@ -19,7 +19,7 @@
 """
 
 
-def sdbm(plain_text: str) -> str:
+def sdbm(plain_text: str) -> int:
     """
     Function implements sdbm hash, easy to use, great for bits scrambling.
     iterates over each character in the given string and applies function to each of

--- a/traversals/binary_tree_traversals.py
+++ b/traversals/binary_tree_traversals.py
@@ -188,7 +188,7 @@ def pre_order_iter(node: TreeNode) -> None:
     """
     if not isinstance(node, TreeNode) or not node:
         return
-    stack: List[TreeNode] = []
+    stack: list[TreeNode] = []
     n = node
     while n or stack:
         while n:  # start from root node, find its left child
@@ -218,7 +218,7 @@ def in_order_iter(node: TreeNode) -> None:
     """
     if not isinstance(node, TreeNode) or not node:
         return
-    stack: List[TreeNode] = []
+    stack: list[TreeNode] = []
     n = node
     while n or stack:
         while n:


### PR DESCRIPTION
### **Describe your change:**

Related Issue:  #4052 
Fix incorrect confusing type annotations in hashes

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
