### PR TITLE
closest_pair_of_points.py

### DIFF
--- a/divide_and_conquer/closest_pair_of_points.py
+++ b/divide_and_conquer/closest_pair_of_points.py
@@ -101,22 +101,24 @@ def closest_pair_of_points_sqr(points_sorted_on_x, points_sorted_on_y, points_co
     # recursion
     mid = points_counts // 2
     closest_in_left = closest_pair_of_points_sqr(
-        points_sorted_on_x, points_sorted_on_y[:mid], mid
-    )
-    closest_in_right = closest_pair_of_points_sqr(
-        points_sorted_on_y, points_sorted_on_y[mid:], points_counts - mid
-    )
-    closest_pair_dis = min(closest_in_left, closest_in_right)
+    points_sorted_on_x, points_sorted_on_y[:mid], mid
+)
+closest_in_right = closest_pair_of_points_sqr(
+    points_sorted_on_x, points_sorted_on_y[mid:], points_counts - mid
+)
+closest_pair_dis = min(closest_in_left, closest_in_right)
+
 
     """
     cross_strip contains the points, whose Xcoords are at a
     distance(< closest_pair_dis) from mid's Xcoord
     """
+cross_strip = []
+mid_x = points_sorted_on_x[mid][0]  # x-coordinate of the middle point
+for point in points_sorted_on_x:
+    if abs(point[0] - mid_x) < closest_pair_dis:
+        cross_strip.append(point)
 
-    cross_strip = []
-    for point in points_sorted_on_x:
-        if abs(point[0] - points_sorted_on_x[mid][0]) < closest_pair_dis:
-            cross_strip.append(point)
 
     closest_in_strip = dis_between_closest_in_strip(
         cross_strip, len(cross_strip), closest_pair_dis


### PR DESCRIPTION
1. in lines 103 to 109, i corrected the typo by changing the first argument in the call to `closest_pair_of_points_sqr` to `points_sorted_on_x` instead of `points_sorted_on_y`, as i've done below:

  `closest_in_left = closest_pair_of_points_sqr(
       points_sorted_on_x, points_sorted_on_y[:mid], mid
   )
   closest_in_right = closest_pair_of_points_sqr(
       points_sorted_on_x, points_sorted_on_y[mid:], points_counts - mid
   )
   closest_pair_dis = min(closest_in_left, closest_in_right)`

2. in lines 116 to 119, i've improved the code by considering the cross strip efficiently. I calculated `mid_x` to represent the x-coordinate of the middle point and used it to filter points within the strip. this ensures that only relevant points are considered and optimizes this part of the algorithm. The code now looks like this:

 `cross_strip = []
   mid_x = points_sorted_on_x[mid][0]  # x-coordinate of the middle point
   for point in points_sorted_on_x:
       if abs(point[0] - mid_x) < closest_pair_dis:
           cross_strip.append(point)`