### PR TITLE
backtracking -> word_search - replacing the example in doctest

### DIFF
--- a/arithmetic_analysis/lu_decomposition.py
+++ b/arithmetic_analysis/lu_decomposition.py
@@ -88,15 +88,19 @@ def lower_upper_decomposition(table: np.ndarray) -> tuple[np.ndarray, np.ndarray
 
     lower = np.zeros((rows, columns))
     upper = np.zeros((rows, columns))
+
+    # in 'total', the necessary data is extracted through slices
+    # and the sum of the products is obtained.
+
     for i in range(columns):
         for j in range(i):
-            total = sum(lower[i][k] * upper[k][j] for k in range(j))
+            total = np.sum(lower[i, :i] * upper[:i, j])
             if upper[j][j] == 0:
                 raise ArithmeticError("No LU decomposition exists")
             lower[i][j] = (table[i][j] - total) / upper[j][j]
         lower[i][i] = 1
         for j in range(i, columns):
-            total = sum(lower[i][k] * upper[k][j] for k in range(j))
+            total = np.sum(lower[i, :i] * upper[:i, j])
             upper[i][j] = table[i][j] - total
     return lower, upper
 

--- a/arithmetic_analysis/lu_decomposition.py
+++ b/arithmetic_analysis/lu_decomposition.py
@@ -88,19 +88,15 @@ def lower_upper_decomposition(table: np.ndarray) -> tuple[np.ndarray, np.ndarray
 
     lower = np.zeros((rows, columns))
     upper = np.zeros((rows, columns))
-
-    # in 'total', the necessary data is extracted through slices
-    # and the sum of the products is obtained.
-
     for i in range(columns):
         for j in range(i):
-            total = np.sum(lower[i, :i] * upper[:i, j])
+            total = sum(lower[i][k] * upper[k][j] for k in range(j))
             if upper[j][j] == 0:
                 raise ArithmeticError("No LU decomposition exists")
             lower[i][j] = (table[i][j] - total) / upper[j][j]
         lower[i][i] = 1
         for j in range(i, columns):
-            total = np.sum(lower[i, :i] * upper[:i, j])
+            total = sum(lower[i][k] * upper[k][j] for k in range(j))
             upper[i][j] = table[i][j] - total
     return lower, upper
 

--- a/backtracking/word_search.py
+++ b/backtracking/word_search.py
@@ -98,13 +98,7 @@ def word_exists(board: list[list[str]], word: str) -> bool:
     False
     >>> word_exists([["A"]], "A")
     True
-    >>> word_exists([["A","A","A","A","A","A"],
-    ...              ["A","A","A","A","A","A"],
-    ...              ["A","A","A","A","A","A"],
-    ...              ["A","A","A","A","A","A"],
-    ...              ["A","A","A","A","A","B"],
-    ...              ["A","A","A","A","B","A"]],
-    ...             "AAAAAAAAAAAAABB")
+    >>> word_exists([["B", "A", "A"], ["A", "A", "A"], ["A", "B", "A"]], "ABB")
     False
     >>> word_exists([["A"]], 123)
     Traceback (most recent call last):


### PR DESCRIPTION
### Describe your change:

Contributes to https://github.com/TheAlgorithms/Python/issues/9718

I replaced  in this pull request 10188, the example in doctest with a less resource-intensive.

Before:
```
>>> word_exists([["A","A","A","A","A","A"],
...              ["A","A","A","A","A","A"],
...              ["A","A","A","A","A","A"],
...              ["A","A","A","A","A","A"],
...              ["A","A","A","A","A","B"],
...              ["A","A","A","A","B","A"]],
...             "AAAAAAAAAAAAABB")
False
```

After:

```
>>> word_exists([["B", "A", "A"], ["A", "A", "A"], ["A", "B", "A"]], "ABB")
False
```

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): " #ISSUE-9718".
