### PR TITLE
Change shebang of validation script to python, because python3 is not installed on Windows

### DIFF
--- a/scripts/validate_filenames.py
+++ b/scripts/validate_filenames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import os
 
 try:


### PR DESCRIPTION
### Describe your change:

When I run `pre-commit run --all files` I got an error. 

```
Validate filenames.......................................................Failed
- hook id: validate-filenames
- exit code: 9009
```

This error happens because the python3 executable is not found. 

I have a Windows machine and just installed the latest Python via the official installer. Python3 alias is not included.

It was a time when using python2 and python3 aliases was important, but now python2 is not used anymore so it should not be a problem.


* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
