### PR TITLE
return type hint added

### DIFF
--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -54,17 +54,20 @@ def hubble_parameter(
     result : Hubble parameter in and the unit km/s/Mpc (the unit can be
     changed if you want, just need to change the unit of the Hubble constant)
 
-    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density=-0.3, dark_energy=0.7, redshift=1)
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, \
+                         matter_density=-0.3, dark_energy=0.7, redshift=1)
     Traceback (most recent call last):
     ...
     ValueError: All input parameters must be positive
 
-    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density= 1.2, dark_energy=0.7, redshift=1)
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, \
+                         matter_density= 1.2, dark_energy=0.7, redshift=1)
     Traceback (most recent call last):
     ...
     ValueError: Relative densities cannot be greater than one
-
-    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density= 0.3, dark_energy=0.7, redshift=0)
+    
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, \
+                         matter_density= 0.3, dark_energy=0.7, redshift=0)
     68.3
     """
 

--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -65,7 +65,7 @@ def hubble_parameter(
     Traceback (most recent call last):
     ...
     ValueError: Relative densities cannot be greater than one
-    
+
     >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, \
                          matter_density= 0.3, dark_energy=0.7, redshift=0)
     68.3

--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -1,0 +1,104 @@
+"""
+Title : Calculating the Hubble Parameter
+
+Description : The Hubble parameter H is the Universe expansion rate in any time.
+In cosmology is customary to use the redshift redshift in place of time, because
+the redshift is directily mensure in the light of galaxies moving away
+from us.
+
+So, the general relation that we obtain is
+
+H = hubble_constant*(radiation_density*(redshift+1)**4
+                     + matter_density*(redshift+1)**3
+                     + curvature*(redshift+1)**2 + dark_energy)**(1/2)
+
+where radiation_density, matter_density, dark_energy are the relativity
+(the percentage) energy densities that exist
+in the Universe today. Here, matter_density is the
+sum of the barion density and the
+dark matter. Curvature is the curvature parameter and can be written in term
+of the densities by the completeness
+
+
+curvature = 1 - (matter_density + radiation_density + dark_energy)
+
+Source :
+https://www.sciencedirect.com/topics/mathematics/hubble-parameter
+"""
+
+
+def hubble_parameter(
+    hubble_constant: float,
+    radiation_density: float,
+    matter_density: float,
+    dark_energy: float,
+    redshift: float,
+):
+
+    """
+    Input Parameters
+    ----------------
+    hubble_constant: Hubble constante is the expansion rate today usually
+    given in km/(s*Mpc)
+
+    radiation_density: relative radiation density today
+
+    matter_density: relative mass density today
+
+    dark_energy: relative dark energy density today
+
+    redshift: the light redshift
+
+    Returns
+    -------
+    result : Hubble parameter in and the unit km/s/Mpc (the unit can be
+    changed if you want, just need to change the unit of the Hubble constant)
+
+    >>> hubble_parameter(hubble_constant=63.3,
+    radiation_density=1e-4, matter_density=-0.3, dark_energy=0.7, redshift=1)
+    ...
+    ValueError: Any input parameter can be negative
+
+    >>> hubble_parameter(hubble_constant=63.3,
+    radiation_density=1e-4, matter_density= 1.2, dark_energy=0.7, redshift=1)
+    ...
+     ValueError: Relative densities cannot be greater than one
+    """
+
+    if any(0 > p for p in (redshift, radiation_density, matter_density, dark_energy)):
+        raise ValueError("All input parameters must be positive")
+
+    if matter_density > 1 or radiation_density > 1 or dark_energy > 1:
+        raise ValueError("Relative densities cannot be greater than one")
+    else:
+        curvature = 1 - (matter_density + radiation_density + dark_energy)
+
+        e_2 = (
+            radiation_density * (redshift + 1) ** 4
+            + matter_density * (redshift + 1) ** 3
+            + curvature * (redshift + 1) ** 2
+            + dark_energy
+        )
+
+        hubble = hubble_constant * e_2 ** (1 / 2)
+        return hubble
+
+
+if __name__ == "__main__":
+    import doctest
+
+    # run doctest
+    doctest.testmod()
+
+    # demo LCDM approximation
+    matter_density = 0.3
+
+    print(
+        hubble_parameter(
+            hubble_constant = 68.3,
+            radiation_density = 1e-4,
+            matter_density = matter_density,
+            dark_energy = 1 - matter_density,
+            redshift = 0
+            )
+    )

--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -54,21 +54,24 @@ def hubble_parameter(
     result : Hubble parameter in and the unit km/s/Mpc (the unit can be
     changed if you want, just need to change the unit of the Hubble constant)
 
-    >>> hubble_parameter(hubble_constant=63.3,
-    radiation_density=1e-4, matter_density=-0.3, dark_energy=0.7, redshift=1)
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density=-0.3, dark_energy=0.7, redshift=1)
+    Traceback (most recent call last):
     ...
-    ValueError: Any input parameter can be negative
+    ValueError: All input parameters must be positive
 
-    >>> hubble_parameter(hubble_constant=63.3,
-    radiation_density=1e-4, matter_density= 1.2, dark_energy=0.7, redshift=1)
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density= 1.2, dark_energy=0.7, redshift=1)
+    Traceback (most recent call last):
     ...
-     ValueError: Relative densities cannot be greater than one
+    ValueError: Relative densities cannot be greater than one
+    
+    >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density= 0.3, dark_energy=0.7, redshift=0)
+    68.3
     """
 
     if any(0 > p for p in (redshift, radiation_density, matter_density, dark_energy)):
         raise ValueError("All input parameters must be positive")
 
-    if matter_density > 1 or radiation_density > 1 or dark_energy > 1:
+    if any(1 < p for p in (radiation_density, matter_density, dark_energy)):
         raise ValueError("Relative densities cannot be greater than one")
     else:
         curvature = 1 - (matter_density + radiation_density + dark_energy)

--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -33,7 +33,7 @@ def hubble_parameter(
     matter_density: float,
     dark_energy: float,
     redshift: float,
-):
+) -> float:
 
     """
     Input Parameters
@@ -95,10 +95,10 @@ if __name__ == "__main__":
 
     print(
         hubble_parameter(
-            hubble_constant = 68.3,
-            radiation_density = 1e-4,
-            matter_density = matter_density,
-            dark_energy = 1 - matter_density,
-            redshift = 0
-            )
+            hubble_constant=68.3,
+            radiation_density=1e-4,
+            matter_density=matter_density,
+            dark_energy=1 - matter_density,
+            redshift=0,
+        )
     )

--- a/physics/hubble_parameter.py
+++ b/physics/hubble_parameter.py
@@ -63,7 +63,7 @@ def hubble_parameter(
     Traceback (most recent call last):
     ...
     ValueError: Relative densities cannot be greater than one
-    
+
     >>> hubble_parameter(hubble_constant=68.3, radiation_density=1e-4, matter_density= 0.3, dark_energy=0.7, redshift=0)
     68.3
     """


### PR DESCRIPTION
### Describe your change: Added a Hubble Parameter calculator and fixed the return hint.

Closes #7671 

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
