### PR TITLE
Returning Index instead of boolean in knuth_morris_pratt (kmp) function, making it compatible with str.find().

### DIFF
--- a/neural_network/back_propagation_neural_network.py
+++ b/neural_network/back_propagation_neural_network.py
@@ -163,7 +163,7 @@ class BPNN:
 
     def plot_loss(self):
         if self.ax_loss.lines:
-            self.ax_loss.lines.remove(self.ax_loss.lines[0])
+            self.ax_loss.lines[0].remove()
         self.ax_loss.plot(self.train_mse, "r-")
         plt.ion()
         plt.xlabel("step")

--- a/neural_network/back_propagation_neural_network.py
+++ b/neural_network/back_propagation_neural_network.py
@@ -163,7 +163,7 @@ class BPNN:
 
     def plot_loss(self):
         if self.ax_loss.lines:
-            self.ax_loss.lines[0].remove()
+            self.ax_loss.lines.remove(self.ax_loss.lines[0])
         self.ax_loss.plot(self.train_mse, "r-")
         plt.ion()
         plt.xlabel("step")

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -14,6 +14,12 @@ def knuth_morris_pratt(text: str, pattern: str) -> int:
     2) Step through the text one character at a time and compare it to a character in
         the pattern updating our location within the pattern if necessary
 
+    >>> knuth_morris_pratt = "knuth_morris_pratt"
+    >>> all(
+    ...    knuth_morris_pratt(kmp, s) == kmp.find(s)
+    ...    for s in ("kn", "h_m", "rr", "tt", "not there")
+    ... )
+    True
     """
 
     # 1) Construct the failure array
@@ -57,6 +63,10 @@ def get_failure_array(pattern: str) -> list[int]:
 
 
 if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
     # Test 1)
     pattern = "abc1abc12"
     text1 = "alskfjaldsabc1abc1abc12k23adsfabcabc"

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     pattern = "abc1abc12"
     text1 = "alskfjaldsabc1abc1abc12k23adsfabcabc"
     text2 = "alskfjaldsk23adsfabcabc"
-    assert knuth_morris_pratt(text1, pattern) and not knuth_morris_pratt(text2, pattern)
+    assert knuth_morris_pratt(text1, pattern) and knuth_morris_pratt(text2, pattern)
 
     # Test 2)
     pattern = "ABABX"
@@ -78,6 +78,11 @@ if __name__ == "__main__":
     text = "abcxabcdabxabcdabcdabcy"
     assert knuth_morris_pratt(text, pattern)
 
-    # Test 5)
+    # Test 5) -> Doctest
+    pattern = "kn"
+    text = "knuthmorrispratt"
+    print( text.find("kn") == knuth_morris_pratt(text, pattern) )
+
+    # Test 6)
     pattern = "aabaabaaa"
     assert get_failure_array(pattern) == [0, 1, 0, 1, 2, 3, 4, 5, 2]

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     # Test 5) -> Doctest
     pattern = "kn"
     text = "knuthmorrispratt"
-    print( text.find("kn") == knuth_morris_pratt(text, pattern) )
+    print(text.find("kn") == knuth_morris_pratt(text, pattern))
 
     # Test 6)
     pattern = "aabaabaaa"

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -78,10 +78,14 @@ if __name__ == "__main__":
     text = "abcxabcdabxabcdabcdabcy"
     assert knuth_morris_pratt(text, pattern)
 
-    # Test 5) -> Doctest
-    pattern = "kn"
-    text = "knuthmorrispratt"
-    print(text.find("kn") == knuth_morris_pratt(text, pattern))
+    # Test 5) -> Doctests
+    kmp = "knuth_morris_pratt"
+    assert (knuth_morris_pratt(kmp, "kn") == kmp.find("kn"))
+    assert (knuth_morris_pratt(kmp, "h_m") == kmp.find("h_m"))
+    assert (knuth_morris_pratt(kmp, "rr") == kmp.find("rr"))
+    assert (knuth_morris_pratt(kmp, "tt") == kmp.find("tt"))
+    assert (knuth_morris_pratt(kmp, "not there") == kmp.find("not there"))
+    assert (all( knuth_morris_pratt(kmp, s) == kmp.find(s) for s in ( "kn", "h_m", "rr", "tt", "not there" ) ))
 
     # Test 6)
     pattern = "aabaabaaa"

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-def kmp(pattern: str, text: str) -> bool:
+def knuth_morris_pratt(text: str, pattern: str) -> int:
     """
     The Knuth-Morris-Pratt Algorithm for finding a pattern within a piece of text
     with complexity O(n + m)
@@ -24,7 +24,7 @@ def kmp(pattern: str, text: str) -> bool:
     while i < len(text):
         if pattern[j] == text[i]:
             if j == (len(pattern) - 1):
-                return j
+                return i-j
             j += 1
 
         # if this is a prefix in our pattern
