### PR TITLE
[mypy] Fixed type annotations in maths

### DIFF
--- a/maths/greedy_coin_change.py
+++ b/maths/greedy_coin_change.py
@@ -74,8 +74,8 @@ def find_minimum_change(denominations: list[int], value: int) -> list[int]:
 # Driver Code
 if __name__ == "__main__":
 
-    denominations = list()
-    value = 0
+    denominations: list[int] = list()
+    value: int = 0
 
     if (
         input("Do you want to enter your denominations ? (yY/n): ").strip().lower()
@@ -85,13 +85,13 @@ if __name__ == "__main__":
 
         for i in range(0, n):
             denominations.append(int(input(f"Denomination {i}: ").strip()))
-        value = input("Enter the change you want to make in Indian Currency: ").strip()
+        value = int(input("Enter the change you want to make in Indian Currency: ").strip())
     else:
         # All denominations of Indian Currency if user does not enter
         denominations = [1, 2, 5, 10, 20, 50, 100, 500, 2000]
-        value = input("Enter the change you want to make: ").strip()
+        value = int(input("Enter the change you want to make: ").strip())
 
-    if int(value) == 0 or int(value) < 0:
+    if value <= 0:
         print("The total value cannot be zero or negative.")
 
     else:

--- a/maths/series/geometric_series.py
+++ b/maths/series/geometric_series.py
@@ -11,7 +11,7 @@ python3 geometric_series.py
 """
 
 
-def geometric_series(nth_term: int, start_term_a: int, common_ratio_r: int) -> list:
+def geometric_series(nth_term: int, start_term_a: float, common_ratio_r: float) -> list[float]:
     """Pure Python implementation of Geometric Series algorithm
     :param nth_term: The last term (nth term of Geometric Series)
     :param start_term_a : The first term of Geometric Series
@@ -20,15 +20,13 @@ def geometric_series(nth_term: int, start_term_a: int, common_ratio_r: int) -> l
         ration with first term with increase in power till last term (nth term)
     Examples:
     >>> geometric_series(4, 2, 2)
-    [2, '4.0', '8.0', '16.0']
+    [2, 4.0, 8.0, 16.0]
     >>> geometric_series(4.0, 2.0, 2.0)
-    [2.0, '4.0', '8.0', '16.0']
-    >>> geometric_series(4.1, 2.1, 2.1)
-    [2.1, '4.41', '9.261000000000001', '19.448100000000004']
+    [2.0, 4.0, 8.0, 16.0]
     >>> geometric_series(4, 2, -2)
-    [2, '-4.0', '8.0', '-16.0']
+    [2, -4.0, 8.0, -16.0]
     >>> geometric_series(4, -2, 2)
-    [-2, '-4.0', '-8.0', '-16.0']
+    [-2, -4.0, -8.0, -16.0]
     >>> geometric_series(-4, 2, 2)
     []
     >>> geometric_series(0, 100, 500)
@@ -38,26 +36,17 @@ def geometric_series(nth_term: int, start_term_a: int, common_ratio_r: int) -> l
     >>> geometric_series(0, 0, 0)
     []
     """
-    if "" in (nth_term, start_term_a, common_ratio_r):
-        return ""
     series = []
-    power = 1
-    multiple = common_ratio_r
-    for _ in range(int(nth_term)):
-        if series == []:
-            series.append(start_term_a)
-        else:
-            power += 1
-            series.append(str(float(start_term_a) * float(multiple)))
-            multiple = pow(float(common_ratio_r), power)
+    for power in range(nth_term):
+        series.append(start_term_a * pow(common_ratio_r, power))
     return series
 
 
 if __name__ == "__main__":
-    nth_term = input("Enter the last number (n term) of the Geometric Series")
-    start_term_a = input("Enter the starting term (a) of the Geometric Series")
-    common_ratio_r = input(
-        "Enter the common ratio between two terms (r) of the Geometric Series"
-    )
+    nth_term = int(input("Enter the last number (n term) of the Geometric Series: "))
+    start_term_a = int(input("Enter the starting term (a) of the Geometric Series: "))
+    common_ratio_r = int(input(
+        "Enter the common ratio between two terms (r) of the Geometric Series: "
+    ))
     print("Formula of Geometric Series => a + ar + ar^2 ... +ar^n")
     print(geometric_series(nth_term, start_term_a, common_ratio_r))

--- a/maths/series/harmonic_series.py
+++ b/maths/series/harmonic_series.py
@@ -10,9 +10,10 @@ python3 -m doctest -v harmonic_series.py
 For manual testing run:
 python3 harmonic_series.py
 """
+from fractions import Fraction
 
 
-def harmonic_series(n_term: str) -> list:
+def harmonic_series(n_term: int) -> list[Fraction]:
     """Pure Python implementation of Harmonic Series algorithm
 
     :param n_term: The last (nth) term of Harmonic Series
@@ -32,15 +33,13 @@ def harmonic_series(n_term: str) -> list:
     >>> harmonic_series(1)
     ['1']
     """
-    if n_term == "":
-        return n_term
     series = []
     for temp in range(int(n_term)):
-        series.append(f"1/{temp + 1}" if series else "1")
+        series.append(Fraction(1, temp + 1))
     return series
 
 
 if __name__ == "__main__":
-    nth_term = input("Enter the last number (nth term) of the Harmonic Series")
+    nth_term = int(input("Enter the last number (nth term) of the Harmonic Series: "))
     print("Formula of Harmonic Series => 1+1/2+1/3 ..... 1/n")
-    print(harmonic_series(nth_term))
+    print([str(i) for i in harmonic_series(nth_term)])

--- a/maths/series/p_series.py
+++ b/maths/series/p_series.py
@@ -10,9 +10,10 @@ python3 -m doctest -v p_series.py
 For manual testing run:
 python3 p_series.py
 """
+from fractions import Fraction
 
 
-def p_series(nth_term: int, power: int) -> list:
+def p_series(nth_term: int, power: int) -> list[Fraction]:
     """Pure Python implementation of P-Series algorithm
 
     :return: The P-Series starting from 1 to last (nth) term
@@ -24,25 +25,19 @@ def p_series(nth_term: int, power: int) -> list:
     []
     >>> p_series(5, -2)
     [1, '1/0.25', '1/0.1111111111111111', '1/0.0625', '1/0.04']
-    >>> p_series("", 1000)
-    ''
     >>> p_series(0, 0)
     []
     >>> p_series(1, 1)
     [1]
     """
-    if nth_term == "":
-        return nth_term
-    nth_term = int(nth_term)
-    power = int(power)
     series = []
-    for temp in range(int(nth_term)):
-        series.append(f"1/{pow(temp + 1, int(power))}" if series else 1)
+    for temp in range(nth_term):
+        series.append(Fraction(1, pow(temp + 1, power)))
     return series
 
 
 if __name__ == "__main__":
-    nth_term = input("Enter the last number (nth term) of the P-Series")
-    power = input("Enter the power for  P-Series")
+    nth_term = int(input("Enter the last number (nth term) of the P-Series: "))
+    power = int(input("Enter the power for  P-Series: "))
     print("Formula of P-Series => 1+1/2^p+1/3^p ..... 1/n^p")
-    print(p_series(nth_term, power))
+    print([str(i) for i in p_series(nth_term, power)])

--- a/maths/sigmoid.py
+++ b/maths/sigmoid.py
@@ -11,7 +11,7 @@ https://en.wikipedia.org/wiki/Sigmoid_function
 import numpy as np
 
 
-def sigmoid(vector: np.array) -> np.array:
+def sigmoid(vector: np.ndarray) -> np.ndarray:
     """
     Implements the sigmoid function
 

--- a/maths/triplet_sum.py
+++ b/maths/triplet_sum.py
@@ -5,7 +5,7 @@ the target.
 """
 from __future__ import annotations
 
-from itertools import permutations
+from itertools import combinations
 from random import randint
 from timeit import repeat
 
@@ -32,9 +32,9 @@ def triplet_sum1(arr: list[int], target: int) -> tuple[int, int, int]:
     >>> triplet_sum1(arr, target)
     (0, 0, 0)
     """
-    for triplet in permutations(arr, 3):
+    for triplet in combinations(sorted(arr), 3):
         if sum(triplet) == target:
-            return tuple(sorted(triplet))
+            return triplet
     return (0, 0, 0)
 
 

--- a/maths/two_sum.py
+++ b/maths/two_sum.py
@@ -31,7 +31,7 @@ def two_sum(nums: list[int], target: int) -> list[int]:
     >>> two_sum([3 * i for i in range(10)], 19)
     []
     """
-    chk_map = {}
+    chk_map: dict = {}
     for index, val in enumerate(nums):
         compl = target - val
         if compl in chk_map:

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,4 +2,4 @@
 ignore_missing_imports = True
 
 ; FIXME: #4052 fix mypy errors in the exclude directories and remove them below
-exclude = (data_structures|dynamic_programming|graphs|maths|matrix|other|project_euler|searches|strings*)/$
+exclude = (data_structures|dynamic_programming|graphs|matrix|other|project_euler|searches|strings*)/$


### PR DESCRIPTION
### **Describe your change:**

For issue #4052 
Improved some logic in series functions as well and I have these functions return numeric types instead of strings.
Changed permutations to combinations in triplet_sum.py since it is more appropriate for the purpose and because mypy does not recognize any fixed length tuples from permutations, but it does for combinations (See [this](https://github.com/python/typeshed/pull/4309))

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
