### PR TITLE
Bug Fix: Integer overflow on windows in Project Euler 072

### DIFF
--- a/project_euler/problem_072/sol1.py
+++ b/project_euler/problem_072/sol1.py
@@ -36,7 +36,7 @@ def solution(limit: int = 1_000_000) -> int:
     """
 
     # generating an array from -1 to limit
-    phi = np.arange(-1, limit)
+    phi = np.arange(-1, limit, dtype=np.int64)
 
     for i in range(2, limit + 1):
         if phi[i] == i - 1:

--- a/project_euler/problem_072/sol1.py
+++ b/project_euler/problem_072/sol1.py
@@ -18,7 +18,7 @@ Number of numbers between 1 and n that are coprime to n is given by the Euler's 
 function, phi(n). So, the answer is simply the sum of phi(n) for 2 <= n <= 1,000,000
 Sum of phi(d), for all d|n = n. This result can be used to find phi(n) using a sieve.
 
-Time: 1 sec
+Time: 0.4 sec
 """
 
 import numpy as np
@@ -40,8 +40,7 @@ def solution(limit: int = 1_000_000) -> int:
 
     for i in range(2, limit + 1):
         if phi[i] == i - 1:
-            ind = np.arange(2 * i, limit + 1, i)  # indexes for selection
-            phi[ind] -= phi[ind] // i
+            phi[2 * i :: i] -= phi[2 * i :: i] // i
 
     return np.sum(phi[2 : limit + 1])
 

--- a/project_euler/problem_072/sol2.py
+++ b/project_euler/problem_072/sol2.py
@@ -20,6 +20,9 @@ for d ≤ 1,000,000?
 def solution(limit: int = 1000000) -> int:
     """
     Return the number of reduced proper fractions with denominator less than limit.
+
+    Time: 1 sec
+
     >>> solution(8)
     21
     >>> solution(1000)

--- a/project_euler/problem_072/sol2.py
+++ b/project_euler/problem_072/sol2.py
@@ -17,6 +17,30 @@ for d ≤ 1,000,000?
 """
 
 
+def set_generate_primes(limit: int) -> set:
+    """
+    Returns prime numbers below max_number.
+
+    >>> set_generate_primes(10)
+    {2, 3, 5, 7}
+    >>> set_generate_primes(2)
+    set()
+    """
+
+    if limit <= 2:
+        return set()
+
+    primes = set(range(3, limit, 2))
+    primes.add(2)
+
+    for p in range(3, limit, 2):
+        if p not in primes:
+            continue
+        primes.difference_update(set(range(p * p, limit, p)))
+
+    return primes
+
+
 def solution(limit: int = 1000000) -> int:
     """
     Return the number of reduced proper fractions with denominator less than limit.
@@ -28,13 +52,8 @@ def solution(limit: int = 1000000) -> int:
     >>> solution(1000)
     304191
     """
-    primes = set(range(3, limit, 2))
-    primes.add(2)
-    for p in range(3, limit, 2):
-        if p not in primes:
-            continue
-        primes.difference_update(set(range(p * p, limit, p)))
 
+    primes = set_generate_primes(limit)
     phi = [float(n) for n in range(limit + 1)]
 
     for p in primes:


### PR DESCRIPTION
### Describe your change:

- ### Bug Fix in Sol1.py
    - I've identified a bug in `sol1.py` that appears to be related to integer overflow. This issue specifically arises on Windows platforms because, by default, numpy on `Windows 64-bit` uses `32-bit integers`, whereas on `Linux`, it employs `64-bit integers`, so it also **went unnoticed in automated checking**.
- ### Sol2.py
    - Separated prime number generator from solution.
- ### Checked all Euler Problems
    - I've checked all other project euler solutions using the following command on both windows and linux.
        - `pytest scripts\validate_solutions.py`
- Both solutions have a runtime of less than or equal to 1 sec. So, I've not tried to optimize anything yet. Let me know if required.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ x This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
