### PR TITLE
Add Logistic Elastic Regression in machine_learning

### DIFF
--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -96,6 +96,14 @@ class MyElasticLogisticRegression(object):
         return sigmoid(logit(inputs_modified, self.w))
 
     def predict(self, inputs: Any, threshold: float = 0.5) -> Any:
+        """
+        >>> from sklearn.datasets import load_iris
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X, y = load_iris(return_X_y=True)
+        >>> clf = LogisticRegression(random_state=0).fit(X, y)
+        >>> clf.predict(X[:2, :])
+        array([0, 0])
+        """
         return self.predict_proba(inputs) >= threshold
 
     def get_weights(self) -> Any:

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -51,7 +51,7 @@ class MyElasticLogisticRegression(object):
 
     More at Wikipedia:
     https://en.wikipedia.org/wiki/Elastic_net_regularization
-    
+
     Original paper:
     https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.124.4696
     """

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -69,9 +69,9 @@ class MyElasticLogisticRegression(object):
         """
         >>> from sklearn.datasets import make_blobs
         >>> X, y = make_blobs(n_samples=10,
-        >>>                   centers=[[-2,0.5],[3,-0.5]],
-        >>>                   cluster_std=1,
-        >>>                   random_state=42)
+        ...                   centers=[[-2,0.5],[3,-0.5]],
+        ...                   cluster_std=1,
+        ...                   random_state=42)
         >>> clf = MyElasticLogisticRegression(0.1, 0.1)
         >>> losses = clf.fit(X, y, epochs=1, batch_size=5)
         >>> losses
@@ -135,7 +135,7 @@ class MyElasticLogisticRegression(object):
         """
         >>> from sklearn.model_selection import train_test_split
         >>> def linear_expression(x):
-        >>>     return 5 * x + 6
+        ...     return 5 * x + 6
         >>> objects_num = 50
         >>> X = np.linspace(-5, 5, objects_num)
         >>> y = linear_expression(X) + np.random.randn(objects_num) * 5
@@ -153,9 +153,9 @@ class MyElasticLogisticRegression(object):
         """
         >>> from sklearn.datasets import make_blobs
         >>> X, y = make_blobs(n_samples=10,
-        >>>                   centers=[[-2,0.5],[3,-0.5]],
-        >>>                   cluster_std=1,
-        >>>                   random_state=42)
+        ...                   centers=[[-2,0.5],[3,-0.5]],
+        ...                   cluster_std=1,
+        ...                   random_state=42)
         >>> clf = MyElasticLogisticRegression(0.1, 0.1)
         >>> losses = clf.fit(X, y, epochs=1, batch_size=5)
         >>> y_pred = clf.predict_proba(X)

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -199,4 +199,3 @@ if __name__ == "__main__":
     plt.pcolormesh(xx, yy, Z, cmap=cmap_light, shading="auto")
 
     plt.scatter(X[:, 0], X[:, 1], c=colored_y)
-

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -1,9 +1,9 @@
-import numpy as np  # type: ignore
-from sklearn.datasets import make_blobs  # type: ignore
-import matplotlib.pyplot as plt  # type: ignore
-from matplotlib.colors import ListedColormap  # type: ignore
+from typing import Any, Generator, Tuple
 
-from typing import Any, Tuple, Generator
+import matplotlib.pyplot as plt  # type: ignore
+import numpy as np  # type: ignore
+from matplotlib.colors import ListedColormap  # type: ignore
+from sklearn.datasets import make_blobs  # type: ignore
 
 Batch = Generator[Tuple[Any, Any], None, None]
 
@@ -51,9 +51,6 @@ class MyElasticLogisticRegression(object):
 
     More at Wikipedia:
     https://en.wikipedia.org/wiki/Elastic_net_regularization
-
-    Original paper:
-    https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.124.4696
     """
 
     def __init__(self, l1_coef: float, l2_coef: float) -> None:
@@ -71,7 +68,10 @@ class MyElasticLogisticRegression(object):
     ) -> list[float]:
         """
         >>> from sklearn.datasets import make_blobs
