### PR TITLE
Fix indentation in sha1.py

### DIFF
--- a/hashes/sha1.py
+++ b/hashes/sha1.py
@@ -118,13 +118,13 @@ class SHA1Hash:
                     c,
                     d,
                 )
-        self.h = (
-            self.h[0] + a & 0xFFFFFFFF,
-            self.h[1] + b & 0xFFFFFFFF,
-            self.h[2] + c & 0xFFFFFFFF,
-            self.h[3] + d & 0xFFFFFFFF,
-            self.h[4] + e & 0xFFFFFFFF,
-        )
+              self.h = (
+                     self.h[0] + a & 0xFFFFFFFF,
+                     self.h[1] + b & 0xFFFFFFFF,
+                     self.h[2] + c & 0xFFFFFFFF,
+                     self.h[3] + d & 0xFFFFFFFF,
+                     self.h[4] + e & 0xFFFFFFFF,
+              )
         return "%08x%08x%08x%08x%08x" % tuple(self.h)
 
 


### PR DESCRIPTION
The mistake caused the code to output wrong hashes of strings greater than 64 bytes

### **Describe your change:**
tabbed lines 121 - 127 once


* [ ] Add an algorithm?
* [#4529 ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
