### PR TITLE
change space complexity of linked list's __len__ from O(n) to O(1)

### DIFF
--- a/data_structures/linked_list/circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list.py
@@ -24,7 +24,7 @@ class CircularLinkedList:
                 break
 
     def __len__(self) -> int:
-        return len(tuple(iter(self)))
+        return sum(1 for _ in self)
 
     def __repr__(self):
         return "->".join(str(item) for item in iter(self))

--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -51,7 +51,7 @@ class DoublyLinkedList:
         >>> len(linked_list) == 5
         True
         """
-        return len(tuple(iter(self)))
+        return sum(1 for _ in self)
 
     def insert_at_head(self, data):
         self.insert_at_nth(0, data)

--- a/data_structures/linked_list/merge_two_lists.py
+++ b/data_structures/linked_list/merge_two_lists.py
@@ -44,7 +44,7 @@ class SortedLinkedList:
         >>> len(SortedLinkedList(test_data_odd))
         8
         """
-        return len(tuple(iter(self)))
+        return sum(1 for _ in self)
 
     def __str__(self) -> str:
         """

--- a/data_structures/linked_list/singly_linked_list.py
+++ b/data_structures/linked_list/singly_linked_list.py
@@ -72,7 +72,7 @@ class LinkedList:
         >>> len(linked_list)
         0
         """
-        return len(tuple(iter(self)))
+        return sum(1 for _ in self)
 
     def __repr__(self) -> str:
         """


### PR DESCRIPTION
### Describe your change:

Following #5315 and #5320, I was convinced that it's better to calculate `__len__` each time on demand. But current implementation has "*space*" complexity problem when dealing with a huge linked list. That temporary `tuple` is unnecessary.  A one-line change using built-in `sum()` and a generator expression would solve it without breaking existing codes.


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
