### PR TITLE
Do not fix ruff EXE001 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ lint.ignore = [    # `ruff rule S101` for a description of that rule
   "B905",     # `zip()` without an explicit `strict=` parameter -- FIX ME
   "E741",     # Ambiguous variable name 'l' -- FIX ME
   "EM101",    # Exception must not use a string literal, assign to variable first
-  "EXE001",   # Shebang is present but file is not executable" -- DO NOT FIX
+  "EXE001",   # Shebang is present but file is not executable -- DO NOT FIX
   "G004",     # Logging statement uses f-string
   "PLC1901",  # `{}` can be simplified to `{}` as an empty string is falsey
   "PLW060",   # Using global for `{name}` but no assignment is done -- DO NOT FIX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ lint.ignore = [    # `ruff rule S101` for a description of that rule
   "B905",     # `zip()` without an explicit `strict=` parameter -- FIX ME
   "E741",     # Ambiguous variable name 'l' -- FIX ME
   "EM101",    # Exception must not use a string literal, assign to variable first
-  "EXE001",   # Shebang is present but file is not executable" -- FIX ME
+  "EXE001",   # Shebang is present but file is not executable" -- DO NOT FIX
   "G004",     # Logging statement uses f-string
   "PLC1901",  # `{}` can be simplified to `{}` as an empty string is falsey
   "PLW060",   # Using global for `{name}` but no assignment is done -- DO NOT FIX


### PR DESCRIPTION
### Describe your change:

Do not fix ruff `EXE001` rule

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
