### PR TITLE
Fixes#9331: Added Power of four logarithm solution

### DIFF
--- a/maths/power_of_four.py
+++ b/maths/power_of_four.py
@@ -1,4 +1,4 @@
-# Problem Statement:
+# Problem Statement: Link : https://leetcode.com/problems/power-of-four/description/
 # Given an integer n, return true if it is a power of four. Otherwise, return false.
 # An integer n is a power of four, if there exists an integer x such that n == 4x.
 # Example 1:

--- a/maths/power_of_four.py
+++ b/maths/power_of_four.py
@@ -1,0 +1,42 @@
+# Problem Statement:
+# Given an integer n, return true if it is a power of four. Otherwise, return false.
+# An integer n is a power of four, if there exists an integer x such that n == 4x.
+# Example 1:
+# Input: n = 16
+# Output: true
+
+# Example 2:
+# Input: n = 5
+# Output: false
+
+# Example 3:
+# Input: n = 1
+# Output: true
+
+
+
+# Intuition:
+# The intuition behind this code is based on the property of powers of four. In base-4 (quaternary) representation, any power of four will have only one '1' digit followed by zero or more '0' digits. 
+# For example, 4^0 = 1, 4^1 = 4, 4^2 = 16, and so on. In base-4, these numbers are represented as 1, 10, 100, and so on.
+# So, if you take the base-10 logarithm of a power of four and divide it by the base-10 logarithm of 4, you should get an integer. If you get an integer, it means the number is a power of four.
+
+# Time Complexity:
+# The time complexity of this code is O(1) because it involves basic mathematical operations like logarithms and integer checks, which have constant time complexity.
+
+#  Space Complexity:
+#  The space complexity of this code is also O(1) because it uses a constant amount of memory to store the result of the logarithmic calculation and the integer check. The space used is not dependent on the input value n, so it remains constant regardless of the size of n.
+
+
+import math
+
+def isPowerOfFour(n):
+    if n <= 0:
+        return False
+
+    logarithm4 = math.log10(n) / math.log10(4)
+
+    return logarithm4.is_integer()
+
+# Example usage:
+print(isPowerOfFour(16))  # Output: True
+print(isPowerOfFour(5))   # Output: False


### PR DESCRIPTION
### Describe your change:
Fixes #9331 issue
The intuition behind this code is based on the property of powers of four. 
In base-4 (quaternary) representation, any power of four will have only one '1' digit followed by zero or more '0' digits. 
For example, 4^0 = 1, 4^1 = 4, 4^2 = 16, and so on. In base-4, these numbers are represented as 1, 10, 100, and so on.
So, if you take the base-10 logarithm of a power of four and divide it by the base-10 logarithm of 4, you should get an integer. If you get an integer, it means the number is a power of four.


### Checklist:
* [✔ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [✔ ] This pull request is all my own work -- I have not plagiarized.
* [✔ ] I know that pull requests will not be merged if they fail the automated tests.
* [✔ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [✔ ] All new Python files are placed inside an existing directory.
* [✔ ] All filenames are in all lowercase characters with no spaces or dashes.
* [✔ ] All functions and variable names follow Python naming conventions.
* [✔ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [✔ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [✔ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ✔] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #9331 ".
