### PR TITLE
adding the array complement algorithm

### DIFF
--- a/maths/array_complement.py
+++ b/maths/array_complement.py
@@ -1,19 +1,19 @@
 def array_complement(initial_lst: list, diff_lst: list) -> list:
-	"""
-	removes all values from list initial_lst which
-	are also present in list diff_lst [ while keeping
-	the initial order of the elements ]
-	https://en.wikipedia.org/wiki/Complement_(set_theory)
-	>>> array_complement([1, 6, 2, 8], [1, 4])
-	[6, 2, 8]
-	>>> array_complement([146], [146, 25])
-	[]
-	>>> array_complement([35], [36])
-	[35]
-	"""
+    """
+    removes all values from list initial_lst which
+    are also present in list diff_lst [ while keeping
+    the initial order of the elements ]
+    https://en.wikipedia.org/wiki/Complement_(set_theory)
+    >>> array_complement([1, 6, 2, 8], [1, 4])
+    [6, 2, 8]
+    >>> array_complement([146], [146, 25])
+    []
+    >>> array_complement([35], [36])
+    [35]
+    """
 
-	return [c for c in initial_lst if c not in diff_lst]
+    return [c for c in initial_lst if c not in diff_lst]
 
 
 if __name__ == "__main__":
-	__import__("doctest").testmod()
+    __import__("doctest").testmod()

--- a/maths/array_complement.py
+++ b/maths/array_complement.py
@@ -1,0 +1,19 @@
+def array_complement(initial_lst: list, diff_lst: list) -> list:
+	"""
+	removes all values from list initial_lst which
+	are also present in list diff_lst [ while keeping
+	the initial order of the elements ]
+	https://en.wikipedia.org/wiki/Complement_(set_theory)
+	>>> array_complement([1, 6, 2, 8], [1, 4])
+	[6, 2, 8]
+	>>> array_complement([146], [146, 25])
+	[]
+	>>> array_complement([35], [36])
+	[35]
+	"""
+
+	return [c for c in initial_lst if c not in diff_lst]
+
+
+if __name__ == "__main__":
+	__import__("doctest").testmod()


### PR DESCRIPTION
### Describe your change:

removes all values from list _**a**_ which are also present in list _**b**_ [ while keeping the initial order of the elements ]

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
