### PR TITLE
Add root mean square speed of gas molecules to physics

### DIFF
--- a/physics/rms_speed_of_molecule.py
+++ b/physics/rms_speed_of_molecule.py
@@ -36,8 +36,7 @@ def rms_speed_of_molecule(temperature: float, molar_mass: float) -> float:
     if molar_mass <= 0:
         raise Exception("Molar mass cannot be less than or equal to 0 kg/mol")
     else:
-        vrms: float = (3 * UNIVERSAL_GAS_CONSTANT * temperature / molar_mass) ** 0.5
-        return vrms
+        return (3 * UNIVERSAL_GAS_CONSTANT * temperature / molar_mass) ** 0.5
 
 
 if __name__ == "__main__":

--- a/physics/rms_speed_of_molecule.py
+++ b/physics/rms_speed_of_molecule.py
@@ -1,0 +1,53 @@
+"""
+The root-mean-square speed is essential in measuring the average speed of particles
+contained in a gas, defined as,
+ -----------------
+ | Vrms = √3RT/M |
+ -----------------
+
+In Kinetic Molecular Theory, gasified particles are in a condition of constant random
+motion; each particle moves at a completely different pace, perpetually clashing and
+changing directions consistently velocity is used to describe the movement of gas
+particles, thereby taking into account both speed and direction. Although the velocity
+of gaseous particles is constantly changing, the distribution of velocities does not
+change.
+We cannot gauge the velocity of every individual particle, thus we frequently reason
+in terms of the particles average behavior. Particles moving in opposite directions
+have velocities of opposite signs. Since gas particles are in random motion, it's
+plausible that there'll be about as several moving in one direction as within the other
+way, which means that the average velocity for a collection of gas particles equals
+zero; as this value is unhelpful, the average of velocities can be determined using an
+alternative method.
+"""
+
+
+UNIVERSAL_GAS_CONSTANT = 8.3144598
+
+
+def rms_speed_of_molecule(temperature: float, molar_mass: float) -> float:
+    """
+    >>> rms_speed_of_molecule(100, 2)
+    35.315279554323226
+    >>> rms_speed_of_molecule(273, 12)
+    23.821458421977443
+    """
+    if temperature < 0:
+        raise Exception("Temperature cannot be less than 0 K")
+    if molar_mass <= 0:
+        raise Exception("Molar mass cannot be less than or equal to 0 kg/mol")
+    else:
+        vrms: float = (3 * UNIVERSAL_GAS_CONSTANT * temperature / molar_mass) ** 0.5
+        return vrms
+
+
+if __name__ == "__main__":
+    import doctest
+
+    # run doctest
+    doctest.testmod()
+
+    # example
+    temperature = 300
+    molar_mass = 28
+    vrms = rms_speed_of_molecule(temperature, molar_mass)
+    print(f"Vrms of Nitrogen gas at 300 K is {vrms} m/s")


### PR DESCRIPTION
### Root Mean Square Speed of gas molecule added to physics. The function returns the calculated Vrms value for the given temperature and molar mass of the gas system.


* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
