### PR TITLE
Fixes for ruff rule RUF012

### DIFF
--- a/data_structures/queue/double_ended_queue.py
+++ b/data_structures/queue/double_ended_queue.py
@@ -32,7 +32,7 @@ class Deque:
         the number of nodes
     """
 
-    __slots__ = ["_front", "_back", "_len"]
+    __slots__ = ("_front", "_back", "_len")
 
     @dataclass
     class _Node:
@@ -54,7 +54,7 @@ class Deque:
             the current node of the iteration.
         """
 
-        __slots__ = ["_cur"]
+        __slots__ = "_cur"
 
         def __init__(self, cur: Deque._Node | None) -> None:
             self._cur = cur

--- a/maths/least_common_multiple.py
+++ b/maths/least_common_multiple.py
@@ -67,7 +67,7 @@ def benchmark():
 
 
 class TestLeastCommonMultiple(unittest.TestCase):
-    test_inputs = [
+    test_inputs = (
         (10, 20),
         (13, 15),
         (4, 31),
@@ -77,8 +77,8 @@ class TestLeastCommonMultiple(unittest.TestCase):
         (12, 25),
         (10, 25),
         (6, 9),
-    ]
-    expected_results = [20, 195, 124, 210, 1462, 60, 300, 50, 18]
+    )
+    expected_results = (20, 195, 124, 210, 1462, 60, 300, 50, 18)
 
     def test_lcm_function(self):
         for i, (first_num, second_num) in enumerate(self.test_inputs):

--- a/project_euler/problem_054/sol1.py
+++ b/project_euler/problem_054/sol1.py
@@ -70,7 +70,7 @@ class PokerHand:
         list.sort(), sorted()
     """
 
-    _HAND_NAME = [
+    _HAND_NAME = (
         "High card",
         "One pair",
         "Two pairs",
@@ -81,9 +81,9 @@ class PokerHand:
         "Four of a kind",
         "Straight flush",
         "Royal flush",
-    ]
+    )
 
-    _CARD_NAME = [
+    _CARD_NAME = (
         "",  # placeholder as lists are zero indexed
         "One",
         "Two",
@@ -99,7 +99,7 @@ class PokerHand:
         "Queen",
         "King",
         "Ace",
-    ]
+    )
 
     def __init__(self, hand: str) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ max-complexity = 17  # default: 10
 "machine_learning/linear_discriminant_analysis.py" = ["ARG005"]
 "machine_learning/sequential_minimum_optimization.py" = ["SIM115"]
 "matrix/sherman_morrison.py" = ["SIM103", "SIM114"]
+"other/lfu_cache.py" = ["RUF012"]
 "physics/newtons_second_law_of_motion.py" = ["BLE001"]
 "project_euler/problem_099/sol1.py" = ["SIM115"]
 "sorts/external_sort.py" = ["SIM115"]


### PR DESCRIPTION
### Describe your change:
% `ruff rule RUF012`
# mutable-class-default (RUF012)

Derived from the **Ruff-specific rules** linter.

## What it does
Checks for mutable default values in class attributes.

## Why is this bad?
Mutable default values share state across all instances of the class,
while not being obvious. This can lead to bugs when the attributes are
changed in one instance, as those changes will unexpectedly affect all
other instances.

When mutable value are intended, they should be annotated with
`typing.ClassVar`.

## Examples
```python
class A:
    mutable_default: list[int] = []
```

Use instead:
```python
from typing import ClassVar


class A:
    mutable_default: ClassVar[list[int]] = []
```


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
