### PR TITLE
[mypy] Fixes typing errors in other/dpll

### DIFF
--- a/other/davisb_putnamb_logemannb_loveland.py
+++ b/other/davisb_putnamb_logemannb_loveland.py
@@ -11,6 +11,7 @@ For more information about the algorithm: https://en.wikipedia.org/wiki/DPLL_alg
 from __future__ import annotations
 
 import random
+from typing import Iterable
 
 
 class Clause:
@@ -27,12 +28,12 @@ class Clause:
     True
     """
 
-    def __init__(self, literals: list[int]) -> None:
+    def __init__(self, literals: list[str]) -> None:
         """
         Represent the literals and an assignment in a clause."
         """
         # Assign all literals to None initially
-        self.literals = {literal: None for literal in literals}
+        self.literals: dict[str, bool | None] = {literal: None for literal in literals}
 
     def __str__(self) -> str:
         """
@@ -52,7 +53,7 @@ class Clause:
         """
         return len(self.literals)
 
-    def assign(self, model: dict[str, bool]) -> None:
+    def assign(self, model: dict[str, bool | None]) -> None:
         """
         Assign values to literals of the clause as given by model.
         """
@@ -68,7 +69,7 @@ class Clause:
                     value = not value
             self.literals[literal] = value
 
-    def evaluate(self, model: dict[str, bool]) -> bool:
+    def evaluate(self, model: dict[str, bool | None]) -> bool | None:
         """
         Evaluates the clause with the assignments in model.
         This has the following steps:
@@ -97,7 +98,7 @@ class Formula:
         {{A1, A2, A3'}, {A5', A2', A1}} is ((A1 v A2 v A3') and (A5' v A2' v A1))
     """
 
-    def __init__(self, clauses: list[Clause]) -> None:
+    def __init__(self, clauses: Iterable[Clause]) -> None:
         """
         Represent the number of clauses and the clauses themselves.
         """
@@ -139,14 +140,14 @@ def generate_formula() -> Formula:
     """
     Randomly generate a formula.
     """
-    clauses = set()
+    clauses: set[Clause] = set()
     no_of_clauses = random.randint(1, 10)
     while len(clauses) < no_of_clauses:
         clauses.add(generate_clause())
-    return Formula(set(clauses))
+    return Formula(clauses)
 
 
-def generate_parameters(formula: Formula) -> (list[Clause], list[str]):
+def generate_parameters(formula: Formula) -> tuple[list[Clause], list[str]]:
     """
     Return the clauses and symbols from a formula.
     A symbol is the uncomplemented form of a literal.
@@ -173,8 +174,8 @@ def generate_parameters(formula: Formula) -> (list[Clause], list[str]):
 
 
 def find_pure_symbols(
-    clauses: list[Clause], symbols: list[str], model: dict[str, bool]
-) -> (list[str], dict[str, bool]):
+    clauses: list[Clause], symbols: list[str], model: dict[str, bool | None]
+) -> tuple[list[str], dict[str, bool | None]]:
     """
     Return pure symbols and their values to satisfy clause.
     Pure symbols are symbols in a formula that exist only
@@ -198,11 +199,11 @@ def find_pure_symbols(
     {'A1': True, 'A2': False, 'A3': True, 'A5': False}
     """
     pure_symbols = []
-    assignment = dict()
+    assignment: dict[str, bool | None] = dict()
     literals = []
 
     for clause in clauses:
-        if clause.evaluate(model) is True:
+        if clause.evaluate(model):
             continue
         for literal in clause.literals:
             literals.append(literal)
@@ -225,8 +226,8 @@ def find_pure_symbols(
 
 
 def find_unit_clauses(
-    clauses: list[Clause], model: dict[str, bool]
-) -> (list[str], dict[str, bool]):
+    clauses: list[Clause], model: dict[str, bool | None]
+) -> tuple[list[str], dict[str, bool | None]]:
     """
     Returns the unit symbols and their values to satisfy clause.
     Unit symbols are symbols in a formula that are:
@@ -263,7 +264,7 @@ def find_unit_clauses(
                     Ncount += 1
             if Fcount == len(clause) - 1 and Ncount == 1:
                 unit_symbols.append(sym)
-    assignment = dict()
+    assignment: dict[str, bool | None] = dict()
     for i in unit_symbols:
         symbol = i[:2]
         assignment[symbol] = len(i) == 2
@@ -273,8 +274,8 @@ def find_unit_clauses(
 
 
 def dpll_algorithm(
-    clauses: list[Clause], symbols: list[str], model: dict[str, bool]
-) -> (bool, dict[str, bool]):
+    clauses: list[Clause], symbols: list[str], model: dict[str, bool | None]
+) -> tuple[bool | None, dict[str, bool | None] | None]:
     """
     Returns the model if the formula is satisfiable, else None
     This has the following steps:


