### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ciphers/enigma_machine2.py
+++ b/ciphers/enigma_machine2.py
@@ -79,7 +79,7 @@ def _validator(
 'ZJXESIUQLHAVRMDOYGTNFWPBKC'), \
 {'P': 'O', 'O': 'P', 'L': 'A', 'A': 'L', 'N': 'D', 'D': 'N'})
 
-    :param rotpos: rotor_positon
+    :param rotpos: rotor_position
     :param rotsel: rotor_selection
     :param pb: plugb -> validated and transformed
     :return: (rotpos, rotsel, pb)

--- a/machine_learning/local_weighted_learning/local_weighted_learning.md
+++ b/machine_learning/local_weighted_learning/local_weighted_learning.md
@@ -29,7 +29,7 @@ This training phase is possible when data points are linear, but there again com
 So, here comes the role of non-parametric algorithm which doesn't compute predictions based on fixed set of params. Rather parameters $\theta$ are computed individually for each query point/data point x.
 <br />
 <br />
-While Computing $\theta$ , a higher "preferance" is given to points in the vicinity of x than points farther from x.
+While Computing $\theta$ , a higher "preference" is given to points in the vicinity of x than points farther from x.
 
 Cost Function J($\theta$) = $\sum_{i=1}^m$ $w^i$ (($\theta$)$^T$ $x^i$ - $y^i$)$^2$
 

--- a/project_euler/problem_493/sol1.py
+++ b/project_euler/problem_493/sol1.py
@@ -9,7 +9,7 @@ Give your answer with nine digits after the decimal point (a.bcdefghij).
 
 This combinatorial problem can be solved by decomposing the problem into the
 following steps:
-1. Calculate the total number of possible picking cominations
+1. Calculate the total number of possible picking combinations
 [combinations := binom_coeff(70, 20)]
 2. Calculate the number of combinations with one colour missing
 [missing := binom_coeff(60, 20)]

--- a/searches/hill_climbing.py
+++ b/searches/hill_climbing.py
@@ -94,7 +94,7 @@ def hill_climbing(
     max_iter: int = 10000,
 ) -> SearchProblem:
     """
-    Implementation of the hill climbling algorithm.
+    Implementation of the hill climbing algorithm.
     We start with a given state, find all its neighbors,
     move towards the neighbor which provides the maximum (or minimum) change.
     We keep doing this until we are at a state where we do not have any


### PR DESCRIPTION
There are small typos in:
- ciphers/enigma_machine2.py
- machine_learning/local_weighted_learning/local_weighted_learning.md
- project_euler/problem_493/sol1.py
- searches/hill_climbing.py

Fixes:
- Should read `preference` rather than `preferance`.
- Should read `position` rather than `positon`.
- Should read `combinations` rather than `cominations`.
- Should read `climbing` rather than `climbling`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md