### PR TITLE
Fix bugs and typo errors in closest pair of points

### DIFF
--- a/divide_and_conquer/closest_pair_of_points.py
+++ b/divide_and_conquer/closest_pair_of_points.py
@@ -73,8 +73,8 @@ def dis_between_closest_in_strip(points, points_counts, min_dis=float("inf")):
     85
     """
 
-    for i in range(min(6, points_counts - 1), points_counts):
-        for j in range(max(0, i - 6), i):
+    for i in range(points_counts-1):
+        for j in range(i+1, min(i + 6, points_counts)):
             current_dis = euclidean_distance_sqr(points[i], points[j])
             if current_dis < min_dis:
                 min_dis = current_dis
@@ -101,10 +101,10 @@ def closest_pair_of_points_sqr(points_sorted_on_x, points_sorted_on_y, points_co
     # recursion
     mid = points_counts // 2
     closest_in_left = closest_pair_of_points_sqr(
-        points_sorted_on_x, points_sorted_on_y[:mid], mid
+        points_sorted_on_x[:mid], points_sorted_on_y, mid
     )
     closest_in_right = closest_pair_of_points_sqr(
-        points_sorted_on_y, points_sorted_on_y[mid:], points_counts - mid
+        points_sorted_on_x[mid:], points_sorted_on_y, points_counts - mid
     )
     closest_pair_dis = min(closest_in_left, closest_in_right)
 
@@ -114,7 +114,7 @@ def closest_pair_of_points_sqr(points_sorted_on_x, points_sorted_on_y, points_co
     """
 
     cross_strip = []
-    for point in points_sorted_on_x:
+    for point in points_sorted_on_y:
         if abs(point[0] - points_sorted_on_x[mid][0]) < closest_pair_dis:
             cross_strip.append(point)
 


### PR DESCRIPTION
There are typo errors in closest_pair_points function and errors in dis_between_closest_in_strip function.

### **Describe your change:**



* [ ] Add an algorithm?
* [Y ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [Y ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [Y ] This pull request is all my own work -- I have not plagiarized.
* [Y ] I know that pull requests will not be merged if they fail the automated tests.
* [Y ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [Y ] All new Python files are placed inside an existing directory.
* [Y ] All filenames are in all lowercase characters with no spaces or dashes.
* [Y ] All functions and variable names follow Python naming conventions.
* [Y ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [Y ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [Y ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [Y ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
