### PR TITLE
feat: Added Scaled Exponential Linear Unit Activation Function

### DIFF
--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -1,0 +1,35 @@
+"""
+Implements the Scaled Exponential Linear Unit or SELU function.
+
+The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) and lambda (default = 1.0507)
+as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation function. 
+It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be standardized 
+due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
+
+References :
+https://iq.opengenus.org/scaled-exponential-linear-unit/
+"""
+
+import numpy as np
+
+def scaled_exponential_linear_unit(vector: np.ndarray, alpha : float = 1.6732, _lambda : float = 1.0507) -> np.ndarray:
+    """
+    Applies the Scaled Exponential Linear Unit function to each element of the vector.
+    Parameters : vector : np.ndarray
+                 alpha : float (default = 1.6732)
+                 _lambda : float (default = 1.0507)
+    Returns : np.ndarray
+    Formula : f(x) = _lambda * x if x > 0
+                     _lambda * alpha * (e**x - 1) if x <= 0
+    Examples :
+    >>> scaled_exponential_linear_unit(vector = np.array([1.3, 3.7, 2.4]))
+    Output : np.array([1.36591, 3.88759, 2.52168])
+
+    >>> scaled_exponential_linear_unit(vector = np.array([2.342, -3.455, -7.2116, 0.0, -4.532]))
+    Output : np.array([2.4607394, -1.70249977, -1.75673386,  0., -1.73911634])
+    """
+    return _lambda * np.where(vector > 0, vector, alpha * (np.exp(vector) - 1))
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -2,8 +2,8 @@
 Implements the Scaled Exponential Linear Unit or SELU function.
 
 The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) and lambda (default = 1.0507)
-as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation function. 
-It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be standardized 
+as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation function.
+It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be standardized
 due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
 
 References :
@@ -12,7 +12,10 @@ https://iq.opengenus.org/scaled-exponential-linear-unit/
 
 import numpy as np
 
-def scaled_exponential_linear_unit(vector: np.ndarray, alpha : float = 1.6732, _lambda : float = 1.0507) -> np.ndarray:
+
+def scaled_exponential_linear_unit(
+    vector: np.ndarray, alpha: float = 1.6732, _lambda: float = 1.0507
+) -> np.ndarray:
     """
     Applies the Scaled Exponential Linear Unit function to each element of the vector.
     Parameters : vector : np.ndarray
@@ -30,6 +33,8 @@ def scaled_exponential_linear_unit(vector: np.ndarray, alpha : float = 1.6732, _
     """
     return _lambda * np.where(vector > 0, vector, alpha * (np.exp(vector) - 1))
 
+
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -1,10 +1,10 @@
 """
 Implements the Scaled Exponential Linear Unit or SELU function.
 
-The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) and lambda (default = 1.0507)
-as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation function.
-It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be standardized
-due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
+The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) & lambda (default = 1.0507)
+as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation 
+function. It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be 
+standardized due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
 
 References :
 https://iq.opengenus.org/scaled-exponential-linear-unit/
@@ -25,10 +25,10 @@ def scaled_exponential_linear_unit(
     Formula : f(x) = _lambda * x if x > 0
                      _lambda * alpha * (e**x - 1) if x <= 0
     Examples :
-    >>> scaled_exponential_linear_unit(vector = np.array([1.3, 3.7, 2.4]))
+    >>> scaled_exponential_linear_unit(np.array([1.3, 3.7, 2.4]))
     Output : np.array([1.36591, 3.88759, 2.52168])
 
-    >>> scaled_exponential_linear_unit(vector = np.array([2.342, -3.455, -7.2116, 0.0, -4.532]))
+    >>> scaled_exponential_linear_unit(np.array([2.342, -3.455, -7.2116, 0.0, -4.532]))
     Output : np.array([2.4607394, -1.70249977, -1.75673386,  0., -1.73911634])
     """
     return _lambda * np.where(vector > 0, vector, alpha * (np.exp(vector) - 1))

--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -1,13 +1,13 @@
 """
 Implements the Scaled Exponential Linear Unit or SELU function.
 
-The function takes a vector of K real numbers and two real numbers 
-alpha(default = 1.6732) & lambda (default = 1.0507) as input and 
-then applies the SELU function to each element of the vector. 
-SELU is a self-normalizing activation function. It is a variant 
-of the ELU. The main advantage of SELU is that we can be sure 
-that the output will always be standardized due to its 
-self-normalizing behavior. That means there is no need to 
+The function takes a vector of K real numbers and two real numbers
+alpha(default = 1.6732) & lambda (default = 1.0507) as input and
+then applies the SELU function to each element of the vector.
+SELU is a self-normalizing activation function. It is a variant
+of the ELU. The main advantage of SELU is that we can be sure
+that the output will always be standardized due to its
+self-normalizing behavior. That means there is no need to
 include Batch-Normalization layers.
 
 References :

--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -1,10 +1,14 @@
 """
 Implements the Scaled Exponential Linear Unit or SELU function.
 
-The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) & lambda (default = 1.0507)
-as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation
-function. It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be
-standardized due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
+The function takes a vector of K real numbers and two real numbers 
+alpha(default = 1.6732) & lambda (default = 1.0507) as input and 
+then applies the SELU function to each element of the vector. 
+SELU is a self-normalizing activation function. It is a variant 
+of the ELU. The main advantage of SELU is that we can be sure 
+that the output will always be standardized due to its 
+self-normalizing behavior. That means there is no need to 
+include Batch-Normalization layers.
 
 References :
 https://iq.opengenus.org/scaled-exponential-linear-unit/

--- a/neural_network/activation_functions/scaled_exponential_linear_unit.py
+++ b/neural_network/activation_functions/scaled_exponential_linear_unit.py
@@ -2,8 +2,8 @@
 Implements the Scaled Exponential Linear Unit or SELU function.
 
 The function takes a vector of K real numbers and two real numbers alpha(default = 1.6732) & lambda (default = 1.0507)
-as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation 
-function. It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be 
+as input and then applies the SELU function to each element of the vector. SELU is a self-normalizing activation
+function. It is a variant of the ELU. The main advantage of SELU is that we can be sure that the output will always be
 standardized due to its self-normalizing behavior. That means there is no need to include Batch-Normalization layers.
 
 References :


### PR DESCRIPTION
Added Scaled Exponential Linear Unit Activation (SELU)  Function under TheAlgorithms/Python/neural_network/activation_functions. Description of SELU taken from reference link provided in the top comment section in scaled_exponential_linear_unit.py
Fixes #9010


* [X] Add an algorithm?

### Checklist:
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [X] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
