### PR TITLE
Fix return type for "minimum-spanning-tree-kruskal.py"

### DIFF
--- a/graphs/minimum_spanning_tree_kruskal.py
+++ b/graphs/minimum_spanning_tree_kruskal.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 
-def kruskal(num_nodes: int, num_edges: int, edges: List[Tuple[int, int, int]]) -> int:
+def kruskal(num_nodes: int, num_edges: int, edges: List[Tuple[int, int, int]]) -> List[Tuple[int, int, int]]:
     """
     >>> kruskal(4, 3, [(0, 1, 3), (1, 2, 5), (2, 3, 1)])
     [(2, 3, 1), (0, 1, 3), (1, 2, 5)]


### PR DESCRIPTION
The function is returning a list of selected edges, not an integer value.

### **Describe your change:**



* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
