### PR TITLE
[mypy] Fixes and annotates other/least_recently_used

### DIFF
--- a/other/least_recently_used.py
+++ b/other/least_recently_used.py
@@ -8,7 +8,27 @@ T = TypeVar("T")
 
 
 class LRUCache(Generic[T]):
-    """Page Replacement Algorithm, Least Recently Used (LRU) Caching."""
+    """
+    Page Replacement Algorithm, Least Recently Used (LRU) Caching.
+
+    >>> lru_cache: LRUCache[str | int] = LRUCache(4)
+    >>> lru_cache.refer("A")
+    >>> lru_cache.refer(2)
+    >>> lru_cache.refer(3)
+
+    >>> lru_cache
+    LRUCache(4) => [3, 2, 'A']
+
+    >>> lru_cache.refer("A")
+    >>> lru_cache
+    LRUCache(4) => ['A', 3, 2]
+
+    >>> lru_cache.refer(4)
+    >>> lru_cache.refer(5)
+    >>> lru_cache
+    LRUCache(4) => [5, 4, 'A', 3]
+
+    """
 
     dq_store: deque[T]  # Cache store of keys
     key_reference: set[T]  # References of the keys in cache
@@ -50,8 +70,14 @@ class LRUCache(Generic[T]):
         for k in self.dq_store:
             print(k)
 
+    def __repr__(self) -> str:
+        return f"LRUCache({self._MAX_CAPACITY}) => {list(self.dq_store)}"
+
 
 if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
 
     lru_cache: LRUCache[str | int] = LRUCache(4)
     lru_cache.refer("A")
@@ -61,3 +87,6 @@ if __name__ == "__main__":
     lru_cache.refer(4)
     lru_cache.refer(5)
     lru_cache.display()
+
+    print(lru_cache)
+    assert str(lru_cache) == "LRUCache(4) => [5, 4, 'A', 3]"


### PR DESCRIPTION
### Describe your change:

+ fix bug in dq_removal code.  Needed to pass key to .remove() rather than index.
+ remove incorrect annotation to make the `__init__` an abstract function.
+ Annotate all functions and class `Generic[T]`
+ Expand example to show creating a `LRUCache` over concrete and mixed types.
+ Adds doctest to LRUCache class
+ Adds assert test in main.

Related to: #4052 

#### Before
```
% git checkout master
Your branch is up to date with 'origin/master'.

% mypy --ignore-missing-imports --install-types least_recently_used.py
least_recently_used.py:57: error: Cannot instantiate abstract class "LRUCache" with abstract attribute "__init__"
Found 1 error in 1 file (checked 1 source file)
```

```
% mypy --strict least_recently_used.py
least_recently_used.py:27: error: Function is missing a type annotation
least_recently_used.py:33: error: Unsupported right operand type for in ("object")
least_recently_used.py:34: error: Argument 1 to "len" has incompatible type "object"; expected "Sized"
least_recently_used.py:35: error: "object" has no attribute "pop"
least_recently_used.py:36: error: "object" has no attribute "remove"
least_recently_used.py:39: error: Need type annotation for "key"
least_recently_used.py:39: error: Argument 1 to "enumerate" has incompatible type "object"; expected "Iterable[<nothing>]"
least_recently_used.py:43: error: "object" has no attribute "remove"
least_recently_used.py:45: error: "object" has no attribute "appendleft"
least_recently_used.py:46: error: "object" has no attribute "add"
least_recently_used.py:48: error: Function is missing a return type annotation
least_recently_used.py:48: note: Use "-> None" if function does not return a value
least_recently_used.py:52: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
least_recently_used.py:57: error: Cannot instantiate abstract class "LRUCache" with abstract attribute "__init__"
least_recently_used.py:58: error: Call to untyped function "refer" in typed context
least_recently_used.py:59: error: Call to untyped function "refer" in typed context
least_recently_used.py:60: error: Call to untyped function "refer" in typed context
least_recently_used.py:61: error: Call to untyped function "refer" in typed context
least_recently_used.py:62: error: Call to untyped function "refer" in typed context
least_recently_used.py:63: error: Call to untyped function "refer" in typed context
least_recently_used.py:64: error: Call to untyped function "display" in typed context
Found 20 errors in 1 file (checked 1 source file)
```

#### After
```
% git checkout mypy-fix-other-least_recently_used
Switched to branch 'mypy-fix-other-least_recently_used'
Your branch is up to date with 'origin/mypy-fix-other-least_recently_used'.

% mypy --strict least_recently_used.py
Success: no issues found in 1 source file
```

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
