### PR TITLE
Update xgboost_regressor.py

### DIFF
--- a/machine_learning/xgboost_regressor.py
+++ b/machine_learning/xgboost_regressor.py
@@ -39,7 +39,7 @@ def main() -> None:
     """
     >>> main()
     Mean Absolute Error : 0.3089678116585885
-    Mean Square Error  : 21783275170643127
+    Mean Square Error  : 0.21783275170643127
 
     The URL for this algorithm
     https://xgboost.readthedocs.io/en/stable/

--- a/machine_learning/xgboost_regressor.py
+++ b/machine_learning/xgboost_regressor.py
@@ -25,7 +25,7 @@ def xgboost(
     ...    907. , 2.45799458,   40.58 , -124.26]]),np.array([1.114]),
     ... np.array([[1.97840000e+00,  3.70000000e+01,  4.98858447e+00,  1.03881279e+00,
     ...    1.14300000e+03,  2.60958904e+00,  3.67800000e+01, -1.19780000e+02]]))
-    array([[1.1139996]], dtype=float32)
+    array([[1.114]], dtype=float32)
     """
     xgb = XGBRegressor(verbosity=0, random_state=42)
     xgb.fit(features, target)
@@ -38,8 +38,8 @@ def xgboost(
 def main() -> None:
     """
     >>> main()
-    Mean Absolute Error : 0.30957163379906033
-    Mean Square Error  : 0.22611560196662744
+    Mean Absolute Error : 0.3089678116585885
+    Mean Square Error  : 21783275170643127
 
     The URL for this algorithm
     https://xgboost.readthedocs.io/en/stable/


### PR DESCRIPTION
### Describe your change:

The `mean_squared_error()` function has been updated in the latest version of scikit-learn. The previous version of the function used a different formula for calculating the mean squared error, which resulted in a different value. This PR updates the code (changed the doctest results) to use the new formula.

The new version of the function uses the following formula:

          mean_squared_error(y_true, y_predicted) = np.average((y_true - y_predicted)**2)

The previous version of the function used the following formula:

         mean_squared_error(y_true, y_predicted) = np.sum((y_true - y_predicted)**2) / len(y_true)


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
