### PR TITLE
Approve functions used as default arguments

### DIFF
--- a/other/linear_congruential_generator.py
+++ b/other/linear_congruential_generator.py
@@ -8,18 +8,18 @@ class LinearCongruentialGenerator:
     A pseudorandom number generator.
     """
 
+    # The default value for **seed** is the result of a function call which is not
+    # normally recommended and causes flake8-bugbear to raise a B008 error. However,
+    # in this case, it is accptable because `LinearCongruentialGenerator.__init__()`
+    # will only be called once per instance and it ensures that each instance will
+    # generate a unique sequence of numbers.
+
     def __init__(self, multiplier, increment, modulo, seed=int(time())):  # noqa: B008
         """
         These parameters are saved and used when nextNumber() is called.
 
         modulo is the largest number that can be generated (exclusive). The most
         efficient values are powers of 2. 2^32 is a common value.
-        
-        The default value for **seed** is the result of a function call which is not
-        normally recommended and causes flake8-bugbear to raise a B008 error. However,
-        in this case, it is accptable because `LinearCongruentialGenerator.__init__()`
-        will only be called once per instance and it ensures that each instance will
-        generate a unique sequence of numbers.
         """
         self.multiplier = multiplier
         self.increment = increment

--- a/other/linear_congruential_generator.py
+++ b/other/linear_congruential_generator.py
@@ -8,7 +8,7 @@ class LinearCongruentialGenerator:
     A pseudorandom number generator.
     """
 
-    def __init__(self, multiplier, increment, modulo, seed=int(time())):
+    def __init__(self, multiplier, increment, modulo, seed=int(time())):  # noqa: B008
         """
         These parameters are saved and used when nextNumber() is called.
 

--- a/other/linear_congruential_generator.py
+++ b/other/linear_congruential_generator.py
@@ -14,6 +14,12 @@ class LinearCongruentialGenerator:
 
         modulo is the largest number that can be generated (exclusive). The most
         efficient values are powers of 2. 2^32 is a common value.
+        
+        The default value for **seed** is the result of a function call which is not
+        normally recommended and causes flake8-bugbear to raise a B008 error. However,
+        in this case, it is accptable because `LinearCongruentialGenerator.__init__()`
+        will only be called once per instance and it ensures that each instance will
+        generate a unique sequence of numbers.
         """
         self.multiplier = multiplier
         self.increment = increment

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -52,11 +52,11 @@ def full_adder(
     circuit.cx(input2_loc, carry_in)
     circuit.cx(input1_loc, input2_loc)
 
-
 # The default value for **backend** is the result of a function call which is not
 # normally recommended and causes flake8-bugbear to raise a B008 error. However,
 # in this case, it is accptable because `Aer.get_backend()` is called when the
 # function is definition and that same backend is then reused for function calls.
+
 
 def ripple_adder(
     val1: int,

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -52,6 +52,7 @@ def full_adder(
     circuit.cx(input2_loc, carry_in)
     circuit.cx(input1_loc, input2_loc)
 
+
 # The default value for **backend** is the result of a function call which is not
 # normally recommended and causes flake8-bugbear to raise a B008 error. However,
 # in this case, this is accptable because `Aer.get_backend()` is called when the

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -55,7 +55,7 @@ def full_adder(
 # The default value for **backend** is the result of a function call which is not
 # normally recommended and causes flake8-bugbear to raise a B008 error. However,
 # in this case, this is accptable because `Aer.get_backend()` is called when the
-# function is defined and that same backend is then reused for function calls.
+# function is defined and that same backend is then reused for all function calls.
 
 
 def ripple_adder(

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -65,7 +65,12 @@ def ripple_adder(
     Currently only adds 'emulated' Classical Bits
     but nothing prevents us from doing this with hadamard'd bits :)
 
-    Only supports adding +ve Integers
+    Only supports adding positive integers
+    
+    The default value for **backend** is the result of a function call which is not
+    normally recommended and causes flake8-bugbear to raise a B008 error. However,
+    in this case, it is accptable because `Aer.get_backend()` is called when the
+    function is definition and that same backend is then reused for function calls.
 
     >>> ripple_adder(3, 4)
     7
@@ -101,7 +106,7 @@ def ripple_adder(
     res = execute(circuit, backend, shots=1).result()
 
     # The result is in binary. Convert it back to int
-    return int(list(res.get_counts().keys())[0], 2)
+    return int(list(res.get_counts())[0], 2)
 
 
 if __name__ == "__main__":

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -53,6 +53,11 @@ def full_adder(
     circuit.cx(input1_loc, input2_loc)
 
 
+# The default value for **backend** is the result of a function call which is not
+# normally recommended and causes flake8-bugbear to raise a B008 error. However,
+# in this case, it is accptable because `Aer.get_backend()` is called when the
+# function is definition and that same backend is then reused for function calls.
+
 def ripple_adder(
     val1: int,
     val2: int,
@@ -66,11 +71,6 @@ def ripple_adder(
     but nothing prevents us from doing this with hadamard'd bits :)
 
     Only supports adding positive integers
-    
-    The default value for **backend** is the result of a function call which is not
-    normally recommended and causes flake8-bugbear to raise a B008 error. However,
-    in this case, it is accptable because `Aer.get_backend()` is called when the
-    function is definition and that same backend is then reused for function calls.
 
     >>> ripple_adder(3, 4)
     7

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -54,7 +54,9 @@ def full_adder(
 
 
 def ripple_adder(
-    val1: int, val2: int, backend: BaseBackend = Aer.get_backend("qasm_simulator")
+    val1: int,
+    val2: int,
+    backend: BaseBackend = Aer.get_backend("qasm_simulator"),  # noqa: B008
 ) -> int:
     """
     Quantum Equivalent of a Ripple Adder Circuit

--- a/quantum/ripple_adder_classic.py
+++ b/quantum/ripple_adder_classic.py
@@ -54,8 +54,8 @@ def full_adder(
 
 # The default value for **backend** is the result of a function call which is not
 # normally recommended and causes flake8-bugbear to raise a B008 error. However,
-# in this case, it is accptable because `Aer.get_backend()` is called when the
-# function is definition and that same backend is then reused for function calls.
+# in this case, this is accptable because `Aer.get_backend()` is called when the
+# function is defined and that same backend is then reused for function calls.
 
 
 def ripple_adder(


### PR DESCRIPTION
### **Describe your change:**

Use linter directive `# noqa: B0008` for these functions because they set a seed value and `BaseBackend` is reused across all calls and `LinearCongruentialGenerator.__init__()` is only called once for each instance.

[flake8-bugbear](https://pypi.org/project/flake8-bugbear) ___B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.___

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
