### PR TITLE
fixes #8673; Add operator's associativity check for stacks/infix_to_p…

### DIFF
--- a/data_structures/stacks/infix_to_postfix_conversion.py
+++ b/data_structures/stacks/infix_to_postfix_conversion.py
@@ -4,8 +4,25 @@ https://en.wikipedia.org/wiki/Reverse_Polish_notation
 https://en.wikipedia.org/wiki/Shunting-yard_algorithm
 """
 
+from typing import Literal
+
 from .balanced_parentheses import balanced_parentheses
 from .stack import Stack
+
+PRECEDENCES: dict[str, int] = {
+    "+": 1,
+    "-": 1,
+    "*": 2,
+    "/": 2,
+    "^": 3,
+}
+ASSOCIATIVITIES: dict[str, Literal["LR", "RL"]] = {
+    "+": "LR",
+    "-": "LR",
+    "*": "LR",
+    "/": "LR",
+    "^": "RL",
+}
 
 
 def precedence(char: str) -> int:
@@ -14,7 +31,15 @@ def precedence(char: str) -> int:
     order of operation.
     https://en.wikipedia.org/wiki/Order_of_operations
     """
-    return {"+": 1, "-": 1, "*": 2, "/": 2, "^": 3}.get(char, -1)
+    return PRECEDENCES.get(char, -1)
+
+
+def associativity(char: str) -> Literal["LR", "RL"]:
+    """
+    Return the associativity of the operator `char`.
+    https://en.wikipedia.org/wiki/Operator_associativity
+    """
+    return ASSOCIATIVITIES[char]
 
 
 def infix_to_postfix(expression_str: str) -> str:
@@ -35,6 +60,8 @@ def infix_to_postfix(expression_str: str) -> str:
     'a b c * + d e * f + g * +'
     >>> infix_to_postfix("x^y/(5*z)+2")
     'x y ^ 5 z * / 2 +'
+    >>> infix_to_postfix("2^3^2")
+    '2 3 2 ^ ^'
     """
     if not balanced_parentheses(expression_str):
         raise ValueError("Mismatched parentheses")
@@ -50,9 +77,26 @@ def infix_to_postfix(expression_str: str) -> str:
                 postfix.append(stack.pop())
             stack.pop()
         else:
-            while not stack.is_empty() and precedence(char) <= precedence(stack.peek()):
-                postfix.append(stack.pop())
-            stack.push(char)
+            while True:
+                if stack.is_empty():
+                    stack.push(char)
+                    break
+
+                char_precedence = precedence(char)
+                TOS_precedence = precedence(stack.peek())
+
+                if char_precedence > TOS_precedence:
+                    stack.push(char)
+                    break
+                elif char_precedence == TOS_precedence:
+                    if associativity(char) == "RL":
+                        stack.push(char)
+                        break
+                    else:
+                        postfix.append(stack.pop())
+                else:
+                    postfix.append(stack.pop())
+
     while not stack.is_empty():
         postfix.append(stack.pop())
     return " ".join(postfix)


### PR DESCRIPTION
…ostfix_conversion.py

### Describe your change:

I added a doctest to reveal the error.

Also I found it inefficient to create a dictionary for every call to `precedence` function. So I extract the precedence dictionary and associativity dictionary to a constant in global.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
