### PR TITLE
Newton raphson better implementation

### DIFF
--- a/arithmetic_analysis/newton_raphson_new.py
+++ b/arithmetic_analysis/newton_raphson_new.py
@@ -1,26 +1,26 @@
-
 # Implementing Newton Raphson method in Python
-# Author: Saksham Gupta 
+# Author: Saksham Gupta
 #
 # The Newton-Raphson method (also known as Newton's method) is a way to
-# quickly find a good approximation for the root of a real-valued function
+# quickly find a good approximation for the root of a functreal-valued ion
 # The method can also be extended to complex functions
 #
 # Newton's Method - https://en.wikipedia.org/wiki/Newton's_method
 
-from sympy import diff, symbols, lambdify
-from sympy.functions import *
+from sympy import diff, lambdify, symbols
+from sympy.functions import *  # noqa: F401, F403
 
 
 def newton_raphson(
     function: str,
     starting_point: complex,
     variable: str = "x",
-    precision: float = 10 ** -10,
-    multiplicity: int = 1
+    precision: float = 10**-10,
+    multiplicity: int = 1,
 ) -> complex:
     """Finds root from the 'starting_point' onwards by Newton-Raphson method
-    Refer to https://docs.sympy.org/latest/modules/functions/index.html for usable mathematical functions
+    Refer to https://docs.sympy.org/latest/modules/functions/index.html
+    for usable mathematical functions
 
     >>> newton_raphson("sin(x)", 2)
     3.141592653589793
@@ -37,19 +37,21 @@ def newton_raphson(
     """
 
     x = symbols(variable)
+    func = lambdify(x, function)
     diff_function = lambdify(x, diff(function, x))
-    function = lambdify(x, function)
 
     prev_guess = starting_point
 
     while True:
         if diff_function(prev_guess) != 0:
-            next_guess = prev_guess -  multiplicity * function(prev_guess) / diff_function(prev_guess)
+            next_guess = prev_guess - multiplicity * func(prev_guess) / diff_function(
+                prev_guess
+            )
         else:
             raise ZeroDivisionError("Could not find root") from None
-        
+
         # Precision is checked by comparing the difference of consecutive guesses
-        if abs(next_guess-prev_guess) < precision:
+        if abs(next_guess - prev_guess) < precision:
             return next_guess
 
         prev_guess = next_guess
@@ -61,13 +63,22 @@ if __name__ == "__main__":
     # Find root of trigonometric function
     # Find value of pi
     print(f"The root of sin(x) = 0 is {newton_raphson('sin(x)', 2)}")
+
     # Find root of polynomial
     # Find fourth Root of 5
     print(f"The root of x**4 - 5 = 0 is {newton_raphson('x**4 -5', 0.4 +5j)}")
+
     # Find value of e
-    print(f"The root of log(y) - 1 = 0 is {newton_raphson('log(y) - 1', 2, variable='y')}")
+    print(
+        f"The root of log(y) - 1 = 0 is \
+{newton_raphson('log(y) - 1', 2, variable='y')}"
+    )
+
     # Exponential Roots
-    print(f"The root of exp(x) - 1 = 0 is {newton_raphson('exp(x) - 1', 10, precision=0.005)}")
+    print(
+        f"The root of exp(x) - 1 = 0 is \
+{newton_raphson('exp(x) - 1', 10, precision=0.005)}"
+    )
+
     # Find root of cos(x)
     print(f"The root of cos(x) = 0 is {newton_raphson('cos(x)', 0)}")
-    

--- a/arithmetic_analysis/newton_raphson_new.py
+++ b/arithmetic_analysis/newton_raphson_new.py
@@ -1,0 +1,73 @@
+
+# Implementing Newton Raphson method in Python
+# Author: Saksham Gupta 
+#
+# The Newton-Raphson method (also known as Newton's method) is a way to
+# quickly find a good approximation for the root of a real-valued function
+# The method can also be extended to complex functions
+#
+# Newton's Method - https://en.wikipedia.org/wiki/Newton's_method
+
+from sympy import diff, symbols, lambdify
+from sympy.functions import *
+
+
+def newton_raphson(
+    function: str,
+    starting_point: complex,
+    variable: str = "x",
+    precision: float = 10 ** -10,
+    multiplicity: int = 1
+) -> complex:
+    """Finds root from the 'starting_point' onwards by Newton-Raphson method
+    Refer to https://docs.sympy.org/latest/modules/functions/index.html for usable mathematical functions
+
+    >>> newton_raphson("sin(x)", 2)
+    3.141592653589793
+    >>> newton_raphson("x**4 -5", 0.4 + 5j)
+    (-7.52316384526264e-37+1.4953487812212207j)
+    >>> newton_raphson('log(y) - 1', 2, variable='y')
+    2.7182818284590455
+    >>> newton_raphson('exp(x) - 1', 10, precision=0.005)
+    1.2186556186174883e-10
+    >>> newton_raphson('cos(x)', 0)
+    Traceback (most recent call last):
+    ...
+    ZeroDivisionError: Could not find root
+    """
+
+    x = symbols(variable)
+    diff_function = lambdify(x, diff(function, x))
+    function = lambdify(x, function)
+
+    prev_guess = starting_point
+
+    while True:
+        if diff_function(prev_guess) != 0:
+            next_guess = prev_guess -  multiplicity * function(prev_guess) / diff_function(prev_guess)
+        else:
+            raise ZeroDivisionError("Could not find root") from None
+        
+        # Precision is checked by comparing the difference of consecutive guesses
+        if abs(next_guess-prev_guess) < precision:
+            return next_guess
+
+        prev_guess = next_guess
+
+
+# Let's Execute
+if __name__ == "__main__":
+
+    # Find root of trigonometric function
+    # Find value of pi
+    print(f"The root of sin(x) = 0 is {newton_raphson('sin(x)', 2)}")
+    # Find root of polynomial
+    # Find fourth Root of 5
+    print(f"The root of x**4 - 5 = 0 is {newton_raphson('x**4 -5', 0.4 +5j)}")
+    # Find value of e
+    print(f"The root of log(y) - 1 = 0 is {newton_raphson('log(y) - 1', 2, variable='y')}")
+    # Exponential Roots
+    print(f"The root of exp(x) - 1 = 0 is {newton_raphson('exp(x) - 1', 10, precision=0.005)}")
+    # Find root of cos(x)
+    print(f"The root of cos(x) = 0 is {newton_raphson('cos(x)', 0)}")
+    


### PR DESCRIPTION
I noticed the Newton Raphson method could be improved, so I made an altered script for it.

There are currently 2 scripts for newton raphson method in `Python/arithmetic_analysis/` :
`newton_method.py`
`newton_raphson.py`

There are a few **issues** with them,
- They both don't support _complex numbers_, while the method itself in theory does.
- `newton_method.py`: requires user to pass both the mathematical function and its derivative into the function
- `newton_raphson.py`: uses the wrong precision check; it compares the value of the f(x) with the precision required, rather than the difference in the consecutive x's. This resulted in its values to be wrong as in their test cases they showed pi = `3.1415926536808043` while correct precision check would give a value of `3.141592653589793` which is way closer to actual value of pi.
- `newton_raphson.py`: also extensively uses `eval()` statements, which are necessary for finding derivatives, but the implementation limits them from only taking the x as variable, and it was also used in every loop making the computation slower.
- `newton_raphson.py`: it doesn't check for the division by 0, which is the biggest limitation to using newton method, since the root can't be found for those cases.

I have taken goods from both the files and added more improvements and created a third file for the time being.