### PR TITLE
Add methods to generate Pascal's Triangle

### DIFF
--- a/maths/pascals_triangle.py
+++ b/maths/pascals_triangle.py
@@ -1,0 +1,113 @@
+"""
+Pascal's Triangle is a triangular array that tabulates the result of binomial expansions.
+The row x of the triangle may be though of as the coefficients for a binomial expression
+raised to the power of x.
+
+e.g. (a + b)^3 --> 1 (a^3) + 3 (a^2b) + 3 (ab^2) + 1 (b^3) --> 1 3 3 1,
+which is equivalent to the third row of pascal's triangle.
+
+The triangle may be constructed by summing the two values immediately
+above each index or by using the binomial expansion therom.
+
+More information is available at: https://en.wikipedia.org/wiki/Pascal%27s_triangle
+"""
+
+from typing import List
+
+
+def pascals_triangle_row(n: int) -> List[int]:
+    """
+    Compute the given row of Pascal's Triangle using binomial expansion therom.
+
+    Each row of the triangle can be represented as the binomial expansion of that number,
+    so we can represent each position as "N choose k" (alternatively called nCk or nCr)
+    of each index, where N is the row number and k is the current index.
+
+    so, triangle[n][k] = C(n, k) = n! / k! (n-k)!, which applies for each k in the row.
+
+    However, this can be further simplified by computing each value dynamically from the
+    previous value.
+
+    C(N, 0) = 1
+    C(N, 1) = N / 1
+    C(N, 2) = (N)(N-1) / 1*2
+    C(N, 3) = (N)(N-1)(N-2) / 1*2*3
+
+    Therefore, each C(N, k+1) = C(N, k) * (N-k) / (k+1)
+
+    More information is available at:
+    https://en.wikipedia.org/wiki/Pascal%27s_triangle#Calculating_a_row_or_diagonal_by_itself
+
+    >>> pascals_triangle_row(0)
+    [1]
+    >>> pascals_triangle_row(5)
+    [1, 5, 10, 10, 5, 1]
+    >>> pascals_triangle_row(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: n cannot be less than zero
+    """
+
+    if n < 0:
+        raise ValueError("n cannot be less than zero")
+
+    row = [0 for i in range(n + 1)]
+
+    row[0] = 1
+    row[-1] = 1
+
+    for k in range(n // 2):
+        index_val = row[k] * (n - k) // (k + 1)
+
+        row[k + 1] = index_val
+        row[n - k - 1] = index_val
+
+    return row
+
+
+def pascals_triangle_total(rows: int) -> List[List[int]]:
+    """
+    Compute all of pascal's triangle up to the given depth by summing the
+    two values immediately above each index. Note that depth is zero-indexed,
+    so calculating depth = 5 will return layers 0 through 5, inclusive.
+
+    >>> pascals_triangle_total(0)
+    [[1]]
+    >>> pascals_triangle_total(4)
+    [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1]]
+    >>> pascals_triangle_total(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: The size of Pascal's Triangle cannot be a negative number
+    """
+
+    if rows < 0:
+        raise ValueError("The size of Pascal's Triangle cannot be a negative number")
+    elif rows == 0:
+        return [[1]]
+
+    # make the total number of rows zero-indexed
+    rows += 1
+
+    # initialize an empty triangle with the top two layers filled
+    triangle = [[0 for i in range(d)] for d in range(1, rows + 1)]
+    triangle[0] = [1]
+    triangle[1] = [1, 1]
+
+    for d in range(2, rows):
+
+        triangle[d][0] = 1
+        triangle[d][-1] = 1
+
+        # compute the value at each index by summing the two numbers in the row above it
+        for i in range(1, d):
+            triangle[d][i] = triangle[d - 1][i] + triangle[d - 1][i - 1]
+
+    return triangle
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+
+    [print(r) for r in pascals_triangle_total(10)]

--- a/maths/pascals_triangle.py
+++ b/maths/pascals_triangle.py
@@ -1,6 +1,6 @@
 """
 Pascal's Triangle is a triangular array that tabulates the result of binomial expansions.
-The row x of the triangle may be though of as the coefficients for a binomial expression
+The row x of the triangle may be thought of as the coefficients for a binomial expression
 raised to the power of x.
 
 e.g. (a + b)^3 --> 1 (a^3) + 3 (a^2b) + 3 (ab^2) + 1 (b^3) --> 1 3 3 1,

--- a/maths/pascals_triangle.py
+++ b/maths/pascals_triangle.py
@@ -1,13 +1,10 @@
 """
-Pascal's Triangle is a triangular array that tabulates the result of binomial expansions.
-The row x of the triangle may be thought of as the coefficients for a binomial expression
-raised to the power of x.
-
+Pascal's Triangle is a triangular array that tabulates the result of binomial 
+expansions. The nth row of the triangle can be thought of as the coefficients 
+for a binomial expression raised to the power of x.
+		
 e.g. (a + b)^3 --> 1 (a^3) + 3 (a^2b) + 3 (ab^2) + 1 (b^3) --> 1 3 3 1,
 which is equivalent to the third row of pascal's triangle.
-
-The triangle may be constructed by summing the two values immediately
-above each index or by using the binomial expansion therom.
 
 More information is available at: https://en.wikipedia.org/wiki/Pascal%27s_triangle
 """
@@ -17,26 +14,28 @@ from typing import List
 
 def pascals_triangle_row(n: int) -> List[int]:
     """
-    Compute the given row of Pascal's Triangle using binomial expansion therom.
+    Compute the nth row of Pascal's Triangle using the binomial theorem.
 
-    Each row of the triangle can be represented as the binomial expansion of that number,
-    so we can represent each position as "N choose k" (alternatively called nCk or nCr)
-    of each index, where N is the row number and k is the current index.
+    Each row n can be represented as a binomial expression raised to the power n.
+    Each value is therefore the binomial coefficient of its index. This value can be
+    found using the combinations formula (alternatively called C(N, k) or nCk) where 
+    N is the row number and k is the current index.
 
-    so, triangle[n][k] = C(n, k) = n! / k! (n-k)!, which applies for each k in the row.
+    So, triangle[n][k] = C(n, k) = n! / k! (n-k)!, which applies for each index k in row n.
 
-    However, this can be further simplified by computing each value dynamically from the
-    previous value.
+    This can be further simplified by computing each value dynamically from the previous 
+    value. This is done by multiplying each value by (N-k) / (k+1) to find the next value:
 
     C(N, 0) = 1
     C(N, 1) = N / 1
     C(N, 2) = (N)(N-1) / 1*2
     C(N, 3) = (N)(N-1)(N-2) / 1*2*3
 
-    Therefore, each C(N, k+1) = C(N, k) * (N-k) / (k+1)
+    This pattern is generalized as C(N, k+1) = C(N, k) * (N-k) / (k+1)
 
     More information is available at:
     https://en.wikipedia.org/wiki/Pascal%27s_triangle#Calculating_a_row_or_diagonal_by_itself
+    https://en.wikipedia.org/wiki/Binomial_theorem
 
     >>> pascals_triangle_row(0)
     [1]
@@ -69,7 +68,7 @@ def pascals_triangle_total(rows: int) -> List[List[int]]:
     """
     Compute all of pascal's triangle up to the given depth by summing the
     two values immediately above each index. Note that depth is zero-indexed,
-    so calculating depth = 5 will return layers 0 through 5, inclusive.
+    so calculating 5 rows will return rows 0 through 5, inclusive.
 
     >>> pascals_triangle_total(0)
     [[1]]

--- a/maths/pascals_triangle.py
+++ b/maths/pascals_triangle.py
@@ -21,7 +21,7 @@ def pascals_triangle_row(n: int) -> List[int]:
     found using the combinations formula (alternatively called C(N, k) or nCk) where 
     N is the row number and k is the current index.
 
-    So, triangle[n][k] = C(n, k) = n! / k! (n-k)!, which applies for each index k in row n.
+    So, triangle[N][k] = C(N, k) = N! / k! (N-k)!, which applies for each index k in row N.
 
     This can be further simplified by computing each value dynamically from the previous 
     value. This is done by multiplying each value by (N-k) / (k+1) to find the next value:
@@ -66,9 +66,9 @@ def pascals_triangle_row(n: int) -> List[int]:
 
 def pascals_triangle_total(rows: int) -> List[List[int]]:
     """
-    Compute all of pascal's triangle up to the given depth by summing the
-    two values immediately above each index. Note that depth is zero-indexed,
-    so calculating 5 rows will return rows 0 through 5, inclusive.
+    Compute all of pascal's triangle up to the given depth by summing the two values 
+    immediately above each index. Note that the number of rows is zero-indexed, so 
+    calculating 5 rows will return rows 0 through 5, inclusive.
 
     >>> pascals_triangle_total(0)
     [[1]]


### PR DESCRIPTION
### Describe your change:

This adds two methods to compute Pascal's Triangle. The first is pascals_triangle_row, which is an efficient method to compute an arbitrary row of the triangle. The second is pascals_triangle_total, which is a relatively inefficient way to generate the entire triangle that I included for learning purposes.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
