### PR TITLE
Armstrong number definition fix

### DIFF
--- a/maths/armstrong_numbers.py
+++ b/maths/armstrong_numbers.py
@@ -1,5 +1,6 @@
 """
-An Armstrong number is equal to the sum of its own digits each raised to the power of the number of digits.
+An Armstrong number is equal to the sum of its own digits each raised
+to the power of the number of digits.
 For example, 370 is an Armstrong number because 3*3*3 + 7*7*7 + 0*0*0 = 370.
 An Armstrong number is often called Narcissistic number.
 """

--- a/maths/armstrong_numbers.py
+++ b/maths/armstrong_numbers.py
@@ -1,5 +1,5 @@
 """
-An Armstrong number is equal to the sum of the cubes of its digits.
+An Armstrong number is equal to the sum of its own digits each raised to the power of the number of digits.
 For example, 370 is an Armstrong number because 3*3*3 + 7*7*7 + 0*0*0 = 370.
 An Armstrong number is often called Narcissistic number.
 """


### PR DESCRIPTION
### **Describe your change:**

Armstrong number is not the sum of cube's of number digits, but
the sum of number's digits each raised to the power of the number of digits

Reference: https://en.wikipedia.org/wiki/Narcissistic_number

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
