### PR TITLE
Added vertex-limited network flow reduction

### DIFF
--- a/networking_flow/vertex_limited.py
+++ b/networking_flow/vertex_limited.py
@@ -1,4 +1,4 @@
-from ford_fulkerson import ford_fulkerson
+from networking_flow.ford_fulkerson import ford_fulkerson
 
 # Max-Flow reduction for vertex-limited networks (rather than edge-limited)
 """

--- a/networking_flow/vertex_limited.py
+++ b/networking_flow/vertex_limited.py
@@ -1,25 +1,30 @@
+from ford_fulkerson import ford_fulkerson
+
 # Max-Flow reduction for vertex-limited networks (rather than edge-limited)
 """
-Reduces a network that has vertex capacities into a network with edge capacities so that Ford-Fulkerson will work.
+Reduces a network that has vertex capacities into a network with edge capacities
+so that Ford-Fulkerson will work.
 Explanation: https://en.wikipedia.org/wiki/Maximum_flow_problem#Maximum_flow_with_vertex_capacities
 """
 
+
 def vertex_limited(graph, limits):
-    max_flow_graph = [[0 for i in range(2*len(graph))] for j in range(2*len(graph))]
-    
+    max_flow_graph = [[0 for i in range(2 * len(graph))] for j in range(2 * len(graph))]
+
     # Give all directed edges infinite capacity
     for src_vertex in range(len(graph)):
         for dest_vertex in range(len(graph[0])):
-            if (graph[src_vertex][dest_vertex] == 1):
-                max_flow_graph[src_vertex][dest_vertex] = float('inf')
+            if graph[src_vertex][dest_vertex] == 1:
+                max_flow_graph[src_vertex][dest_vertex] = float("inf")
 
     # Expand all vertices into two vertices
     for src_vertex in range(len(graph)):
         # move all outbound edges of the vertex to the new vertex
-        max_flow_graph[src_vertex + len(graph)] = max_flow_graph[src_vertex] 
+        max_flow_graph[src_vertex + len(graph)] = max_flow_graph[src_vertex]
         max_flow_graph[src_vertex] = [0 for i in range(len(max_flow_graph))]
 
-        # create edge with capacity equal to the vertex's limit from original to the new vertex
+        # create edge with capacity equal to the vertex's limit
+        # from the original vertex to the new vertex
         max_flow_graph[src_vertex][src_vertex + len(graph)] = limits[src_vertex]
 
     return max_flow_graph
@@ -27,10 +32,9 @@ def vertex_limited(graph, limits):
 
 # Test Case
 
-from ford_fulkerson import ford_fulkerson
 
 limits = [29, 12, 14, 20, 7, 29]
-graph = [ # rows are source, columns are destination
+graph = [  # rows are source, columns are destination
     [0, 1, 1, 0, 0, 0],
     [0, 0, 1, 1, 0, 0],
     [0, 1, 0, 0, 1, 0],
@@ -40,5 +44,5 @@ graph = [ # rows are source, columns are destination
 ]
 
 mf_graph = vertex_limited(graph, limits)
-print(mf_graph) # prints graph reduced to a standard flow network
-print(ford_fulkerson(mf_graph, 0, len(mf_graph)-1)) # max flow should be 19
+print(mf_graph)  # prints graph reduced to a standard flow network
+print(ford_fulkerson(mf_graph, 0, len(mf_graph) - 1))  # max flow should be 19

--- a/networking_flow/vertex_limited.py
+++ b/networking_flow/vertex_limited.py
@@ -1,6 +1,7 @@
 # Max-Flow reduction for vertex-limited networks (rather than edge-limited)
 """
 Reduces a network that has vertex capacities into a network with edge capacities so that Ford-Fulkerson will work.
+Explanation: https://en.wikipedia.org/wiki/Maximum_flow_problem#Maximum_flow_with_vertex_capacities
 """
 
 def vertex_limited(graph, limits):

--- a/networking_flow/vertex_limited.py
+++ b/networking_flow/vertex_limited.py
@@ -1,0 +1,43 @@
+# Max-Flow reduction for vertex-limited networks (rather than edge-limited)
+"""
+Reduces a network that has vertex capacities into a network with edge capacities so that Ford-Fulkerson will work.
+"""
+
+def vertex_limited(graph, limits):
+    max_flow_graph = [[0 for i in range(2*len(graph))] for j in range(2*len(graph))]
+    
+    # Give all directed edges infinite capacity
+    for src_vertex in range(len(graph)):
+        for dest_vertex in range(len(graph[0])):
+            if (graph[src_vertex][dest_vertex] == 1):
+                max_flow_graph[src_vertex][dest_vertex] = float('inf')
+
+    # Expand all vertices into two vertices
+    for src_vertex in range(len(graph)):
+        # move all outbound edges of the vertex to the new vertex
+        max_flow_graph[src_vertex + len(graph)] = max_flow_graph[src_vertex] 
+        max_flow_graph[src_vertex] = [0 for i in range(len(max_flow_graph))]
+
+        # create edge with capacity equal to the vertex's limit from original to the new vertex
+        max_flow_graph[src_vertex][src_vertex + len(graph)] = limits[src_vertex]
+
+    return max_flow_graph
+
+
+# Test Case
+
+from ford_fulkerson import ford_fulkerson
+
+limits = [29, 12, 14, 20, 7, 29]
+graph = [ # rows are source, columns are destination
+    [0, 1, 1, 0, 0, 0],
+    [0, 0, 1, 1, 0, 0],
+    [0, 1, 0, 0, 1, 0],
+    [0, 0, 1, 0, 0, 1],
+    [0, 0, 0, 1, 0, 1],
+    [0, 0, 0, 0, 0, 0],
+]
+
+mf_graph = vertex_limited(graph, limits)
+print(mf_graph) # prints graph reduced to a standard flow network
+print(ford_fulkerson(mf_graph, 0, len(mf_graph)-1)) # max flow should be 19


### PR DESCRIPTION
### Describe your change:

Implemented a reduction algorithm for flow networks that have capacities on vertices instead of edges. This reduction converts such a flow network into a standard flow network for which the Ford-Fulkerson algorithm can compute a max-flow.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
