### PR TITLE
Replace typing.optional with new annotations syntax

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -525,6 +525,7 @@
   * [Perfect Cube](https://github.com/TheAlgorithms/Python/blob/master/maths/perfect_cube.py)
   * [Perfect Number](https://github.com/TheAlgorithms/Python/blob/master/maths/perfect_number.py)
   * [Perfect Square](https://github.com/TheAlgorithms/Python/blob/master/maths/perfect_square.py)
+  * [Persistence](https://github.com/TheAlgorithms/Python/blob/master/maths/persistence.py)
   * [Pi Monte Carlo Estimation](https://github.com/TheAlgorithms/Python/blob/master/maths/pi_monte_carlo_estimation.py)
   * [Pollard Rho](https://github.com/TheAlgorithms/Python/blob/master/maths/pollard_rho.py)
   * [Polynomial Evaluation](https://github.com/TheAlgorithms/Python/blob/master/maths/polynomial_evaluation.py)

--- a/data_structures/linked_list/__init__.py
+++ b/data_structures/linked_list/__init__.py
@@ -5,8 +5,9 @@ Nodes contain data and also may link to other nodes:
                  head node gives us access of the complete list
     - Last node: points to null
 """
+from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 class Node:
@@ -17,7 +18,7 @@ class Node:
 
 class LinkedList:
     def __init__(self) -> None:
-        self.head: Optional[Node] = None
+        self.head: Node | None = None
         self.size = 0
 
     def add(self, item: Any) -> None:

--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -1,10 +1,12 @@
-from typing import Any, Iterator, Optional
+from __future__ import annotations
+
+from typing import Any, Iterator
 
 
 class Node:
     def __init__(self, data: Any):
         self.data: Any = data
-        self.next: Optional[Node] = None
+        self.next: Node | None = None
 
 
 class CircularLinkedList:

--- a/data_structures/linked_list/has_loop.py
+++ b/data_structures/linked_list/has_loop.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 
 class ContainsLoopError(Exception):
@@ -8,7 +10,7 @@ class ContainsLoopError(Exception):
 class Node:
     def __init__(self, data: Any) -> None:
         self.data: Any = data
-        self.next_node: Optional[Node] = None
+        self.next_node: Node | None = None
 
     def __iter__(self):
         node = self

--- a/data_structures/linked_list/middle_element_of_linked_list.py
+++ b/data_structures/linked_list/middle_element_of_linked_list.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 
 class Node:
@@ -17,7 +17,7 @@ class LinkedList:
         self.head = new_node
         return self.head.data
 
-    def middle_element(self) -> Optional[int]:
+    def middle_element(self) -> int | None:
         """
         >>> link = LinkedList()
         >>> link.middle_element()

--- a/maths/pollard_rho.py
+++ b/maths/pollard_rho.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from math import gcd
-from typing import Union
 
 
 def pollard_rho(
@@ -7,7 +8,7 @@ def pollard_rho(
     seed: int = 2,
     step: int = 1,
     attempts: int = 3,
-) -> Union[int, None]:
+) -> int | None:
     """
     Use Pollard's Rho algorithm to return a nontrivial factor of ``num``.
     The returned factor may be composite and require further factorization.


### PR DESCRIPTION
### Describe your change:

https://www.python.org/dev/peps/pep-0563/

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
