### PR TITLE
[mypy] Fix type annotations for strings/join.py

### DIFF
--- a/strings/join.py
+++ b/strings/join.py
@@ -26,7 +26,7 @@ def join(separator: str, separated: list[str]) -> str:
     return joined.strip(separator)
 
 
-if "__name__" == "__main__":
+if __name__ == "__main__":
     from doctest import testmod
 
     testmod()


### PR DESCRIPTION
### **Describe your change:**

Fixed missing type annotation for [strings/join.py](strings/join.py). It now passes `mypy --strict`. Additionally, fixed a bug in the `__name__ == "__main__"` check uncovered by mypy.

Related to #4052

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### **Checklist:**
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
