### PR TITLE
Added algorithm for finding index of rightmost set bit

### DIFF
--- a/bit_manipulation/index_of_rightmost_set_bit.py
+++ b/bit_manipulation/index_of_rightmost_set_bit.py
@@ -1,0 +1,41 @@
+"""
+Finding the index of rightmost set bit has some very peculiar use-cases,
+especially in finding missing or/and repeating numbers in a list of positive integers.
+"""
+
+def get_index_of_rightmost_set_bit(number: int) -> int:
+
+    """
+    Take in a positive integer 'number'.
+    Returns the zero-based index of first set bit in that 'number' from right.
+    Returns -1, If no set bit found.
+
+    >>> get_index_of_rightmost_set_bit(0) 
+    -1
+    >>> get_index_of_rightmost_set_bit(5) 
+    0
+    >>> get_index_of_rightmost_set_bit(36) 
+    2
+    >>> get_index_of_rightmost_set_bit(8)  
+    3
+    >>> get_index_of_rightmost_set_bit(-18) 
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be a non-negative integer
+    """
+
+    if number>=0 and type(number)==int:
+        temp = number
+        intermediate = number&~(number-1)
+        index = 0
+        while intermediate:
+            intermediate>>=1
+            index+=1
+        return index-1
+    else: raise ValueError("Input must be a non-negative integer")
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
Added algorithm for finding the zero-based index of rightmost set bit in a given positive integer under bit_manipulation using python

### Describe your change:



* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