@@ -61,22 +61,22 @@ if __name__ == "__main__":
     pattern = "abc1abc12"
     text1 = "alskfjaldsabc1abc1abc12k23adsfabcabc"
     text2 = "alskfjaldsk23adsfabcabc"
-    assert kmp(pattern, text1) and not kmp(pattern, text2)
+    assert knuth_morris_pratt(text1, pattern) and not knuth_morris_pratt(text2, pattern)
 
     # Test 2)
     pattern = "ABABX"
     text = "ABABZABABYABABX"
-    assert kmp(pattern, text)
+    assert knuth_morris_pratt(text, pattern)
 
     # Test 3)
     pattern = "AAAB"
     text = "ABAAAAAB"
-    assert kmp(pattern, text)
+    assert knuth_morris_pratt(text, pattern)
 
     # Test 4)
     pattern = "abcdabcy"
     text = "abcxabcdabxabcdabcdabcy"
-    assert kmp(pattern, text)
+    assert knuth_morris_pratt(text, pattern)
 
     # Test 5)
     pattern = "aabaabaaa"

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -80,12 +80,15 @@ if __name__ == "__main__":
 
     # Test 5) -> Doctests
     kmp = "knuth_morris_pratt"
-    assert (knuth_morris_pratt(kmp, "kn") == kmp.find("kn"))
-    assert (knuth_morris_pratt(kmp, "h_m") == kmp.find("h_m"))
-    assert (knuth_morris_pratt(kmp, "rr") == kmp.find("rr"))
-    assert (knuth_morris_pratt(kmp, "tt") == kmp.find("tt"))
-    assert (knuth_morris_pratt(kmp, "not there") == kmp.find("not there"))
-    assert (all( knuth_morris_pratt(kmp, s) == kmp.find(s) for s in ( "kn", "h_m", "rr", "tt", "not there" ) ))
+    assert knuth_morris_pratt(kmp, "kn") == kmp.find("kn")
+    assert knuth_morris_pratt(kmp, "h_m") == kmp.find("h_m")
+    assert knuth_morris_pratt(kmp, "rr") == kmp.find("rr")
+    assert knuth_morris_pratt(kmp, "tt") == kmp.find("tt")
+    assert knuth_morris_pratt(kmp, "not there") == kmp.find("not there")
+    assert all(
+        knuth_morris_pratt(kmp, s) == kmp.find(s)
+        for s in ("kn", "h_m", "rr", "tt", "not there")
+    )
 
     # Test 6)
     pattern = "aabaabaaa"

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -24,7 +24,7 @@ def kmp(pattern: str, text: str) -> bool:
     while i < len(text):
         if pattern[j] == text[i]:
             if j == (len(pattern) - 1):
-                return True
+                return j
             j += 1
 
         # if this is a prefix in our pattern
@@ -33,7 +33,7 @@ def kmp(pattern: str, text: str) -> bool:
             j = failure[j - 1]
             continue
         i += 1
-    return False
+    return -1
 
 
 def get_failure_array(pattern: str) -> list[int]:

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -24,7 +24,7 @@ def knuth_morris_pratt(text: str, pattern: str) -> int:
     while i < len(text):
         if pattern[j] == text[i]:
             if j == (len(pattern) - 1):
-                return i-j
+                return i - j
             j += 1
 
         # if this is a prefix in our pattern

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -14,7 +14,7 @@ def knuth_morris_pratt(text: str, pattern: str) -> int:
     2) Step through the text one character at a time and compare it to a character in
         the pattern updating our location within the pattern if necessary
 
-    >>> knuth_morris_pratt = "knuth_morris_pratt"
+    >>> kmp = "knuth_morris_pratt"
     >>> all(
     ...    knuth_morris_pratt(kmp, s) == kmp.find(s)
     ...    for s in ("kn", "h_m", "rr", "tt", "not there")

--- a/strings/knuth_morris_pratt.py
+++ b/strings/knuth_morris_pratt.py
@@ -80,11 +80,6 @@ if __name__ == "__main__":
 
     # Test 5) -> Doctests
     kmp = "knuth_morris_pratt"
-    assert knuth_morris_pratt(kmp, "kn") == kmp.find("kn")
-    assert knuth_morris_pratt(kmp, "h_m") == kmp.find("h_m")
-    assert knuth_morris_pratt(kmp, "rr") == kmp.find("rr")
-    assert knuth_morris_pratt(kmp, "tt") == kmp.find("tt")
-    assert knuth_morris_pratt(kmp, "not there") == kmp.find("not there")
     assert all(
         knuth_morris_pratt(kmp, s) == kmp.find(s)
         for s in ("kn", "h_m", "rr", "tt", "not there")


### PR DESCRIPTION
### Describe your change:

Returning the index of first occurrence of a match in knuth_morris_pratt algorithm. The return type is converted from boolean to int. The function name parameters are aligned to Python naming conventions. 
Fixes #9077


* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword : Fixes https://github.com/TheAlgorithms/Python/issues/9077".
