### PR TITLE
Fix failing tests from ruff/newton_raphson (ignore S307 "possibly insecure function")

### DIFF
--- a/arithmetic_analysis/newton_raphson.py
+++ b/arithmetic_analysis/newton_raphson.py
@@ -25,9 +25,9 @@ def newton_raphson(
     """
     x = a
     while True:
-        x = Decimal(x) - (Decimal(eval(func)) / Decimal(eval(str(diff(func)))))
+        x = Decimal(x) - (Decimal(eval(func)) / Decimal(eval(str(diff(func)))))  # noqa: S307
         # This number dictates the accuracy of the answer
-        if abs(eval(func)) < precision:
+        if abs(eval(func)) < precision:  # noqa: S307
             return float(x)
 
 

--- a/arithmetic_analysis/newton_raphson.py
+++ b/arithmetic_analysis/newton_raphson.py
@@ -26,8 +26,8 @@ def newton_raphson(
     x = a
     while True:
         x = Decimal(x) - (
-            Decimal(eval(func)) / Decimal(eval(str(diff(func))))
-        )  # noqa: S307
+            Decimal(eval(func)) / Decimal(eval(str(diff(func))))  # noqa: S307
+        )
         # This number dictates the accuracy of the answer
         if abs(eval(func)) < precision:  # noqa: S307
             return float(x)

--- a/arithmetic_analysis/newton_raphson.py
+++ b/arithmetic_analysis/newton_raphson.py
@@ -25,7 +25,9 @@ def newton_raphson(
     """
     x = a
     while True:
-        x = Decimal(x) - (Decimal(eval(func)) / Decimal(eval(str(diff(func)))))  # noqa: S307
+        x = Decimal(x) - (
+            Decimal(eval(func)) / Decimal(eval(str(diff(func))))
+        )  # noqa: S307
         # This number dictates the accuracy of the answer
         if abs(eval(func)) < precision:  # noqa: S307
             return float(x)


### PR DESCRIPTION
### Describe your change:
Fixes: #8864

Fix failing ruff tests by adding `# noqa: S307`


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
