### PR TITLE
Fix: This implemention fails with the way of string construction.

### DIFF
--- a/strings/manacher.py
+++ b/strings/manacher.py
@@ -24,9 +24,9 @@ def palindromic_string(input_string: str) -> str:
     # append each character + "|" in new_string for range(0, length-1)
     for i in input_string[: len(input_string) - 1]:
         new_input_string += i + "|"
-    # append the last character and then add the surrounding markers. 
+    # append the last character and then add the surrounding markers.
     # it becomes "|a|b|a|".
-    new_input_string = '|' + new_input_string + input_string[-1] + '|'   
+    new_input_string = "|" + new_input_string + input_string[-1] + "|"   
 
     # we will store the starting and ending of previous furthest ending palindromic
     # substring

--- a/strings/manacher.py
+++ b/strings/manacher.py
@@ -17,15 +17,15 @@ def palindromic_string(input_string: str) -> str:
     """
     max_length = 0
 
-    # if input_string is "aba" than new_input_string become "a|b|a"
+    # if input_string is "aba" then new_input_string become "a|b|a"
     new_input_string = ""
     output_string = ""
 
     # append each character + "|" in new_string for range(0, length-1)
     for i in input_string[: len(input_string) - 1]:
         new_input_string += i + "|"
-    # append last character
-    new_input_string += input_string[-1]
+    # append the last character and then add the surrounding markers.
+    new_input_string = '|' + new_input_string + input_string[-1] + '|'   
 
     # we will store the starting and ending of previous furthest ending palindromic
     # substring

--- a/strings/manacher.py
+++ b/strings/manacher.py
@@ -24,7 +24,8 @@ def palindromic_string(input_string: str) -> str:
     # append each character + "|" in new_string for range(0, length-1)
     for i in input_string[: len(input_string) - 1]:
         new_input_string += i + "|"
-    # append the last character and then add the surrounding markers.
+    # append the last character and then add the surrounding markers. 
+    # it becomes "|a|b|a|".
     new_input_string = '|' + new_input_string + input_string[-1] + '|'   
 
     # we will store the starting and ending of previous furthest ending palindromic


### PR DESCRIPTION
An example which fails in this implemention: "abb"
+ The answer should be "bb".
+ This implemention returns "b" only.
+ With the fix, the answer is "bb" now.

Moreover, `than` is a typo, should be `then`.


### Describe your change:

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
