### PR TITLE
Fix for AttributeError in Back Propagation Neural Network

### DIFF
--- a/neural_network/back_propagation_neural_network.py
+++ b/neural_network/back_propagation_neural_network.py
@@ -163,7 +163,7 @@ class BPNN:
 
     def plot_loss(self):
         if self.ax_loss.lines:
-            self.ax_loss.lines.remove(self.ax_loss.lines[0])
+            self.ax_loss.lines[0].remove()
         self.ax_loss.plot(self.train_mse, "r-")
         plt.ion()
         plt.xlabel("step")


### PR DESCRIPTION
### Describe your change:
Modified the plot_loss function in the Back Propagation Neural Network to correctly remove a plotted line, fixing an AttributeError that was occurring.


* [ ] Add an algorithm
* [x] Fix a bug or typo in an existing algorithm
* [ ] Documentation change

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #9015".
