### PR TITLE
Remove extra `len` calls in doubly-linked-list's methods

### DIFF
--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -81,7 +81,9 @@ class DoublyLinkedList:
             ....
         IndexError: list index out of range
         """
-        if not 0 <= index <= len(self):
+        length = len(self)
+
+        if not 0 <= index <= length:
             raise IndexError("list index out of range")
         new_node = Node(data)
         if self.head is None:
@@ -90,7 +92,7 @@ class DoublyLinkedList:
             self.head.previous = new_node
             new_node.next = self.head
             self.head = new_node
-        elif index == len(self):
+        elif index == length:
             self.tail.next = new_node
             new_node.previous = self.tail
             self.tail = new_node
@@ -131,15 +133,17 @@ class DoublyLinkedList:
             ....
         IndexError: list index out of range
         """
-        if not 0 <= index <= len(self) - 1:
+        length = len(self)
+
+        if not 0 <= index <= length - 1:
             raise IndexError("list index out of range")
         delete_node = self.head  # default first node
-        if len(self) == 1:
+        if length == 1:
             self.head = self.tail = None
         elif index == 0:
             self.head = self.head.next
             self.head.previous = None
-        elif index == len(self) - 1:
+        elif index == length - 1:
             delete_node = self.tail
             self.tail = self.tail.previous
             self.tail.next = None


### PR DESCRIPTION
### Describe your change:

I reduced the number of calls to `__len__` by storing the result into a local variable as it's currently a costly method( O(N) ).

To elaborate more: Suppose we insert an item at the tail like:
```python
l = DoublyLinkedList()
l.insert_at_tail("foo")
l.insert_at_tail("boo")   # <------- Here
```
The second call to `insert_at_tail` causes `__len__` to be called three times:
1. inside `self.insert_at_nth(len(self), data)` (because of delegating to `insert_at_nth`)
2. one at `if not 0 <= index <= len(self)` inside `insert_at_nth`
3. one at `elif index == len(self)` inside `insert_at_nth`

Same thing happens in `delete_at_nth`.

---

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
