### PR TITLE
Correct Treap split docstring to reflect actual working, Fixes: #7854

### DIFF
--- a/data_structures/binary_tree/treap.py
+++ b/data_structures/binary_tree/treap.py
@@ -36,8 +36,8 @@ def split(root: Node | None, value: int) -> tuple[Node | None, Node | None]:
     """
     We split current tree into 2 trees with value:
 
-    Left tree contains all values less than split value.
-    Right tree contains all values greater or equal, than split value
+    Left tree contains all values less than or equal to split value.
+    Right tree contains all values greater than split value
     """
     if root is None:  # None tree is split into 2 Nones
         return None, None


### PR DESCRIPTION
Corrected the split docstring to reflect the working of the function, i.e., elements equal to the split value will be contained by left subtree, which before correction the docstring stated to be contained in the right subtree.

### Describe your change:

Implemented the suggestion by @vbvg2008 for issue #7854 to correct the docstring. Didn't choose to modify the code as stated in the latter part of suggestion as I found couple of resources online which kept the elements equal to the key in left subtree, supporting the former part of the suggestion.
Links to resources -
https://cp-algorithms.com/data_structures/treap.html#implicit-treaps
https://medium.com/carpanese/a-visual-introduction-to-treap-data-structure-part-1-6196d6cc12ee

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
