### PR TITLE
Fix minor typo and add matrix dimension check

### DIFF
--- a/matrix/inverse_of_matrix.py
+++ b/matrix/inverse_of_matrix.py
@@ -29,6 +29,7 @@ def inverse_of_matrix(matrix: list[list[float]]) -> list[list[float]]:
 
     D = Decimal  # An abbreviation for conciseness
 
+    # Check if the provided matrix has 2 rows and 2 columns, since this implementation only works for 2x2 matrices
     if len(matrix) != 2 or len(matrix[0]) != 2 or len(matrix[1]) != 2:
         raise ValueError("Please provide a matrix of size 2x2.")
 

--- a/matrix/inverse_of_matrix.py
+++ b/matrix/inverse_of_matrix.py
@@ -27,7 +27,7 @@ def inverse_of_matrix(matrix: list[list[float]]) -> list[list[float]]:
     [[0.25, -0.5], [-0.3, 1.0]]
     """
 
-    D = Decimal  # An abbreviation to be conciseness
+    D = Decimal  # An abbreviation for conciseness
     # Calculate the determinant of the matrix
     determinant = D(matrix[0][0]) * D(matrix[1][1]) - D(matrix[1][0]) * D(matrix[0][1])
     if determinant == 0:

--- a/matrix/inverse_of_matrix.py
+++ b/matrix/inverse_of_matrix.py
@@ -28,13 +28,19 @@ def inverse_of_matrix(matrix: list[list[float]]) -> list[list[float]]:
     """
 
     D = Decimal  # An abbreviation for conciseness
+
+    if len(matrix) != 2 or len(matrix[0]) != 2 or len(matrix[1]) != 2:
+        raise ValueError("Please provide a matrix of size 2x2.")
+
     # Calculate the determinant of the matrix
     determinant = D(matrix[0][0]) * D(matrix[1][1]) - D(matrix[1][0]) * D(matrix[0][1])
     if determinant == 0:
         raise ValueError("This matrix has no inverse.")
+
     # Creates a copy of the matrix with swapped positions of the elements
     swapped_matrix = [[0.0, 0.0], [0.0, 0.0]]
     swapped_matrix[0][0], swapped_matrix[1][1] = matrix[1][1], matrix[0][0]
     swapped_matrix[1][0], swapped_matrix[0][1] = -matrix[1][0], -matrix[0][1]
+
     # Calculate the inverse of the matrix
     return [[float(D(n) / determinant) or 0.0 for n in row] for row in swapped_matrix]


### PR DESCRIPTION
### Describe your change:

I have fixed a minor typo in a comment within ìnverse_of_matrix.py` as well as added a simple check to ensure the provided matrix has the correct dimension (in this case only 2x2). 

Since this implementation only works for 2x2 matrices, we want to make sure to give a warning when calling it with 2x3, 3x3, etc., otherwise the function returns false results. I have also added a short comment for clarity.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
