### PR TITLE
[bug fixing] Edge case of the double ended queue 

### DIFF
--- a/data_structures/queue/double_ended_queue.py
+++ b/data_structures/queue/double_ended_queue.py
@@ -242,12 +242,20 @@ class Deque:
         Removes the last element of the deque and returns it.
         Time complexity: O(1)
         @returns topop.val: the value of the node to pop.
-        >>> our_deque = Deque([1, 2, 3, 15182])
-        >>> our_popped = our_deque.pop()
-        >>> our_popped
+        >>> our_deque1 = Deque([1])
+        >>> our_popped1 = our_deque1.pop()
+        >>> our_popped1
+        1
+        >>> our_deque1
+        []
+
+        >>> our_deque2 = Deque([1, 2, 3, 15182])
+        >>> our_popped2 = our_deque2.pop()
+        >>> our_popped2
         15182
-        >>> our_deque
+        >>> our_deque2
         [1, 2, 3]
+
         >>> from collections import deque
         >>> deque_collections = deque([1, 2, 3, 15182])
         >>> collections_popped = deque_collections.pop()
@@ -255,18 +263,24 @@ class Deque:
         15182
         >>> deque_collections
         deque([1, 2, 3])
-        >>> list(our_deque) == list(deque_collections)
+        >>> list(our_deque2) == list(deque_collections)
         True
-        >>> our_popped == collections_popped
+        >>> our_popped2 == collections_popped
         True
         """
         # make sure the deque has elements to pop
         assert not self.is_empty(), "Deque is empty."
 
         topop = self._back
-        self._back = self._back.prev_node  # set new back
-        # drop the last node - python will deallocate memory automatically
-        self._back.next_node = None
+        # if only one value in the queue: point the front and back to None
+        # else remove one element from back
+        if self._front == self._back:
+            self._front = None
+            self._back = None
+        else:
+            self._back = self._back.prev_node  # set new back
+            # drop the last node, python will deallocate memory automatically
+            self._back.next_node = None
 
         self._len -= 1
 
@@ -277,11 +291,17 @@ class Deque:
         Removes the first element of the deque and returns it.
         Time complexity: O(1)
         @returns topop.val: the value of the node to pop.
-        >>> our_deque = Deque([15182, 1, 2, 3])
-        >>> our_popped = our_deque.popleft()
-        >>> our_popped
+        >>> our_deque1 = Deque([1])
+        >>> our_popped1 = our_deque1.pop()
+        >>> our_popped1
+        1
+        >>> our_deque1
+        []
+        >>> our_deque2 = Deque([15182, 1, 2, 3])
+        >>> our_popped2 = our_deque2.popleft()
+        >>> our_popped2
         15182
-        >>> our_deque
+        >>> our_deque2
         [1, 2, 3]
         >>> from collections import deque
         >>> deque_collections = deque([15182, 1, 2, 3])
@@ -290,17 +310,23 @@ class Deque:
         15182
         >>> deque_collections
         deque([1, 2, 3])
-        >>> list(our_deque) == list(deque_collections)
+        >>> list(our_deque2) == list(deque_collections)
         True
-        >>> our_popped == collections_popped
+        >>> our_popped2 == collections_popped
         True
         """
         # make sure the deque has elements to pop
         assert not self.is_empty(), "Deque is empty."
 
         topop = self._front
-        self._front = self._front.next_node  # set new front and drop the first node
-        self._front.prev_node = None
+        # if only one value in the queue: point the front and back to None
+        # else remove one element from front
+        if self._front == self._back:
+            self._front = None
+            self._back = None
+        else:
+            self._front = self._front.next_node  # set new front and drop the first node
+            self._front.prev_node = None
 
         self._len -= 1
 

--- a/data_structures/queue/double_ended_queue.py
+++ b/data_structures/queue/double_ended_queue.py
@@ -272,7 +272,7 @@ class Deque:
         assert not self.is_empty(), "Deque is empty."
 
         topop = self._back
-        # if only one value in the queue: point the front and back to None
+        # if only one element in the queue: point the front and back to None
         # else remove one element from back
         if self._front == self._back:
             self._front = None
@@ -319,7 +319,7 @@ class Deque:
         assert not self.is_empty(), "Deque is empty."
 
         topop = self._front
-        # if only one value in the queue: point the front and back to None
+        # if only one element in the queue: point the front and back to None
         # else remove one element from front
         if self._front == self._back:
             self._front = None
@@ -458,3 +458,5 @@ if __name__ == "__main__":
     import doctest
 
     doctest.testmod()
+    dq = Deque([3])
+    dq.pop()


### PR DESCRIPTION
### Describe your change:

I found a bug in double_ended_queue.py:
There is an error when popping the queue with only one element.
Code:
```python
  dq = Deque([3])
  dq.popleft()
```
Error in dq.popleft()
> self._front.prev_node = None
> AttributeError: 'NoneType' object has no attribute 'prev_node'

same as the pop:
code:
```python
dq = Deque([3])
dq.pop()
```
Error in dq.pop()
> self._back.next_node = None
> AttributeError: 'NoneType' object has no attribute 'next_node'

The fixing is to set both front and back pointers to None if there is only one element left in the queue before popping
I have written the test cases in the code and the tests are passed.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