-        >>> X, y = make_blobs(n_samples=10, centers=[[-2,0.5],[3,-0.5]], cluster_std=1, random_state=42)
+        >>> X, y = make_blobs(n_samples=10,
+        >>>                   centers=[[-2,0.5],[3,-0.5]],
+        >>>                   cluster_std=1,
+        >>>                   random_state=42)
         >>> clf = MyElasticLogisticRegression(0.1, 0.1)
         >>> losses = clf.fit(X, y, epochs=1, batch_size=5)
         >>> losses
@@ -152,7 +152,10 @@ class MyElasticLogisticRegression(object):
     def loss(self, labels: Any, predictions: Any) -> float:
         """
         >>> from sklearn.datasets import make_blobs
-        >>> X, y = make_blobs(n_samples=10, centers=[[-2,0.5],[3,-0.5]], cluster_std=1, random_state=42)
+        >>> X, y = make_blobs(n_samples=10,
+        >>>                   centers=[[-2,0.5],[3,-0.5]],
+        >>>                   cluster_std=1,
+        >>>                   random_state=42)
         >>> clf = MyElasticLogisticRegression(0.1, 0.1)
         >>> losses = clf.fit(X, y, epochs=1, batch_size=5)
         >>> y_pred = clf.predict_proba(X)
@@ -167,9 +170,10 @@ class MyElasticLogisticRegression(object):
 
 
 if __name__ == "__main__":
-    X, y = make_blobs(
-        n_samples=1000, centers=[[-2, 0.5], [3, -0.5]], cluster_std=1, random_state=42
-    )
+    X, y = make_blobs(n_samples=1000,
+                      centers=[[-2, 0.5], [3, -0.5]],
+                      cluster_std=1,
+                      random_state=42)
 
     colors = ("red", "green")
     colored_y = np.zeros(y.size, dtype=str)

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -113,8 +113,8 @@ class MyElasticLogisticRegression(object):
         >>> clf.predict(X[:2, :])
         array([0, 0])
         >>> clf.predict_proba(X[:2, :])
-        array([[9.8...e-01, 1.8...e-02, 1.4...e-08],
-              [9.7...e-01, 2.8...e-02, 3.01...e-08]])
+        array([[9.81814888e-01, 1.81850971e-02, 1.43959138e-08],
+               [9.71755228e-01, 2.82447420e-02, 3.01073014e-08]])
         """
         n, k = inputs.shape
         inputs_modified = np.concatenate((np.ones((n, 1)), inputs), axis=1)
@@ -141,7 +141,7 @@ class MyElasticLogisticRegression(object):
         >>> y = linear_expression(X) + np.random.randn(objects_num) * 5
         >>> X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.5)
         >>> regressor = MyElasticLogisticRegression(0.5, 0.5)
