### PR TITLE
Mistake in maths/average_mode.py fixed.

### DIFF
--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -1,7 +1,8 @@
 import statistics
+from typing import Any
 
 
-def mode(input_list: list) -> int:  # Defining function "mode."
+def mode(input_list: list) -> Any:  # Defining function "mode."
     """This function returns the mode(Mode as in the measures of
     central tendency) of the input data.
 
@@ -10,21 +11,28 @@ def mode(input_list: list) -> int:  # Defining function "mode."
     >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
     >>> mode(input_list)
     2
+    >>> input_list = [3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 4, 2, 2, 2]
+    >>> mode(input_list)
+    2
+    >>> input_list = ["x", "y", "y", "z"]
+    >>> mode(input_list) 
+    'y'
     >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
+    >>> mode(input_list) == statistics.mode(input_list)
+    True
+    >>> input_list = ["x", "y", "y", "z"]
     >>> mode(input_list) == statistics.mode(input_list)
     True
     """
     # Copying input_list to check with the index number later.
-    check_list = input_list.copy()
     result = list()  # Empty list to store the counts of elements in input_list
     for x in input_list:
         result.append(input_list.count(x))
     y = max(result)  # Gets the maximum value in the result list.
     # Returns the value with the maximum number of repetitions.
-    return check_list[result.index(y)]
+    return input_list[result.index(y)]
 
 
 if __name__ == "__main__":
-    data = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
-    print(mode(data))
-    print(statistics.mode(data))
+    import doctest
+    doctest.testmod()

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -26,7 +26,7 @@ def mode(input_list: list) -> list:  # Defining function "mode."
     y = max(result)  # Gets the maximum value in the result list.
     # Gets values of modes
     result = [input_list[i] for i, value in enumerate(result) if value == y]
-    result = list(set(result))  # Delete duplicates
+    result = list(set(result))  # Deletes duplicates
     return sorted(result)
 
 

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -15,7 +15,7 @@ def mode(input_list: list) -> Any:  # Defining function "mode."
     >>> mode(input_list)
     2
     >>> input_list = ["x", "y", "y", "z"]
-    >>> mode(input_list) 
+    >>> mode(input_list)
     'y'
     >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
     >>> mode(input_list) == statistics.mode(input_list)
@@ -35,4 +35,5 @@ def mode(input_list: list) -> Any:  # Defining function "mode."
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -1,7 +1,7 @@
 import statistics
 
 
-def mode(input_list):  # Defining function "mode."
+def mode(input_list: list) -> int:  # Defining function "mode."
     """This function returns the mode(Mode as in the measures of
     central tendency) of the input data.
 
@@ -19,10 +19,9 @@ def mode(input_list):  # Defining function "mode."
     result = list()  # Empty list to store the counts of elements in input_list
     for x in input_list:
         result.append(input_list.count(x))
-        input_list.remove(x)
-        y = max(result)  # Gets the maximum value in the result list.
-        # Returns the value with the maximum number of repetitions.
-        return check_list[result.index(y)]
+    y = max(result)  # Gets the maximum value in the result list.
+    # Returns the value with the maximum number of repetitions.
+    return check_list[result.index(y)]
 
 
 if __name__ == "__main__":

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -23,6 +23,8 @@ def mode(input_list: list) -> list:  # Defining function "mode."
     result = list()  # Empty list to store the counts of elements in input_list
     for x in input_list:
         result.append(input_list.count(x))
+    if not result:
+        return []
     y = max(result)  # Gets the maximum value in the result list.
     # Gets values of modes
     result = [input_list[i] for i, value in enumerate(result) if value == y]

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -1,4 +1,3 @@
-import statistics
 from typing import Any
 
 
@@ -17,6 +16,7 @@ def mode(input_list: list) -> Any:  # Defining function "mode."
     >>> input_list = ["x", "y", "y", "z"]
     >>> mode(input_list)
     'y'
+    >>> import statistics
     >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
     >>> mode(input_list) == statistics.mode(input_list)
     True

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -1,7 +1,4 @@
-from typing import Any
-
-
-def mode(input_list: list) -> Any:  # Defining function "mode."
+def mode(input_list: list) -> list:  # Defining function "mode."
     """This function returns the mode(Mode as in the measures of
     central tendency) of the input data.
 
@@ -9,28 +6,28 @@ def mode(input_list: list) -> Any:  # Defining function "mode."
 
     >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
     >>> mode(input_list)
-    2
+    [2]
     >>> input_list = [3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 4, 2, 2, 2]
     >>> mode(input_list)
-    2
+    [2]
+    >>> input_list = [3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 4, 4, 2, 2, 4, 2]
+    >>> mode(input_list)
+    [2, 4]
     >>> input_list = ["x", "y", "y", "z"]
     >>> mode(input_list)
-    'y'
-    >>> import statistics
-    >>> input_list = [2, 3, 4, 5, 3, 4, 2, 5, 2, 2, 4, 2, 2, 2]
-    >>> mode(input_list) == statistics.mode(input_list)
-    True
-    >>> input_list = ["x", "y", "y", "z"]
-    >>> mode(input_list) == statistics.mode(input_list)
-    True
+    ['y']
+    >>> input_list = ["x", "x" , "y", "y", "z"]
+    >>> mode(input_list)
+    ['x', 'y']
     """
-    # Copying input_list to check with the index number later.
     result = list()  # Empty list to store the counts of elements in input_list
     for x in input_list:
         result.append(input_list.count(x))
     y = max(result)  # Gets the maximum value in the result list.
-    # Returns the value with the maximum number of repetitions.
-    return input_list[result.index(y)]
+    # Gets values of modes
+    result = [input_list[i] for i, value in enumerate(result) if value == y]
+    result = list(set(result))  # Delete duplicates
+    return sorted(result)
 
 
 if __name__ == "__main__":

--- a/maths/average_mode.py
+++ b/maths/average_mode.py
@@ -27,8 +27,7 @@ def mode(input_list: list) -> list:  # Defining function "mode."
         return []
     y = max(result)  # Gets the maximum value in the result list.
     # Gets values of modes
-    result = [input_list[i] for i, value in enumerate(result) if value == y]
-    result = list(set(result))  # Deletes duplicates
+    result = {input_list[i] for i, value in enumerate(result) if value == y}
     return sorted(result)
 
 


### PR DESCRIPTION
### **Describe your change:**

* Mistake in maths/average_mode.py fixed. The previous solution was to return the
value on the first loop iteration, which is not correct, more than that it
used to delete repeating values, so result's array and check array lost
relation between each other

* Type hint added

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
