### PR TITLE
Added Knapsack problem where repetition of items is allowed

### DIFF
--- a/knapsack/tests/test_unbounded_knapsack.py
+++ b/knapsack/tests/test_unbounded_knapsack.py
@@ -1,0 +1,63 @@
+"""
+Created on Mon Oct 3 08:46:07 2022
+
+@author: Parag Kumar Goyal
+@license: MIT-license
+
+This file contains the test-suite for the unbounded knapsack problem.
+"""
+import unittest
+
+from knapsack import unbounded_knapsack as uk
+
+
+class Test(unittest.TestCase):
+    def test_base_case(self):
+        """
+        test for the base case
+        """
+        cap = 0
+        val = [0]
+        w = [0]
+        c = len(val)
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 0)
+
+        val = [60]
+        w = [10]
+        c = len(val)
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 0)
+
+    def test_easy_case(self):
+        """
+        test for the base case
+        """
+        cap = 3
+        val = [1, 2, 3]
+        w = [3, 2, 1]
+        c = len(val)
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 9)
+
+    def test_unbounded_knapsack(self):
+        """
+        test for the unbounded knapsack
+        """
+        cap = 50
+        val = [60, 100, 120]
+        w = [10, 20, 30]
+        c = len(val)
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 300)
+
+        cap = 100
+        val = [1, 30]
+        w = [1, 50]
+        c = len(val)
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 100)
+
+        cap = 8
+        val = [10, 40, 50, 70]
+        w = [1, 3, 4, 5]
+        self.assertEqual(uk.unbounded_knapsack(cap, w, val, c), 110)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/knapsack/unbounded_knapsack.py
+++ b/knapsack/unbounded_knapsack.py
@@ -1,0 +1,48 @@
+""" A simple implementation of Unbounded Knapsack Problem
+    https://www.geeksforgeeks.org/unbounded-knapsack-repetition-items-allowed/
+"""
+from __future__ import annotations
+
+
+def unbounded_knapsack(
+    capacity: int, weights: list[int], values: list[int], counter: int
+) -> int:
+    """
+    Returns the maximum value that can be put in a knapsack of a capacity cap,
+    whereby each weight w has a specific value val and a item can be repeated.
+
+    >>> cap = 50
+    >>> val = [60, 100, 120]
+    >>> w = [10, 20, 30]
+    >>> c = len(val)
+    >>> unbounded_knapsack(cap, w, val, c)
+    300
+
+    The result is 300 cause the value of 60 can be used 5 times as it has weight 10
+    and limit is 50.
+    """
+
+    # Base Case
+    if counter == 0 or capacity == 0:
+        return 0
+
+    # If weight of the nth item is more than Knapsack of capacity,
+    #   then this item cannot be included in the optimal solution,
+    # else return the maximum of two cases:
+    #   (1) nth item included
+    #   (2) not included
+    if weights[counter - 1] > capacity:
+        return unbounded_knapsack(capacity, weights, values, counter - 1)
+    else:
+        left_capacity = capacity - weights[counter - 1]
+        new_value_included = values[counter - 1] + unbounded_knapsack(
+            left_capacity, weights, values, counter
+        )
+        without_new_value = unbounded_knapsack(capacity, weights, values, counter - 1)
+        return max(new_value_included, without_new_value)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
In classic Knapsack Problem, repetition of items is not allowed, I have written a program in which we have to find the maximum value out of the given objects with usage of an item more than once.The problem has been taken from geeksforgeeks.
https://www.geeksforgeeks.org/unbounded-knapsack-repetition-items-allowed/

### Describe your change:



* [X] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [X] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