-        >>> regressor.fit(X_train[:, np.newaxis], y_train)
+        >>> losses = regressor.fit(X_train[:, np.newaxis], y_train)
         >>> predictions = regressor.predict(X_test[:, np.newaxis])
         >>> w = regressor.get_weights()
         >>> w

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -106,15 +106,15 @@ class MyElasticLogisticRegression(object):
 
     def predict_proba(self, inputs: Any) -> Any:
         """
-        >>> from sklearn.datasets import load_iris
-        >>> from sklearn.linear_model import LogisticRegression
-        >>> X, y = load_iris(return_X_y=True)
-        >>> clf = LogisticRegression(random_state=0).fit(X, y)
-        >>> clf.predict(X[:2, :])
-        array([0, 0])
-        >>> clf.predict_proba(X[:2, :])
-        array([[9.81814888e-01, 1.81850971e-02, 1.43959138e-08],
-               [9.71755228e-01, 2.82447420e-02, 3.01073014e-08]])
+        >>> from sklearn.datasets import make_blobs
+        >>> X, y = make_blobs(n_samples=2,
+        ...                   centers=[[-2,0.5],[3,-0.5]],
+        ...                   cluster_std=1,
+        ...                   random_state=42)
+        >>> clf = MyElasticLogisticRegression(0.5, 0.5)
+        >>> losses = clf.fit(X, y)
+        >>> clf.predict_proba(X)
+        array([0.65..., 0.71...])
         """
         n, k = inputs.shape
         inputs_modified = np.concatenate((np.ones((n, 1)), inputs), axis=1)

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -1,0 +1,130 @@
+import numpy as np  # type: ignore
+from sklearn.datasets import make_blobs # type: ignore
+import matplotlib.pyplot as plt # type: ignore
+from matplotlib.colors import ListedColormap # type: ignore
+
+from typing import Any, Tuple, Generator
+
+
+def generate_batches(X: Any, y: Any, batch_size: int) -> Generator[Tuple[Any, Any], None, None]:
+    assert len(X) == len(y)
+    np.random.seed(42)
+    X = np.array(X)
+    y = np.array(y)
+    perm = np.random.permutation(len(X))
+    k = int(len(X) / batch_size)
+    for i in range(k):
+        batch_indx = perm[i * batch_size : (i + 1) * batch_size]
+        yield X[batch_indx], y[batch_indx]
+
+
+def logit(x: Any, w: Any):
+    return np.dot(x, w)
+
+
+def sigmoid(h: Any) -> Any:
+    return 1.0 / (1 + np.exp(-h))
+
+
+class MyElasticLogisticRegression(object):
+    """
+    Elastic net is a regularized regression method that
+    linearly combines the L1 and L2 penalties
+    of the lasso and ridge methods.
+
+    More at Wikipedia:
+    https://en.wikipedia.org/wiki/Elastic_net_regularization
+    
+    Original paper:
+    https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.124.4696
+    """
+
+    def __init__(self, l1_coef, l2_coef):
+        self.l1_coef = l1_coef
+        self.l2_coef = l2_coef
+        self.w = None
+
+    def fit(self, X, y, epochs=10, lr=0.1, batch_size=100):
+        n, k = X.shape
+        if self.w is None:
+            np.random.seed(42)
+            self.w = np.random.randn(k + 1)
+
+        X_train = np.concatenate((np.ones((n, 1)), X), axis=1)
+
+        losses = []
+
+        # Train loop
+        for _ in range(epochs):
+            gen = generate_batches
+            for X_batch, y_batch in gen(X_train, y, batch_size):
+                y_pred = sigmoid(logit(X_batch, self.w))
+
+                grad = self.get_grad(X_batch, y_batch, y_pred)
+                self.w -= grad * lr
+
+                losses.append(self.__loss(y_batch, y_pred))
+
+        return losses
+
+    def get_grad(self, X_batch, y_batch, predictions):
+        """
+        Accepts X_batch with ones column. 
+        """
+
+        n, k = X_batch.shape
+        w0 = self.w.copy()
+        w0[0] = 0
+        grad = X_batch.T @ (predictions - y_batch) / n
+        grad += self.l1_coef * np.sign(w0)
+        grad += 2 * self.l2_coef * w0
+
+        return grad
+
+    def predict_proba(self, X):
+        n, k = X.shape
+        X_ = np.concatenate((np.ones((n, 1)), X), axis=1)
+        return sigmoid(logit(X_, self.w))
+
+    def predict(self, X, threshold=0.5):
+        return self.predict_proba(X) >= threshold
+
+    def get_weights(self):
+        return self.w
+
+    def __loss(self, y, p):
+        p = np.clip(p, 1e-10, 1 - 1e-10)
+        return -np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))
+
+
+if __name__ == "__main__":
+    X, y = make_blobs(
+        n_samples=1000, centers=[[-2, 0.5], [3, -0.5]], cluster_std=1, random_state=42
+    )
+
+    colors = ("red", "green")
+    colored_y = np.zeros(y.size, dtype=str)
+
+    for i, cl in enumerate([0, 1]):
+        colored_y[y == cl] = str(colors[i])
+
+    plt.figure(figsize=(15, 10))
+    plt.scatter(X[:, 0], X[:, 1], c=colored_y)
+    plt.show()
+
+    clf = MyElasticLogisticRegression(0.1, 0.1)
+    clf.fit(X, y, epochs=1000, batch_size=100)
+    w = clf.get_weights()
+
+    eps = 0.1
+    xx, yy = np.meshgrid(
+        np.linspace(np.min(X[:, 0]) - eps, np.max(X[:, 0]) + eps, 200),
+        np.linspace(np.min(X[:, 1]) - eps, np.max(X[:, 1]) + eps, 200),
+    )
+    Z = clf.predict(np.c_[xx.ravel(), yy.ravel()])
+    Z = Z.reshape(xx.shape)
+    cmap_light = ListedColormap(["#FFAAAA", "#AAFFAA"])
+    plt.pcolormesh(xx, yy, Z, cmap=cmap_light, shading="auto")
+
+    plt.scatter(X[:, 0], X[:, 1], c=colored_y)
+

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -28,10 +28,18 @@ def generate_batches(inputs: Any, labels: Any, batch_size: int) -> Batch:
 
 
 def logit(inputs: Any, weights: Any) -> Any:
