### PR TITLE
Omit `project_euler/` from coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,11 @@ addopts = [
 ]
 
 [tool.coverage.report]
-omit = [".env/*"]
+omit = [
+  ".env/*",
+  "project_euler/*",
+  "scripts/*"
+]
 sort = "Cover"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,7 @@ addopts = [
 [tool.coverage.report]
 omit = [
   ".env/*",
-  "project_euler/*",
-  "scripts/*"
+  "project_euler/*"
 ]
 sort = "Cover"
 


### PR DESCRIPTION
### Describe your change:

Our current `pytest` command for our builds is the following:
```
pytest --ignore=quantum/q_fourier_transform.py --ignore=project_euler/ --ignore=scripts/validate_solutions.py --cov-report=term-missing:skip-covered --cov=. .
```

Since we're not testing files in the `project_euler/` or `scripts/` directories, we should exclude them from our builds' coverage reports as well. `project_euler/` files in particular significantly clutter the reports.

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
