### PR TITLE
Fix greyscale computation and inverted coords

### DIFF
--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -45,6 +45,11 @@ class Burkes:
         >>> Burkes.get_greyscale(255, 255, 255)
         255.0
         """
+        """
+        Formula from https://en.wikipedia.org/wiki/HSL_and_HSV
+        cf Lightness section, and Fig 13c.
+        We use the first of four possible.
+        """
         return 0.114 * blue + 0.587 * green + 0.299 * red
 
     def process(self) -> None:

--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -39,7 +39,7 @@ class Burkes:
     def get_greyscale(cls, blue: int, green: int, red: int) -> float:
         """
         >>> Burkes.get_greyscale(3, 4, 5)
-        3.753
+        4.185
         """
         return 0.114 * blue + 0.587 * green + 0.299 * red
 

--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -40,6 +40,10 @@ class Burkes:
         """
         >>> Burkes.get_greyscale(3, 4, 5)
         4.185
+        >>> Burkes.get_greyscale(0, 0, 0)
+        0.0
+        >>> Burkes.get_greyscale(255, 255, 255)
+        255.0
         """
         return 0.114 * blue + 0.587 * green + 0.299 * red
 

--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -41,7 +41,7 @@ class Burkes:
         >>> Burkes.get_greyscale(3, 4, 5)
         3.753
         """
-        return 0.114 * blue + 0.587 * green + 0.2126 * red
+        return 0.114 * blue + 0.587 * green + 0.299 * red
 
     def process(self) -> None:
         for y in range(self.height):
@@ -49,10 +49,10 @@ class Burkes:
                 greyscale = int(self.get_greyscale(*self.input_img[y][x]))
                 if self.threshold > greyscale + self.error_table[y][x]:
                     self.output_img[y][x] = (0, 0, 0)
-                    current_error = greyscale + self.error_table[x][y]
+                    current_error = greyscale + self.error_table[y][x]
                 else:
                     self.output_img[y][x] = (255, 255, 255)
-                    current_error = greyscale + self.error_table[x][y] - 255
+                    current_error = greyscale + self.error_table[y][x] - 255
                 """
                 Burkes error propagation (`*` is current pixel):
 


### PR DESCRIPTION
### Describe your change:
* [x] Fix a bug or typo in an existing algorithm?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.

### The change:
Hello there,

I've used your algorithm to re-implement it in C for a side-project of mine, and noticed two little bugs in it:

1) the luminance calculation is incorrect - according to Internet, it's either (0.2126*R + 0.7152*G + 0.0722*B) or (0.299*R + 0.587*G + 0.114*B). Here, we had a mix of both (and the greyscale value could never reach 255.

2) the current_error setting used inverted coordinates.

Hope this helps!