### PR TITLE
add monotonic queue algorithm

### DIFF
--- a/data_structures/queue/monotonic_queue.py
+++ b/data_structures/queue/monotonic_queue.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .double_ended_queue import Deque
+from collections import deque
 
 arr = [1, 3, -1, -3, 5, 3, 6, 7]
 window_size = 3
@@ -17,19 +17,19 @@ def max_sliding_window(arr: list[float], window_size: int) -> list[float]:
     True
     """
     max_val = []
-    queue = Deque()
+    mono_queue: deque = deque()
     for i in range(len(arr)):
         # pop the element if the index is outside the window size k
-        if queue and i - queue._front.val >= window_size:
-            queue.popleft()
+        if mono_queue and i - mono_queue[0] >= window_size:
+            mono_queue.popleft()
         # keep the queue monotonically decreasing
         # so that the max value is always on the top
-        while queue and arr[i] >= arr[queue._back.val]:
-            queue.pop()
-        queue.append(i)
+        while mono_queue and arr[i] >= arr[mono_queue[-1]]:
+            mono_queue.pop()
+        mono_queue.append(i)
         # the maximum value is the first element in queue
         if i >= window_size - 1:
-            max_val.append(arr[queue._front.val])
+            max_val.append(arr[mono_queue[0]])
     return max_val
 
 

--- a/data_structures/queue/monotonic_queue.py
+++ b/data_structures/queue/monotonic_queue.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
-from double_ended_queue import Deque
+from .double_ended_queue import Deque
 
 arr = [1, 3, -1, -3, 5, 3, 6, 7]
-k = 3
+window_size = 3
 expect = [3, 3, 5, 5, 6, 7]
 
 
-def max_sliding_window(arr: list[float], k: int) -> list[float]:
+def max_sliding_window(arr: list[float], window_size: int) -> list[float]:
     """
     Given an array of integers nums, there is a sliding window of size k which is moving
     from the very left of the array to the very right.
-    Each time the sliding window of length k moves right by one position.
+    Each time the sliding window of length window_size moves right by one position.
     Return the max sliding window.
-    >>> max_sliding_window(arr, k) == expect
+    >>> max_sliding_window(arr, window_size) == expect
     True
     """
     max_val = []
     queue = Deque()
     for i in range(len(arr)):
         # pop the element if the index is outside the window size k
-        if queue and i - queue._front.val >= k:
+        if queue and i - queue._front.val >= window_size:
             queue.popleft()
         # keep the queue monotonically decreasing
         # so that the max value is always on the top
@@ -28,7 +28,7 @@ def max_sliding_window(arr: list[float], k: int) -> list[float]:
             queue.pop()
         queue.append(i)
         # the maximum value is the first element in queue
-        if i >= k - 1:
+        if i >= window_size - 1:
             max_val.append(arr[queue._front.val])
     return max_val
 

--- a/data_structures/queue/monotonic_queue.py
+++ b/data_structures/queue/monotonic_queue.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from double_ended_queue import Deque
+
+arr = [1, 3, -1, -3, 5, 3, 6, 7]
+k = 3
+expect = [3, 3, 5, 5, 6, 7]
+
+
+def max_sliding_window(arr: list[float], k: int) -> list[float]:
+    """
+    Given an array of integers nums, there is a sliding window of size k which is moving
+    from the very left of the array to the very right.
+    Each time the sliding window of length k moves right by one position.
+    Return the max sliding window.
+    >>> max_sliding_window(arr, k) == expect
+    True
+    """
+    max_val = []
+    queue = Deque()
+    for i in range(len(arr)):
+        # pop the element if the index is outside the window size k
+        if queue and i - queue._front.val >= k:
+            queue.popleft()
+        # keep the queue monotonically decreasing
+        # so that the max value is always in the top
+        while queue and arr[i] >= arr[queue._back.val]:
+            queue.pop()
+        queue.append(i)
+        # the maximum value is the first element in queue
+        if i >= k - 1:
+            max_val.append(arr[queue._front.val])
+    return max_val
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()

--- a/data_structures/queue/monotonic_queue.py
+++ b/data_structures/queue/monotonic_queue.py
@@ -23,7 +23,7 @@ def max_sliding_window(arr: list[float], k: int) -> list[float]:
         if queue and i - queue._front.val >= k:
             queue.popleft()
         # keep the queue monotonically decreasing
-        # so that the max value is always in the top
+        # so that the max value is always on the top
         while queue and arr[i] >= arr[queue._back.val]:
             queue.pop()
         queue.append(i)


### PR DESCRIPTION
### Describe your change:

Similar the monotonic stack implementation in next_greater_element.py, I implemented an epic monotonical queue example: max_sliding_window which is to continuously generate max value in a sliding window over an array. 

I also implemented a test with one example and the test has passed.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
