### PR TITLE
Fix type error in `strassen_matrix_multiplication.py`

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -294,6 +294,7 @@
   * [Mergesort](divide_and_conquer/mergesort.py)
   * [Peak](divide_and_conquer/peak.py)
   * [Power](divide_and_conquer/power.py)
+  * [Strassen Matrix Multiplication](divide_and_conquer/strassen_matrix_multiplication.py)
 
 ## Dynamic Programming
   * [Abbreviation](dynamic_programming/abbreviation.py)

--- a/divide_and_conquer/strassen_matrix_multiplication.py
+++ b/divide_and_conquer/strassen_matrix_multiplication.py
@@ -112,17 +112,19 @@ def strassen(matrix1: list, matrix2: list) -> list:
     [[139, 163], [121, 134], [100, 121]]
     """
     if matrix_dimensions(matrix1)[1] != matrix_dimensions(matrix2)[0]:
-        raise Exception(
-            "Unable to multiply these matrices, please check the dimensions. \n"
-            f"Matrix A:{matrix1} \nMatrix B:{matrix2}"
+        msg = (
+            "Unable to multiply these matrices, please check the dimensions.\n"
+            f"Matrix A: {matrix1}\n"
+            f"Matrix B: {matrix2}"
         )
+        raise Exception(msg)
     dimension1 = matrix_dimensions(matrix1)
     dimension2 = matrix_dimensions(matrix2)
 
     if dimension1[0] == dimension1[1] and dimension2[0] == dimension2[1]:
         return [matrix1, matrix2]
 
-    maximum = max(dimension1, dimension2)
+    maximum = max(*dimension1, *dimension2)
     maxim = int(math.pow(2, math.ceil(math.log2(maximum))))
     new_matrix1 = matrix1
     new_matrix2 = matrix2


### PR DESCRIPTION
### Describe your change:

Fixes #8733

Fixes type error in `divide_and_conquer/strassen_matrix_multiplication.py` by ensuring that matrix dimensions are passed into `max` as ints and not tuples

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
