### PR TITLE
Fix DeprecationWarning in local_weighted_learning.py (Attempt 2)

### DIFF
--- a/machine_learning/local_weighted_learning/local_weighted_learning.py
+++ b/machine_learning/local_weighted_learning/local_weighted_learning.py
@@ -122,7 +122,7 @@ def local_weight_regression(
     """
     y_pred = np.zeros(len(x_train))  # Initialize array of predictions
     for i, item in enumerate(x_train):
-        y_pred[i] = np.dot(item, local_weight(item, x_train, y_train, tau))
+        y_pred[i] = np.dot(item, local_weight(item, x_train, y_train, tau)).item()
 
     return y_pred
 

--- a/machine_learning/local_weighted_learning/local_weighted_learning.py
+++ b/machine_learning/local_weighted_learning/local_weighted_learning.py
@@ -122,7 +122,7 @@ def local_weight_regression(
     """
     y_pred = np.zeros(len(x_train))  # Initialize array of predictions
     for i, item in enumerate(x_train):
-        y_pred[i] = item @ local_weight(item, x_train, y_train, tau)
+        y_pred[i] = np.dot(item, local_weight(item, x_train, y_train, tau))
 
     return y_pred
 


### PR DESCRIPTION
### Describe your change:

My previous PR #9165 didn't resolve the warning because `np.dot()` was still returning an `np.ndarray` rather than a scalar. I added a `.item()` call to explicitly extract the `np.ndarray`'s scalar entry.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
