### PR TITLE
Add the type of norm as an input for Power Iteration

### DIFF
--- a/linear_algebra/src/power_iteration.py
+++ b/linear_algebra/src/power_iteration.py
@@ -6,6 +6,7 @@ def power_iteration(
     vector: np.ndarray,
     error_tol: float = 1e-12,
     max_iterations: int = 100,
+    ord: int = None,
 ) -> tuple[float, np.ndarray]:
     """
     Power Iteration.
@@ -19,6 +20,10 @@ def power_iteration(
     Numpy array. np.shape(input_matrix) == (N,N).
     vector: random initial vector in same space as matrix.
     Numpy array. np.shape(vector) == (N,) or (N,1)
+    ord: The order of the norm used in normalization. Optional.
+    {non-zero int, np.inf, -1*np.inf, ‘fro’, ‘nuc’}
+    See https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html
+    for more details on the valid inputs of ord.
 
     Output
     largest_eigenvalue: largest eigenvalue of the matrix input_matrix.
@@ -54,7 +59,7 @@ def power_iteration(
         # Multiple matrix by the vector.
         w = np.dot(input_matrix, vector)
         # Normalize the resulting output vector.
-        vector = w / np.linalg.norm(w)
+        vector = w / np.linalg.norm(w, ord)
         # Find rayleigh quotient
         # (faster than usual b/c we know vector is normalized already)
         lamda = np.dot(vector.T, np.dot(input_matrix, vector))
@@ -75,10 +80,17 @@ def test_power_iteration() -> None:
     """
     >>> test_power_iteration()  # self running tests
     """
-    # Our implementation.
+    # Our implementation with norm 2
     input_matrix = np.array([[41, 4, 20], [4, 26, 30], [20, 30, 50]])
     vector = np.array([41, 4, 20])
     eigen_value, eigen_vector = power_iteration(input_matrix, vector)
+
+    # Our implementation with norm inf
+    input_matrix = np.array([[41, 4, 20], [4, 26, 30], [20, 30, 50]])
+    vector = np.array([41, 4, 20])
+    eigen_value_inf, eigen_vector_inf = power_iteration(
+        input_matrix, vector, ord=np.inf
+    )
 
     # Numpy implementation.
 
@@ -90,11 +102,17 @@ def test_power_iteration() -> None:
     # Last column in this matrix is eigen vector corresponding to largest eigen value.
     eigen_vector_max = eigen_vectors[:, -1]
 
-    # Check our implementation and numpy gives close answers.
+    # Check our implementation and numpy for eigen value.
     assert np.abs(eigen_value - eigen_value_max) <= 1e-6
-    # Take absolute values element wise of each eigenvector.
-    # as they are only unique to a minus sign.
+    # Check our implementation with norm 2 and norm inf for eigen value.
+    assert np.abs(eigen_value - eigen_value_inf) <= 1e-6
+
+    # Check our implementation and numpy for eigen vector
+    # by take absolute values element wise of each eigenvector as they are only
+    # unique to a minus sign.
     assert np.linalg.norm(np.abs(eigen_vector) - np.abs(eigen_vector_max)) <= 1e-6
+    # Check our implementation with norm 2 and norm inf  for eigen vector.
+    assert np.linalg.norm(np.abs(eigen_vector) - np.abs(eigen_vector_inf)) <= 1e-6
 
 
 if __name__ == "__main__":

--- a/maths/proth_number.py
+++ b/maths/proth_number.py
@@ -1,0 +1,77 @@
+"""
+Calculate the nth Proth number
+
+Source:
+    https://handwiki.org/wiki/Proth_number
+"""
+
+import math
+
+
+def proth(number: int) -> int:
+    """
+    :param number: nth number to calculate in the sequence
+    :return: the nth number in Proth number
+
+    Note: indexing starts at 1 i.e. proth(1) gives the first Proth number of 3
+
+    >>> proth(6)
+    25
+
+    >>> proth(0)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input value of [number=0] must be > 0
+
+    >>> proth(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input value of [number=-1] must be > 0
+
+    >>> proth(6.0)
+    Traceback (most recent call last):
+    ...
+    TypeError: Input value of [number=6.0] must be an integer
+    """
+
+    if not isinstance(number, int):
+        raise TypeError(f"Input value of [number={number}] must be an integer")
+
+    if number < 1:
+        raise ValueError(f"Input value of [number={number}] must be > 0")
+    elif number == 1:
+        return 3
+    elif number == 2:
+        return 5
+    else:
+        block_index = number // 3
+        """
+        +1 for binary starting at 0 i.e. 2^0, 2^1, etc.
+        +1 to start the sequence at the 3rd Proth number
+        Hence, we have a +2 in the below statement
+        """
+        block_index = math.log(block_index, 2) + 2
+        block_index = int(block_index)
+
+        proth_list = [3, 5]
+        proth_index = 2
+        increment = 3
+        for block in range(1, block_index):
+            for move in range(increment):
+                proth_list.append(2 ** (block + 1) + proth_list[proth_index - 1])
+                proth_index += 1
+            increment *= 2
+
+    return proth_list[number - 1]
+
+
+if __name__ == "__main__":
+    for number in range(11):
+        value = 0
+        try:
+            value = proth(number)
+        except ValueError:
+            print(f"ValueError: there is no {number}th Proth number")
+            continue
+
+        print(f"The {number}th Proth number: {value}")


### PR DESCRIPTION
### **Describe your change:**
Power iteration has better convergence if you normalize the output vector after every iteration. This can be seen in the current code. In some case it is better to normalize by the infinity-norm than the 2-norm. I will add an extra parameter to the function so the user can change the type of norm used. The default value would be 2, so existing external implementations of the code will not be altered and would not require changes.


* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [X] Documentation change?

### **Checklist:**
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [X] If this pull request resolves one or more open issues then the commit message contains Fixes: #5301 .
