### PR TITLE
[fixed] module 'numpy' is imported with both 'import' and 'import from'

### DIFF
--- a/arithmetic_analysis/lu_decomposition.py
+++ b/arithmetic_analysis/lu_decomposition.py
@@ -7,8 +7,6 @@ from typing import Tuple
 
 import numpy as np
 
-# from numpy import ndarray
-
 
 def lower_upper_decomposition(table: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Lower-Upper (LU) Decomposition

--- a/arithmetic_analysis/lu_decomposition.py
+++ b/arithmetic_analysis/lu_decomposition.py
@@ -6,10 +6,11 @@ Reference:
 from typing import Tuple
 
 import numpy as np
-from numpy import ndarray
+
+# from numpy import ndarray
 
 
-def lower_upper_decomposition(table: ndarray) -> Tuple[ndarray, ndarray]:
+def lower_upper_decomposition(table: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Lower-Upper (LU) Decomposition
 
     Example:


### PR DESCRIPTION
### **Describe your change:**
fixing LGTM on ```arithmetic_analysis/lu_decomposition.py``` by:
- fixing module ```numpy``` is imported with both 'import' and 'import from'
- commented ```from numpy import ndarray```
- change ```ndarray``` to ```np.ndarray```

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
