### PR TITLE
fix: remove absolute paths in doctest

### DIFF
--- a/data_structures/stacks/stack.py
+++ b/data_structures/stacks/stack.py
@@ -45,7 +45,7 @@ class Stack(Generic[T]):
         >>> Stack().pop()
         Traceback (most recent call last):
             ...
-        data_structures.stacks.stack.StackUnderflowError
+        stack.StackUnderflowError
         """
         if not self.stack:
             raise StackUnderflowError
@@ -58,7 +58,7 @@ class Stack(Generic[T]):
         >>> Stack().pop()
         Traceback (most recent call last):
             ...
-        data_structures.stacks.stack.StackUnderflowError
+        stack.StackUnderflowError
         """
         if not self.stack:
             raise StackUnderflowError


### PR DESCRIPTION
### What has Changed
1. Removed the absolute path name preceding the module name in the expected error message

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