### PR DESCRIPTION
### Describe your change:

+ As per usage examples, clause literals are a list of strings.
  + Note: symbols extracted from literals are expected to be exactly two characters.
+ self.literal boolean values are initialized to None, so must be optional
+ model values should be Booleans, but aren't guaranteed to be non-None
  in the code.
+ uses newer '... | None' annotation for Optional values
+ clauses are passed to the Formula initializer as both lists and sets, they
  are stored as lists.  Returned clauses will always be lists.
+ use explicit tuple annotation from __future__  rather than using (..., ...)
  in return signatures
+ mapping returned by dpll_algorithm is optional per the documentation.

Related to #4052

#### Before

```bash
% git checkout master
Switched to branch 'master'

% mypy ./davisb_putnamb_logemannb_loveland.py
davisb_putnamb_logemannb_loveland.py:43: error: Argument 1 to "join" of "str" has incompatible type "Dict[int, None]"; expected "Iterable[str]"
davisb_putnamb_logemannb_loveland.py:60: error: Value of type "int" is not indexable
davisb_putnamb_logemannb_loveland.py:67: error: "int" has no attribute "endswith"
davisb_putnamb_logemannb_loveland.py:69: error: Incompatible types in assignment (expression has type "bool", target has type "None")
davisb_putnamb_logemannb_loveland.py:81: error: "int" has no attribute "rstrip"
davisb_putnamb_logemannb_loveland.py:81: error: "int" has no attribute "endswith"
davisb_putnamb_logemannb_loveland.py:81: error: Unsupported operand types for + ("int" and "str")
davisb_putnamb_logemannb_loveland.py:88: error: Incompatible return value type (got "None", expected "bool")
davisb_putnamb_logemannb_loveland.py:135: error: Argument 1 to "Clause" has incompatible type "List[str]"; expected "List[int]"
davisb_putnamb_logemannb_loveland.py:142: error: Need type annotation for "clauses" (hint: "clauses: Set[<type>] = ...")
davisb_putnamb_logemannb_loveland.py:146: error: Argument 1 to "Formula" has incompatible type "Set[Clause]"; expected "List[Clause]"
davisb_putnamb_logemannb_loveland.py:149: error: Syntax error in type annotation
davisb_putnamb_logemannb_loveland.py:149: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
davisb_putnamb_logemannb_loveland.py:169: error: Value of type "int" is not indexable
davisb_putnamb_logemannb_loveland.py:177: error: Syntax error in type annotation
davisb_putnamb_logemannb_loveland.py:177: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
davisb_putnamb_logemannb_loveland.py:201: error: Need type annotation for "assignment" (hint: "assignment: Dict[<type>, <type>] = ...")
davisb_putnamb_logemannb_loveland.py:229: error: Syntax error in type annotation
davisb_putnamb_logemannb_loveland.py:229: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
davisb_putnamb_logemannb_loveland.py:268: error: Value of type "int" is not indexable
davisb_putnamb_logemannb_loveland.py:269: error: Argument 1 to "len" has incompatible type "int"; expected "Sized"
davisb_putnamb_logemannb_loveland.py:270: error: Value of type "int" is not indexable
davisb_putnamb_logemannb_loveland.py:277: error: Syntax error in type annotation
davisb_putnamb_logemannb_loveland.py:277: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
Found 20 errors in 1 file (checked 1 source file)

```

#### After

```bash
% git checkout -
Switched to branch 'mypy-fix-other-davisb'
Your branch is up to date with 'origin/mypy-fix-other-davisb'.

% mypy ./davisb_putnamb_logemannb_loveland.py 
Success: no issues found in 1 source file
% mypy --strict ./davisb_putnamb_logemannb_loveland.py
Success: no issues found in 1 source file
```

* [ ] Add an algorithm?
* [X] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
