### PR TITLE
Revert "[pre-commit.ci] pre-commit autoupdate"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
     -   id: auto-walrus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.0.277
     hooks:
       - id: ruff
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.3.0
     hooks:
       - id: black
 


### PR DESCRIPTION
Reverts TheAlgorithms/Python#8872

Breaks many algorithms as shown in these failing tests (from this pr #8875) https://github.com/TheAlgorithms/Python/actions/runs/5629561962/job/15254651560?pr=8875