### PR TITLE
Fixed Pytest warnings for machine_learning/forecasting

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -336,9 +336,11 @@
   * [Minimum Tickets Cost](dynamic_programming/minimum_tickets_cost.py)
   * [Optimal Binary Search Tree](dynamic_programming/optimal_binary_search_tree.py)
   * [Palindrome Partitioning](dynamic_programming/palindrome_partitioning.py)
+  * [Regex Match](dynamic_programming/regex_match.py)
   * [Rod Cutting](dynamic_programming/rod_cutting.py)
   * [Subset Generation](dynamic_programming/subset_generation.py)
   * [Sum Of Subset](dynamic_programming/sum_of_subset.py)
+  * [Tribonacci](dynamic_programming/tribonacci.py)
   * [Viterbi](dynamic_programming/viterbi.py)
   * [Word Break](dynamic_programming/word_break.py)
 

--- a/machine_learning/forecasting/run.py
+++ b/machine_learning/forecasting/run.py
@@ -11,6 +11,8 @@ missing (the amount of data that u expected are not supposed to be)
          u can just adjust it for ur own purpose
 """
 
+from warnings import simplefilter
+
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import Normalizer
@@ -45,8 +47,10 @@ def sarimax_predictor(train_user: list, train_match: list, test_match: list) -> 
     >>> sarimax_predictor([4,2,6,8], [3,1,2,4], [2])
     6.6666671111109626
     """
+    # Suppress the User Warning raised by SARIMAX due to insufficient observations
+    simplefilter("ignore", UserWarning)
     order = (1, 2, 1)
-    seasonal_order = (1, 1, 0, 7)
+    seasonal_order = (1, 1, 1, 7)
     model = SARIMAX(
         train_user, exog=train_match, order=order, seasonal_order=seasonal_order
     )


### PR DESCRIPTION
### Describe your change:

Fixes [#7305] [#8780]
The numpy Runtime warning was due to the 0 in `seasonal_order` tuple and regarding the ARIMA models. For estimation, it needs more observations to work well and the User Warning are raised because of the sample test `>>> sarimax_predictor([4,2,6,8], [3,1,2,4], [2])` used by doctests. 


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
