### PR TITLE
Show images from google query

### DIFF
--- a/web_programming/show_image_tab_from_google_query.py
+++ b/web_programming/show_image_tab_from_google_query.py
@@ -6,7 +6,7 @@ from fake_useragent import UserAgent
 
 
 def show_images_from_google_query(query: str = "dhaka"):
-    """ Searches google using the provided query term and opens the google image
+    """Searches google using the provided query term and opens the google image
     tab in a browser.
 
     Args:
@@ -18,7 +18,7 @@ def show_images_from_google_query(query: str = "dhaka"):
     headers = {"User-Agent": ua.random}
     url = "https://www.google.com/search?q=" + query
     response = requests.get(url, headers=headers)
-    soup = BeautifulSoup(response.text, 'html.parser')
+    soup = BeautifulSoup(response.text, "html.parser")
     links = list(soup.select(".eZt8xd"))
     print(links)
     for link in links:

--- a/web_programming/show_image_tab_from_google_query.py
+++ b/web_programming/show_image_tab_from_google_query.py
@@ -5,13 +5,19 @@ from bs4 import BeautifulSoup
 from fake_useragent import UserAgent
 
 
-def show_images_from_google_query(query: str = "dhaka"):
+def show_images_from_google_query(query: str = "dhaka") -> None:
     """Searches google using the provided query term and opens the google image
     tab in a browser.
 
     Args:
         query : The image search term to be provided by the user. Defaults to
         "dhaka".
+
+    >>> show_images_from_google_query ()
+    Showing images for dhaka.
+
+    >>> show_images_from_google_query ("potato")
+    Showing images for potato.
     """
 
     ua = UserAgent()
@@ -23,8 +29,7 @@ def show_images_from_google_query(query: str = "dhaka"):
     print(links)
     for link in links:
         if link.text == "Images":
-            print("here")
-            print(link.get("href"))
+            print(f"Showing images for {query}.")
             webbrowser.open(f"http://google.com{link.get('href')}")
             break
 

--- a/web_programming/show_image_tab_from_google_query.py
+++ b/web_programming/show_image_tab_from_google_query.py
@@ -1,0 +1,36 @@
+import webbrowser
+import sys
+import requests
+from bs4 import BeautifulSoup
+from fake_useragent import UserAgent
+
+
+def show_images_from_google_query(query: str = "dhaka"):
+    """ Searches google using the provided query term and opens the google image
+    tab in a browser.
+
+    Args:
+        query : The image search term to be provided by the user. Defaults to
+        "dhaka".
+    """
+
+    ua = UserAgent()
+    headers = {"User-Agent": ua.random}
+    url = "https://www.google.com/search?q=" + query
+    response = requests.get(url, headers=headers)
+    soup = BeautifulSoup(response.text, 'html.parser')
+    links = list(soup.select(".eZt8xd"))
+    print(links)
+    for link in links:
+        if link.text == "Images":
+            print("here")
+            print(link.get("href"))
+            webbrowser.open(f"http://google.com{link.get('href')}")
+            break
+
+        else:
+            print(f"Google search images not available for term {query}.")
+
+
+if __name__ == "__main__":
+    show_images_from_google_query(sys.argv[1:])


### PR DESCRIPTION
Added new script `web_programming/show_image_tab_from_google_query.py ` to open the google image tab with a search query. It includes `documentations` and `doctests`. Modularized the script and made it more customizable. Fixed formatting using  `black` and `flake8`. 

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
* [] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
