### PR TITLE
Make decrypt_caesar_with_chi_squared work with upper case letters

### DIFF
--- a/ciphers/decrypt_caesar_with_chi_squared.py
+++ b/ciphers/decrypt_caesar_with_chi_squared.py
@@ -178,8 +178,9 @@ def decrypt_caesar_with_chi_squared(
                 new_key = (alphabet_letters.index(letter.lower()) - shift) % len(
                     alphabet_letters
                 )
-                decrypted_with_shift += (alphabet_letters[new_key].upper()
-                    if case_sensitive and letter.isupper() 
+                decrypted_with_shift += (
+                    alphabet_letters[new_key].upper()
+                    if case_sensitive and letter.isupper()
                     else alphabet_letters[new_key]
                 )
             except ValueError:

--- a/ciphers/decrypt_caesar_with_chi_squared.py
+++ b/ciphers/decrypt_caesar_with_chi_squared.py
@@ -6,7 +6,7 @@ def decrypt_caesar_with_chi_squared(
     ciphertext: str,
     cipher_alphabet: list[str] | None = None,
     frequencies_dict: dict[str, float] | None = None,
-    case_sensetive: bool = False,
+    case_sensitive: bool = False,
 ) -> tuple[int, float, str]:
     """
     Basic Usage
@@ -20,7 +20,7 @@ def decrypt_caesar_with_chi_squared(
     * frequencies_dict (dict): a dictionary of word frequencies where keys are
       the letters and values are a percentage representation of the frequency as
       a decimal/float
-    * case_sensetive (bool): a boolean value: True if the case matters during
+    * case_sensitive (bool): a boolean value: True if the case matters during
       decryption, False if it doesn't
 
     Returns:
@@ -117,6 +117,9 @@ def decrypt_caesar_with_chi_squared(
     >>> decrypt_caesar_with_chi_squared('crybd cdbsxq')
     (10, 233.35343938980898, 'short string')
 
+    >>> decrypt_caesar_with_chi_squared('Crybd Cdbsxq', case_sensitive=True)
+    (10, 233.35343938980898, 'Short String')
+
     >>> decrypt_caesar_with_chi_squared(12)
     Traceback (most recent call last):
     AttributeError: 'int' object has no attribute 'lower'
@@ -158,7 +161,7 @@ def decrypt_caesar_with_chi_squared(
         # Custom frequencies dictionary
         frequencies = frequencies_dict
 
-    if not case_sensetive:
+    if not case_sensitive:
         ciphertext = ciphertext.lower()
 
     # Chi squared statistic values
@@ -172,10 +175,13 @@ def decrypt_caesar_with_chi_squared(
         for letter in ciphertext:
             try:
                 # Try to index the letter in the alphabet
-                new_key = (alphabet_letters.index(letter) - shift) % len(
+                new_key = (alphabet_letters.index(letter.lower()) - shift) % len(
                     alphabet_letters
                 )
-                decrypted_with_shift += alphabet_letters[new_key]
+                decrypted_with_shift += (alphabet_letters[new_key].upper()
+                    if case_sensitive and letter.isupper() 
+                    else alphabet_letters[new_key]
+                )
             except ValueError:
                 # Append the character if it isn't in the alphabet
                 decrypted_with_shift += letter
@@ -184,10 +190,11 @@ def decrypt_caesar_with_chi_squared(
 
         # Loop through each letter in the decoded message with the shift
         for letter in decrypted_with_shift:
-            if case_sensetive:
+            if case_sensitive:
+                letter = letter.lower()
                 if letter in frequencies:
                     # Get the amount of times the letter occurs in the message
-                    occurrences = decrypted_with_shift.count(letter)
+                    occurrences = decrypted_with_shift.lower().count(letter)
 
                     # Get the excepcted amount of times the letter should appear based
                     # on letter frequencies


### PR DESCRIPTION
Fixed case sensitive not working in decrypt_casear_with_chi_squared.py



* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
