### PR TITLE
Fix `radix_tree.py` insertion fail in ["*X", "*XX"] cases

### DIFF
--- a/data_structures/trie/radix_tree.py
+++ b/data_structures/trie/radix_tree.py
@@ -56,9 +56,11 @@ class RadixNode:
         >>> RadixNode("myprefix").insert("mystring")
 
         >>> root = RadixNode()
-        >>> root.insert_many(['A', 'AA'])
-        >>> root.nodes['A'].nodes['A'].prefix
-        'A'
+        >>> root.insert_many(['myprefix', 'myprefixA', 'myprefixAA'])
+        >>> root.print_tree()
+        - myprefix   (leaf)
+        -- A   (leaf)
+        --- A   (leaf)
         """
         # Case 1: If the word is the prefix of the node
         # Solution: We set the current node as leaf

--- a/data_structures/trie/radix_tree.py
+++ b/data_structures/trie/radix_tree.py
@@ -57,7 +57,7 @@ class RadixNode:
         """
         # Case 1: If the word is the prefix of the node
         # Solution: We set the current node as leaf
-        if self.prefix == word:
+        if self.prefix == word and not self.is_leaf:
             self.is_leaf = True
 
         # Case 2: The node has no edges that have a prefix to the word

--- a/data_structures/trie/radix_tree.py
+++ b/data_structures/trie/radix_tree.py
@@ -54,6 +54,11 @@ class RadixNode:
             word (str): word to insert
 
         >>> RadixNode("myprefix").insert("mystring")
+
+        >>> root = RadixNode()
+        >>> root.insert_many(['A', 'AA'])
+        >>> root.nodes['A'].nodes['A'].prefix
+        'A'
         """
         # Case 1: If the word is the prefix of the node
         # Solution: We set the current node as leaf


### PR DESCRIPTION
Fixes: 8888

### Describe your change:
Consider a word, and a copy of that word, but with the last letter repeated twice. (e.g., ["ABC", "ABCC"])
When adding the second word's last letter, it only compares the previous word's prefix—the last letter of the word already in the Radix Tree: 'C'—and the letter to be added—the last letter of the word we're currently adding: 'C'. So it wrongly passes the "Case 1" check, marks the current node as a leaf node when it already was, then returns when there's still one more letter to add.
The issue arises because `prefix` includes the letters of the node itself. (e.g., `nodes: {'C' : RadixNode()}, is_leaf: True, prefix: 'C'`) It can be easily circumvented by simply adding the `is_leaf` check, as the code already assumes you only input new words.

- Test Case: `"A AA AAA AAAA AAAAA AAAAAA"`
  - Fixed correct output:
  ```
  Words:['A', 'AA', 'AAA', 'AAAA', 'AAAAA', 'AAAAAA']
  Tree:
  - A   (leaf)
  -- A   (leaf)
  --- A   (leaf)
  ---- A   (leaf)
  ----- A   (leaf)
  ------ A   (leaf)
  ```
  - Current incorrect output:
  ```
  Words: ['A', 'AA', 'AAA', 'AAAA', 'AAAAA', 'AAAAAA']
  Tree:
  - A   (leaf)
  -- AA   (leaf)
  --- A   (leaf)
  ---- AA   (leaf)
  ```
1. ✅ Insert "**A**". Node is empty. Insert "**A**". Node prefix = "**A**".
2. ❌ Insert "A**A**". Compare node prefix "**A**" to "A**A**". `"A" == "A"`. Fails to insert. No change.
3. ✅ Insert "A**AA**". Compare node prefix "**A**" to "A**AA**". `"A" != "AA"`. Insert "A**AA**". Node prefix = "**AA**".
4. ✅ Insert "AAA**A**". Compare node prefix "**AA**" to "AAA**A**". `"AA" != "A"`. Case 2: Since "AAA" exists, branch and insert "AAA**A**". Node prefix = "**A**". Follows the Step 1 pattern.
5. ❌ Insert "AAAA**A**". Follows the Step 2 pattern.
6. ✅ Insert "AAAA**AA**". Follows the Step 3 pattern. (And the next step would follow Step 1's.)

*N.B.* It passed test cases for [Croatian Open Competition in Informatics 2012/2013 Contest #3 Task 5 HERKABE](https://hsin.hr/coci/archive/2012_2013/)


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