+    """
+    >>> logit(1, 3)
+    3
+    """
     return np.dot(inputs, weights)
 
 
 def sigmoid(outputs: Any) -> Any:
+    """
+    >>> sigmoid(0.2)
+    0.54...
+    """
     return 1.0 / (1 + np.exp(-outputs))
 
 

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -170,10 +170,9 @@ class MyElasticLogisticRegression(object):
 
 
 if __name__ == "__main__":
-    X, y = make_blobs(n_samples=1000,
-                      centers=[[-2, 0.5], [3, -0.5]],
-                      cluster_std=1,
-                      random_state=42)
+    X, y = make_blobs(
+        n_samples=1000, centers=[[-2, 0.5], [3, -0.5]], cluster_std=1, random_state=42
+    )
 
     colors = ("red", "green")
     colored_y = np.zeros(y.size, dtype=str)

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -91,6 +91,17 @@ class MyElasticLogisticRegression(object):
         return grad
 
     def predict_proba(self, inputs: Any) -> Any:
+        """
+        >>> from sklearn.datasets import load_iris
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X, y = load_iris(return_X_y=True)
+        >>> clf = LogisticRegression(random_state=0).fit(X, y)
+        >>> clf.predict(X[:2, :])
+        array([0, 0])
+        >>> clf.predict_proba(X[:2, :])
+        array([[9.8...e-01, 1.8...e-02, 1.4...e-08],
+            [9.7...e-01, 2.8...e-02, ...e-08]])
+        """
         n, k = inputs.shape
         inputs_modified = np.concatenate((np.ones((n, 1)), inputs), axis=1)
         return sigmoid(logit(inputs_modified, self.w))

--- a/machine_learning/logistic_elastic_regression.py
+++ b/machine_learning/logistic_elastic_regression.py
@@ -114,7 +114,7 @@ class MyElasticLogisticRegression(object):
         array([0, 0])
         >>> clf.predict_proba(X[:2, :])
         array([[9.8...e-01, 1.8...e-02, 1.4...e-08],
-            [9.7...e-01, 2.8...e-02, ...e-08]])
+              [9.7...e-01, 2.8...e-02, 3.01...e-08]])
         """
         n, k = inputs.shape
         inputs_modified = np.concatenate((np.ones((n, 1)), inputs), axis=1)
@@ -140,12 +140,12 @@ class MyElasticLogisticRegression(object):
         >>> X = np.linspace(-5, 5, objects_num)
         >>> y = linear_expression(X) + np.random.randn(objects_num) * 5
         >>> X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.5)
-        >>> regressor = MyElasticLogisticRegression()
+        >>> regressor = MyElasticLogisticRegression(0.5, 0.5)
         >>> regressor.fit(X_train[:, np.newaxis], y_train)
         >>> predictions = regressor.predict(X_test[:, np.newaxis])
         >>> w = regressor.get_weights()
         >>> w
-        array([4.7..., 5.7...])
+        array([ 0.49..., -0.13... ])
         """
         return self.w
 


### PR DESCRIPTION
### **Describe your change:**

This pull request implements **Regularization and variable selection via the Elastic Net** - regularized regression method that linearly combines the L1 and L2 penalties of the lasso and ridge methods ([Wikipedia](https://en.wikipedia.org/wiki/Elastic_net_regularization); [Original Paper](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.124.4696)).

There is also a visual demonstration on a toy dataset.

* [x] Add an algorithm?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
