### PR TITLE
Fix Max Fenwick Tree

### DIFF
--- a/data_structures/binary_tree/maximum_fenwick_tree.py
+++ b/data_structures/binary_tree/maximum_fenwick_tree.py
@@ -16,7 +16,7 @@ class MaxFenwickTree:
     20
     >>> ft.update(4, 10)
     >>> ft.query(2, 5)
-    10
+    20
     >>> ft.query(1, 5)
     20
     >>> ft.update(2, 0)
@@ -26,6 +26,14 @@ class MaxFenwickTree:
     >>> ft.update(255, 30)
     >>> ft.query(0, 10000)
     30
+    >>> ft = MaxFenwickTree(6)
+    >>> ft.update(5, 1)
+    >>> ft.query(5, 6)
+    1
+    >>> ft = MaxFenwickTree(6)
+    >>> ft.update(0, 1000)
+    >>> ft.query(0, 1)
+    1000
     """
 
     def __init__(self, size: int) -> None:
@@ -47,14 +55,14 @@ class MaxFenwickTree:
         """
         Get next index in O(1)
         """
-        return index + (index & -index)
+        return index | (index + 1)
 
     @staticmethod
     def get_prev(index: int) -> int:
         """
         Get previous index in O(1)
         """
-        return index - (index & -index)
+        return (index & (index + 1)) - 1
 
     def update(self, index: int, value: int) -> None:
         """
@@ -69,7 +77,11 @@ class MaxFenwickTree:
         """
         self.arr[index] = value
         while index < self.size:
-            self.tree[index] = max(value, self.query(self.get_prev(index), index))
+            current_left_border = self.get_prev(index) + 1
+            if current_left_border == index:
+                self.tree[index] = value
+            else:
+                self.tree[index] = max(value, current_left_border, index)
             index = self.get_next(index)
 
     def query(self, left: int, right: int) -> int:
@@ -85,9 +97,9 @@ class MaxFenwickTree:
         """
         right -= 1  # Because of right is exclusive
         result = 0
-        while left < right:
+        while left <= right:
             current_left = self.get_prev(right)
-            if left < current_left:
+            if left <= current_left:
                 result = max(result, self.tree[right])
                 right = current_left
             else:


### PR DESCRIPTION
### Describe your change:
And test for bugs in Max Fenwick Tree and modifications to fix them.

Using 1-based-indexing operations: `(index | (index + 1))` for a 0-based fenwick tree requires handling edge cases and is the cause for the bugs. Replacing with 0-based-indexing operations.


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
