### PR TITLE
Add missing type annotations in `matrix` directory

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -114,6 +114,7 @@
   * [Harris Corner](https://github.com/TheAlgorithms/Python/blob/master/computer_vision/harris_corner.py)
   * [Mean Threshold](https://github.com/TheAlgorithms/Python/blob/master/computer_vision/mean_threshold.py)
   * [Mosaic Augmentation](https://github.com/TheAlgorithms/Python/blob/master/computer_vision/mosaic_augmentation.py)
+  * [Pooling Functions](https://github.com/TheAlgorithms/Python/blob/master/computer_vision/pooling_functions.py)
 
 ## Conversions
   * [Binary To Decimal](https://github.com/TheAlgorithms/Python/blob/master/conversions/binary_to_decimal.py)

--- a/matrix/count_islands_in_matrix.py
+++ b/matrix/count_islands_in_matrix.py
@@ -9,7 +9,7 @@ class matrix:  # Public class to implement a graph
         self.COL = col
         self.graph = graph
 
-    def is_safe(self, i, j, visited) -> bool:
+    def is_safe(self, i: int, j: int, visited: list[list]) -> bool:
         return (
             0 <= i < self.ROW
             and 0 <= j < self.COL
@@ -17,7 +17,8 @@ class matrix:  # Public class to implement a graph
             and self.graph[i][j]
         )
 
-    def diffs(self, i, j, visited):  # Checking all 8 elements surrounding nth element
+    def diffs(self, i: int, j: int, visited: list[list]) -> None:
+        # Checking all 8 elements surrounding nth element
         rowNbr = [-1, -1, -1, 0, 0, 1, 1, 1]  # Coordinate order
         colNbr = [-1, 0, 1, -1, 1, -1, 0, 1]
         visited[i][j] = True  # Make those cells visited

--- a/matrix/matrix_class.py
+++ b/matrix/matrix_class.py
@@ -1,6 +1,6 @@
 # An OOP approach to representing and manipulating matrices
 
-from __future__ import annotation
+from __future__ import annotations
 
 
 class Matrix:
@@ -19,23 +19,23 @@ class Matrix:
     [[1. 2. 3.]
      [4. 5. 6.]
      [7. 8. 9.]]
-    
+
     Matrix rows and columns are available as 2D arrays
     >>> print(matrix.rows)
     [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     >>> print(matrix.columns())
     [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
-    
+
     Order is returned as a tuple
     >>> matrix.order
     (3, 3)
-    
+
     Squareness and invertability are represented as bool
     >>> matrix.is_square
     True
     >>> matrix.is_invertable()
     False
-    
+
     Identity, Minors, Cofactors and Adjugate are returned as Matrices.  Inverse can be
     a Matrix or Nonetype
     >>> print(matrix.identity())
@@ -59,11 +59,11 @@ class Matrix:
     Traceback (most recent call last):
         ...
     TypeError: Only matrices with a non-zero determinant have an inverse
-    
+
     Determinant is an int, float, or Nonetype
     >>> matrix.determinant()
     0
-    
+
     Negation, scalar multiplication, addition, subtraction, multiplication and
     exponentiation are available and all return a Matrix
     >>> print(-matrix)
@@ -87,7 +87,7 @@ class Matrix:
     [[468. 576. 684.]
      [1062. 1305. 1548.]
      [1656. 2034. 2412.]]
-    
+
     Matrices can also be modified
     >>> matrix.add_row([10, 11, 12])
     >>> print(matrix)

--- a/matrix/matrix_class.py
+++ b/matrix/matrix_class.py
@@ -1,5 +1,8 @@
 # An OOP approach to representing and manipulating matrices
 
+from __future__ import annotations
+from typing import Optional
+
 
 class Matrix:
     """
@@ -17,23 +20,19 @@ class Matrix:
     [[1. 2. 3.]
      [4. 5. 6.]
      [7. 8. 9.]]
-
     Matrix rows and columns are available as 2D arrays
     >>> print(matrix.rows)
     [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     >>> print(matrix.columns())
     [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
-
     Order is returned as a tuple
     >>> matrix.order
     (3, 3)
-
     Squareness and invertability are represented as bool
     >>> matrix.is_square
     True
     >>> matrix.is_invertable()
     False
-
     Identity, Minors, Cofactors and Adjugate are returned as Matrices.  Inverse can be
     a Matrix or Nonetype
     >>> print(matrix.identity())
@@ -55,11 +54,9 @@ class Matrix:
      [-3. 6. -3.]]
     >>> print(matrix.inverse())
     None
-
     Determinant is an int, float, or Nonetype
     >>> matrix.determinant()
     0
-
     Negation, scalar multiplication, addition, subtraction, multiplication and
     exponentiation are available and all return a Matrix
     >>> print(-matrix)
@@ -83,7 +80,6 @@ class Matrix:
     [[468. 576. 684.]
      [1062. 1305. 1548.]
      [1656. 2034. 2412.]]
-
     Matrices can also be modified
     >>> matrix.add_row([10, 11, 12])
     >>> print(matrix)
@@ -101,10 +97,9 @@ class Matrix:
      [198. 243. 288. 304.]
      [306. 378. 450. 472.]
      [414. 513. 612. 640.]]
-
     """
 
-    def __init__(self, rows):
+    def __init__(self, rows: list[list]):
         error = TypeError(
             "Matrices must be formed from a list of zero or more lists containing at "
             "least one and the same number of values, each of which must be of type "
@@ -125,35 +120,35 @@ class Matrix:
             self.rows = []
 
     # MATRIX INFORMATION
-    def columns(self):
+    def columns(self) -> list[list]:
         return [[row[i] for row in self.rows] for i in range(len(self.rows[0]))]
 
     @property
-    def num_rows(self):
+    def num_rows(self) -> int:
         return len(self.rows)
 
     @property
-    def num_columns(self):
+    def num_columns(self) -> int:
         return len(self.rows[0])
 
     @property
-    def order(self):
+    def order(self) -> tuple[int, int]:
         return (self.num_rows, self.num_columns)
 
     @property
-    def is_square(self):
+    def is_square(self) -> bool:
         return self.order[0] == self.order[1]
 
-    def identity(self):
+    def identity(self) -> Matrix:
         values = [
             [0 if column_num != row_num else 1 for column_num in range(self.num_rows)]
             for row_num in range(self.num_rows)
         ]
         return Matrix(values)
 
-    def determinant(self):
+    def determinant(self) -> int:
         if not self.is_square:
-            return None
+            return 0
         if self.order == (0, 0):
             return 1
         if self.order == (1, 1):
@@ -168,10 +163,10 @@ class Matrix:
                 for column in range(self.num_columns)
             )
 
-    def is_invertable(self):
+    def is_invertable(self) -> bool:
         return bool(self.determinant())
 
-    def get_minor(self, row, column):
+    def get_minor(self, row: int, column: int) -> int:
         values = [
             [
                 self.rows[other_row][other_column]
@@ -183,12 +178,12 @@ class Matrix:
         ]
         return Matrix(values).determinant()
 
-    def get_cofactor(self, row, column):
+    def get_cofactor(self, row: int, column: int) -> int:
         if (row + column) % 2 == 0:
             return self.get_minor(row, column)
         return -1 * self.get_minor(row, column)
 
-    def minors(self):
+    def minors(self) -> Matrix:
         return Matrix(
             [
                 [self.get_minor(row, column) for column in range(self.num_columns)]
@@ -196,7 +191,7 @@ class Matrix:
             ]
         )
 
-    def cofactors(self):
+    def cofactors(self) -> Matrix:
         return Matrix(
             [
                 [
@@ -209,21 +204,21 @@ class Matrix:
             ]
         )
 
-    def adjugate(self):
+    def adjugate(self) -> Matrix:
         values = [
             [self.cofactors().rows[column][row] for column in range(self.num_columns)]
             for row in range(self.num_rows)
         ]
         return Matrix(values)
 
-    def inverse(self):
+    def inverse(self) -> Matrix | int:
         determinant = self.determinant()
-        return None if not determinant else self.adjugate() * (1 / determinant)
+        return 0 if not determinant else self.adjugate() * (1 / determinant)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self.rows)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.num_rows == 0:
             return "[]"
         if self.num_rows == 1:
@@ -240,7 +235,7 @@ class Matrix:
         )
 
     # MATRIX MANIPULATION
-    def add_row(self, row, position=None):
+    def add_row(self, row: list, position: Optional[int] = None) -> None:
         type_error = TypeError("Row must be a list containing all ints and/or floats")
         if not isinstance(row, list):
             raise type_error
@@ -256,7 +251,7 @@ class Matrix:
         else:
             self.rows = self.rows[0:position] + [row] + self.rows[position:]
 
-    def add_column(self, column, position=None):
+    def add_column(self, column: list, position: Optional[int] = None) -> None:
         type_error = TypeError(
             "Column must be a list containing all ints and/or floats"
         )
@@ -278,18 +273,18 @@ class Matrix:
             ]
 
     # MATRIX OPERATIONS
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Matrix):
             raise TypeError("A Matrix can only be compared with another Matrix")
         return self.rows == other.rows
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def __neg__(self):
+    def __neg__(self) -> Matrix:
         return self * -1
 
-    def __add__(self, other):
+    def __add__(self, other: Matrix) -> Matrix:
         if self.order != other.order:
             raise ValueError("Addition requires matrices of the same order")
         return Matrix(
@@ -299,7 +294,7 @@ class Matrix:
             ]
         )
 
-    def __sub__(self, other):
+    def __sub__(self, other: Matrix) -> Matrix:
         if self.order != other.order:
             raise ValueError("Subtraction requires matrices of the same order")
         return Matrix(
@@ -309,7 +304,7 @@ class Matrix:
             ]
         )
 
-    def __mul__(self, other):
+    def __mul__(self, other: Matrix | int | float) -> Matrix:
         if isinstance(other, (int, float)):
             return Matrix([[element * other for element in row] for row in self.rows])
         elif isinstance(other, Matrix):
@@ -329,7 +324,7 @@ class Matrix:
                 "A Matrix can only be multiplied by an int, float, or another matrix"
             )
 
-    def __pow__(self, other):
+    def __pow__(self, other: int) -> Matrix:
         if not isinstance(other, int):
             raise TypeError("A Matrix can only be raised to the power of an int")
         if not self.is_square:
@@ -348,7 +343,7 @@ class Matrix:
         return result
 
     @classmethod
-    def dot_product(cls, row, column):
+    def dot_product(cls, row: list, column: list) -> int:
         return sum(row[i] * column[i] for i in range(len(row)))
 
 

--- a/matrix/matrix_class.py
+++ b/matrix/matrix_class.py
@@ -1,7 +1,6 @@
 # An OOP approach to representing and manipulating matrices
 
-from __future__ import annotations
-from typing import Optional
+from __future__ import annotation
 
 
 class Matrix:
@@ -20,19 +19,23 @@ class Matrix:
     [[1. 2. 3.]
      [4. 5. 6.]
      [7. 8. 9.]]
+    
     Matrix rows and columns are available as 2D arrays
     >>> print(matrix.rows)
     [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     >>> print(matrix.columns())
     [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+    
     Order is returned as a tuple
     >>> matrix.order
     (3, 3)
+    
     Squareness and invertability are represented as bool
     >>> matrix.is_square
     True
     >>> matrix.is_invertable()
     False
+    
     Identity, Minors, Cofactors and Adjugate are returned as Matrices.  Inverse can be
     a Matrix or Nonetype
     >>> print(matrix.identity())
@@ -53,10 +56,14 @@ class Matrix:
      [6. -12. 6.]
      [-3. 6. -3.]]
     >>> print(matrix.inverse())
-    None
+    Traceback (most recent call last):
+        ...
+    TypeError: Only matrices with a non-zero determinant have an inverse
+    
     Determinant is an int, float, or Nonetype
     >>> matrix.determinant()
     0
+    
     Negation, scalar multiplication, addition, subtraction, multiplication and
     exponentiation are available and all return a Matrix
     >>> print(-matrix)
@@ -80,6 +87,7 @@ class Matrix:
     [[468. 576. 684.]
      [1062. 1305. 1548.]
      [1656. 2034. 2412.]]
+    
     Matrices can also be modified
     >>> matrix.add_row([10, 11, 12])
     >>> print(matrix)
@@ -211,9 +219,11 @@ class Matrix:
         ]
         return Matrix(values)
 
-    def inverse(self) -> Matrix | int:
+    def inverse(self) -> Matrix:
         determinant = self.determinant()
-        return 0 if not determinant else self.adjugate() * (1 / determinant)
+        if not determinant:
+            raise TypeError("Only matrices with a non-zero determinant have an inverse")
+        return self.adjugate() * (1 / determinant)
 
     def __repr__(self) -> str:
         return str(self.rows)
@@ -235,7 +245,7 @@ class Matrix:
         )
 
     # MATRIX MANIPULATION
-    def add_row(self, row: list, position: Optional[int] = None) -> None:
+    def add_row(self, row: list, position: int | None = None) -> None:
         type_error = TypeError("Row must be a list containing all ints and/or floats")
         if not isinstance(row, list):
             raise type_error
@@ -251,7 +261,7 @@ class Matrix:
         else:
             self.rows = self.rows[0:position] + [row] + self.rows[position:]
 
-    def add_column(self, column: list, position: Optional[int] = None) -> None:
+    def add_column(self, column: list, position: int | None = None) -> None:
         type_error = TypeError(
             "Column must be a list containing all ints and/or floats"
         )

--- a/matrix/matrix_operation.py
+++ b/matrix/matrix_operation.py
@@ -177,7 +177,7 @@ def _verify_matrix_sizes(
     return (shape[0], shape[2]), (shape[1], shape[3])
 
 
-def main():
+def main() -> None:
     matrix_a = [[12, 10], [3, 9]]
     matrix_b = [[3, 4], [7, 4]]
     matrix_c = [[11, 12, 13, 14], [21, 22, 23, 24], [31, 32, 33, 34], [41, 42, 43, 44]]

--- a/matrix/nth_fibonacci_using_matrix_exponentiation.py
+++ b/matrix/nth_fibonacci_using_matrix_exponentiation.py
@@ -16,7 +16,7 @@ We can decrease the n times multiplication by following the divide and conquer a
 """
 
 
-def multiply(matrix_a, matrix_b):
+def multiply(matrix_a: list[list[int]], matrix_b: list[list[int]]) -> list[list[int]]:
     matrix_c = []
     n = len(matrix_a)
     for i in range(n):
@@ -30,11 +30,11 @@ def multiply(matrix_a, matrix_b):
     return matrix_c
 
 
-def identity(n):
+def identity(n: int) -> list[list[int]]:
     return [[int(row == column) for column in range(n)] for row in range(n)]
 
 
-def nth_fibonacci_matrix(n):
+def nth_fibonacci_matrix(n: int) -> int:
     """
     >>> nth_fibonacci_matrix(100)
     354224848179261915075
@@ -54,7 +54,7 @@ def nth_fibonacci_matrix(n):
     return res_matrix[0][0]
 
 
-def nth_fibonacci_bruteforce(n):
+def nth_fibonacci_bruteforce(n: int) -> int:
     """
     >>> nth_fibonacci_bruteforce(100)
     354224848179261915075
@@ -70,7 +70,7 @@ def nth_fibonacci_bruteforce(n):
     return fib1
 
 
-def main():
+def main() -> None:
     for ordinal in "0th 1st 2nd 3rd 10th 100th 1000th".split():
         n = int("".join(c for c in ordinal if c in "0123456789"))  # 1000th --> 1000
         print(

--- a/matrix/searching_in_sorted_matrix.py
+++ b/matrix/searching_in_sorted_matrix.py
@@ -30,7 +30,7 @@ def search_in_a_sorted_matrix(
     print(f"Key {key} not found")
 
 
-def main():
+def main() -> None:
     mat = [[2, 5, 7], [4, 8, 13], [9, 11, 15], [12, 17, 20]]
     x = int(input("Enter the element to be searched:"))
     print(mat)

--- a/matrix/sherman_morrison.py
+++ b/matrix/sherman_morrison.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 class Matrix:
     """
     <class Matrix>
@@ -194,7 +195,6 @@ class Matrix:
             for c in range(self.column):
                 result[c, r] = self[r, c]
         return result
-    
 
     def ShermanMorrison(self, u: Matrix, v: Matrix) -> Matrix | None:
         """

--- a/matrix/sherman_morrison.py
+++ b/matrix/sherman_morrison.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 class Matrix:
     """
     <class Matrix>
     Matrix structure.
     """
 
-    def __init__(self, row: int, column: int, default_value: float = 0):
+    def __init__(self, row: int, column: int, default_value: float = 0) -> None:
         """
         <method Matrix.__init__>
         Initialize matrix with given size and default value.
-
         Example:
         >>> a = Matrix(2, 3, 1)
         >>> a
@@ -20,7 +21,7 @@ class Matrix:
         self.row, self.column = row, column
         self.array = [[default_value for c in range(column)] for r in range(row)]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         <method Matrix.__str__>
         Return string representation of this matrix.
@@ -37,7 +38,7 @@ class Matrix:
         string_format_identifier = "%%%ds" % (max_element_length,)
 
         # Make string and return
-        def single_line(row_vector):
+        def single_line(row_vector: list) -> str:
             nonlocal string_format_identifier
             line = "["
             line += ", ".join(string_format_identifier % (obj,) for obj in row_vector)
@@ -47,14 +48,13 @@ class Matrix:
         s += "\n".join(single_line(row_vector) for row_vector in self.array)
         return s
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
-    def validateIndices(self, loc: tuple):
+    def validateIndices(self, loc: tuple) -> bool:
         """
         <method Matrix.validateIndices>
         Check if given indices are valid to pick element from matrix.
-
         Example:
         >>> a = Matrix(2, 6, 0)
         >>> a.validateIndices((2, 7))
@@ -69,11 +69,10 @@ class Matrix:
         else:
             return True
 
-    def __getitem__(self, loc: tuple):
+    def __getitem__(self, loc: tuple) -> float:
         """
         <method Matrix.__getitem__>
         Return array[row][column] where loc = (row, column).
-
         Example:
         >>> a = Matrix(3, 2, 7)
         >>> a[1, 0]
@@ -82,11 +81,10 @@ class Matrix:
         assert self.validateIndices(loc)
         return self.array[loc[0]][loc[1]]
 
-    def __setitem__(self, loc: tuple, value: float):
+    def __setitem__(self, loc: tuple, value: float) -> None:
         """
         <method Matrix.__setitem__>
         Set array[row][column] = value where loc = (row, column).
-
         Example:
         >>> a = Matrix(2, 3, 1)
         >>> a[1, 2] = 51
@@ -98,11 +96,10 @@ class Matrix:
         assert self.validateIndices(loc)
         self.array[loc[0]][loc[1]] = value
 
-    def __add__(self, another):
+    def __add__(self, another: Matrix) -> Matrix:
         """
         <method Matrix.__add__>
         Return self + another.
-
         Example:
         >>> a = Matrix(2, 1, -4)
         >>> b = Matrix(2, 1, 3)
@@ -123,11 +120,10 @@ class Matrix:
                 result[r, c] = self[r, c] + another[r, c]
         return result
 
-    def __neg__(self):
+    def __neg__(self) -> Matrix:
         """
         <method Matrix.__neg__>
         Return -self.
-
         Example:
         >>> a = Matrix(2, 2, 3)
         >>> a[0, 1] = a[1, 0] = -2
@@ -143,14 +139,13 @@ class Matrix:
                 result[r, c] = -self[r, c]
         return result
 
-    def __sub__(self, another):
+    def __sub__(self, another: Matrix) -> Matrix:
         return self + (-another)
 
-    def __mul__(self, another):
+    def __mul__(self, another: int | float | Matrix) -> Matrix:
         """
         <method Matrix.__mul__>
         Return self * another.
-
         Example:
         >>> a = Matrix(2, 3, 1)
         >>> a[0,2] = a[1,2] = 3
@@ -177,11 +172,10 @@ class Matrix:
         else:
             raise TypeError(f"Unsupported type given for another ({type(another)})")
 
-    def transpose(self):
+    def transpose(self) -> Matrix:
         """
         <method Matrix.transpose>
         Return self^T.
-
         Example:
         >>> a = Matrix(2, 3)
         >>> for r in range(2):
@@ -200,8 +194,9 @@ class Matrix:
             for c in range(self.column):
                 result[c, r] = self[r, c]
         return result
+    
 
-    def ShermanMorrison(self, u, v):
+    def ShermanMorrison(self, u: Matrix, v: Matrix) -> Matrix | None:
         """
         <method Matrix.ShermanMorrison>
         Apply Sherman-Morrison formula in O(n^2).
@@ -211,7 +206,6 @@ class Matrix:
         impossible to calculate.
         Warning: This method doesn't check if self is invertible.
             Make sure self is invertible before execute this method.
-
         Example:
         >>> ainv = Matrix(3, 3, 0)
         >>> for i in range(3): ainv[i,i] = 1
@@ -243,7 +237,7 @@ class Matrix:
 # Testing
 if __name__ == "__main__":
 
-    def test1():
+    def test1() -> None:
         # a^(-1)
         ainv = Matrix(3, 3, 0)
         for i in range(3):
@@ -260,7 +254,7 @@ if __name__ == "__main__":
         # Sherman Morrison
         print(f"(a + uv^T)^(-1) is {ainv.ShermanMorrison(u, v)}")
 
-    def test2():
+    def test2() -> None:
         import doctest
 
         doctest.testmod()

--- a/matrix/spiral_print.py
+++ b/matrix/spiral_print.py
@@ -1,19 +1,17 @@
 """
 This program print the matrix in spiral form.
 This problem has been solved through recursive way.
-
       Matrix must satisfy below conditions
         i) matrix should be only one or two dimensional
         ii) number of column of all rows should be equal
 """
 
-from collections.abc import Iterable
 
-
-def check_matrix(matrix):
+def check_matrix(matrix: list[list]) -> bool:
     # must be
-    if matrix and isinstance(matrix, Iterable):
-        if isinstance(matrix[0], Iterable):
+    matrix = list([list(row) for row in matrix])
+    if matrix and isinstance(matrix, list):
+        if isinstance(matrix[0], list):
             prev_len = 0
             for row in matrix:
                 if prev_len == 0:
@@ -29,32 +27,49 @@ def check_matrix(matrix):
     return result
 
 
-def spiralPrint(a):
+def spiral_print_clockwise(a: list[list]) -> None:
+    """
+    >>> spiral_print([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+    1
+    2
+    3
+    4
+    8
+    12
+    11
+    10
+    9
+    5
+    6
+    7
+    """
+    
     if check_matrix(a) and len(a) > 0:
-        matRow = len(a)
-        if isinstance(a[0], Iterable):
-            matCol = len(a[0])
+        a = list([list(row) for row in a])
+        mat_row = len(a)
+        if isinstance(a[0], list):
+            mat_col = len(a[0])
         else:
             for dat in a:
-                print(dat),
+                print(dat)
             return
 
         # horizotal printing increasing
-        for i in range(0, matCol):
-            print(a[0][i]),
+        for i in range(0, mat_col):
+            print(a[0][i])
         # vertical printing down
-        for i in range(1, matRow):
-            print(a[i][matCol - 1]),
+        for i in range(1, mat_row):
+            print(a[i][mat_col - 1])
         # horizotal printing decreasing
-        if matRow > 1:
-            for i in range(matCol - 2, -1, -1):
-                print(a[matRow - 1][i]),
+        if mat_row > 1:
+            for i in range(mat_col - 2, -1, -1):
+                print(a[mat_row - 1][i])
         # vertical printing up
-        for i in range(matRow - 2, 0, -1):
-            print(a[i][0]),
-        remainMat = [row[1 : matCol - 1] for row in a[1 : matRow - 1]]
-        if len(remainMat) > 0:
-            spiralPrint(remainMat)
+        for i in range(mat_row - 2, 0, -1):
+            print(a[i][0])
+        remain_mat = [row[1 : mat_col - 1] for row in a[1 : mat_row - 1]]
+        if len(remain_mat) > 0:
+            spiral_print_clockwise(remain_mat)
         else:
             return
     else:
@@ -64,5 +79,5 @@ def spiralPrint(a):
 
 # driver code
 if __name__ == "__main__":
-    a = ([1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12])
-    spiralPrint(a)
+    a = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]
+    spiral_print_clockwise(a)

--- a/matrix/spiral_print.py
+++ b/matrix/spiral_print.py
@@ -42,8 +42,7 @@ def spiral_print_clockwise(a: list[list]) -> None:
     5
     6
     7
-    """
-    
+    """ 
     if check_matrix(a) and len(a) > 0:
         a = list([list(row) for row in a])
         mat_row = len(a)

--- a/matrix/spiral_print.py
+++ b/matrix/spiral_print.py
@@ -42,7 +42,7 @@ def spiral_print_clockwise(a: list[list]) -> None:
     5
     6
     7
-    """ 
+    """
     if check_matrix(a) and len(a) > 0:
         a = list([list(row) for row in a])
         mat_row = len(a)

--- a/matrix/spiral_print.py
+++ b/matrix/spiral_print.py
@@ -29,7 +29,7 @@ def check_matrix(matrix: list[list]) -> bool:
 
 def spiral_print_clockwise(a: list[list]) -> None:
     """
-    >>> spiral_print([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+    >>> spiral_print_clockwise([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
     1
     2
     3

--- a/matrix/spiral_print.py
+++ b/matrix/spiral_print.py
@@ -9,7 +9,7 @@ This problem has been solved through recursive way.
 
 def check_matrix(matrix: list[list]) -> bool:
     # must be
-    matrix = list([list(row) for row in matrix])
+    matrix = list(list(row) for row in matrix)
     if matrix and isinstance(matrix, list):
         if isinstance(matrix[0], list):
             prev_len = 0
@@ -44,7 +44,7 @@ def spiral_print_clockwise(a: list[list]) -> None:
     7
     """
     if check_matrix(a) and len(a) > 0:
-        a = list([list(row) for row in a])
+        a = list(list(row) for row in a)
         mat_row = len(a)
         if isinstance(a[0], list):
             mat_col = len(a[0])


### PR DESCRIPTION
### Describe your change:



* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
