### PR TITLE
Remove redundent function in Backtracking Sudoku

### DIFF
--- a/backtracking/sudoku.py
+++ b/backtracking/sudoku.py
@@ -59,27 +59,6 @@ def is_safe(grid: Matrix, row: int, column: int, n: int) -> bool:
     return True
 
 
-def is_completed(grid: Matrix) -> bool:
-    """
-    This function checks if the puzzle is completed or not.
-    it is completed when all the cells are assigned with a non-zero number.
-
-    >>> is_completed([[0]])
-    False
-    >>> is_completed([[1]])
-    True
-    >>> is_completed([[1, 2], [0, 4]])
-    False
-    >>> is_completed([[1, 2], [3, 4]])
-    True
-    >>> is_completed(initial_grid)
-    False
-    >>> is_completed(no_solution)
-    False
-    """
-    return all(all(cell != 0 for cell in row) for row in grid)
-
-
 def find_empty_location(grid: Matrix) -> Optional[Tuple[int, int]]:
     """
     This function finds an empty location so that we can assign a number
@@ -111,12 +90,8 @@ def sudoku(grid: Matrix) -> Optional[Matrix]:
      >>> sudoku(no_solution) is None
      True
     """
-
-    if is_completed(grid):
-        return grid
-
-    location = find_empty_location(grid)
-    if location is not None:
+    
+    if location := find_empty_location(grid):
         row, column = location
     else:
         # If the location is ``None``, then the grid is solved.

--- a/backtracking/sudoku.py
+++ b/backtracking/sudoku.py
@@ -90,7 +90,6 @@ def sudoku(grid: Matrix) -> Optional[Matrix]:
      >>> sudoku(no_solution) is None
      True
     """
-    
     if location := find_empty_location(grid):
         row, column = location
     else:


### PR DESCRIPTION
### **Describe your change:**

After reviewing this code, I've noticed that the `is_completed` function is a redundant operation.
Increasing the number of loops required for each step of the sudoku solver. 
This should remove n² operations where n is the width of the grid.


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
