### PR TITLE
quick_sort method type hint was using the builtin list not Typing Lis…

### DIFF
--- a/sorts/quick_sort.py
+++ b/sorts/quick_sort.py
@@ -10,7 +10,7 @@ python3 quick_sort.py
 from typing import List
 
 
-def quick_sort(collection: list) -> list:
+def quick_sort(collection: List) -> List:
     """A pure Python implementation of quick sort algorithm
 
     :param collection: a mutable collection of comparable items


### PR DESCRIPTION
### **Describe your change:**
quick sort was using builtin list as a type hint. I updated it to typing List


* [ ] Add an algorithm?
* [X] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [X] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
