### PR TITLE
Fixed issue with AVL tree del_node function causing RL rotation asser…

### DIFF
--- a/data_structures/binary_tree/avl_tree.py
+++ b/data_structures/binary_tree/avl_tree.py
@@ -223,7 +223,9 @@ def del_node(root: MyNode, data: Any) -> MyNode | None:
     right_child = root.get_right()
 
     if get_height(right_child) - get_height(left_child) == 2:
-        if right_child and get_height(right_child.get_right()) > get_height(right_child.get_left()):
+        if right_child and get_height(right_child.get_right()) > get_height(
+            right_child.get_left()
+        ):
             root = left_rotation(root)
         else:
             if right_child and right_child.get_left():
@@ -231,7 +233,9 @@ def del_node(root: MyNode, data: Any) -> MyNode | None:
             else:
                 print("Skipping RL rotation as conditions are not met")
     elif get_height(left_child) - get_height(right_child) == 2:
-        if left_child and get_height(left_child.get_left()) > get_height(left_child.get_right()):
+        if left_child and get_height(left_child.get_left()) > get_height(
+            left_child.get_right()
+        ):
             root = right_rotation(root)
         else:
             if left_child and left_child.get_right():
@@ -239,7 +243,9 @@ def del_node(root: MyNode, data: Any) -> MyNode | None:
             else:
                 print("Skipping LR rotation as conditions are not met")
 
-    root.set_height(my_max(get_height(root.get_left()), get_height(root.get_right())) + 1)
+    root.set_height(
+        my_max(get_height(root.get_left()), get_height(root.get_right())) + 1
+    )
     return root
 
 

--- a/data_structures/binary_tree/avl_tree.py
+++ b/data_structures/binary_tree/avl_tree.py
@@ -196,8 +196,12 @@ def get_left_most(root: MyNode) -> Any:
 
 
 def del_node(root: MyNode, data: Any) -> MyNode | None:
+    if root is None:
+        return None
+
     left_child = root.get_left()
     right_child = root.get_right()
+
     if root.get_data() == data:
         if left_child is not None and right_child is not None:
             temp_data = get_left_most(right_child)
@@ -210,31 +214,32 @@ def del_node(root: MyNode, data: Any) -> MyNode | None:
         else:
             return None
     elif root.get_data() > data:
-        if left_child is None:
-            print("No such data")
-            return root
-        else:
-            root.set_left(del_node(left_child, data))
-    # root.get_data() < data
-    elif right_child is None:
-        return root
+        root.set_left(del_node(left_child, data))
     else:
         root.set_right(del_node(right_child, data))
 
+    # Update left and right children after potential changes
+    left_child = root.get_left()
+    right_child = root.get_right()
+
     if get_height(right_child) - get_height(left_child) == 2:
-        assert right_child is not None
-        if get_height(right_child.get_right()) > get_height(right_child.get_left()):
+        if right_child and get_height(right_child.get_right()) > get_height(right_child.get_left()):
             root = left_rotation(root)
         else:
-            root = rl_rotation(root)
-    elif get_height(right_child) - get_height(left_child) == -2:
-        assert left_child is not None
-        if get_height(left_child.get_left()) > get_height(left_child.get_right()):
+            if right_child and right_child.get_left():
+                root = rl_rotation(root)
+            else:
+                print("Skipping RL rotation as conditions are not met")
+    elif get_height(left_child) - get_height(right_child) == 2:
+        if left_child and get_height(left_child.get_left()) > get_height(left_child.get_right()):
             root = right_rotation(root)
         else:
-            root = lr_rotation(root)
-    height = my_max(get_height(root.get_right()), get_height(root.get_left())) + 1
-    root.set_height(height)
+            if left_child and left_child.get_right():
+                root = lr_rotation(root)
+            else:
+                print("Skipping LR rotation as conditions are not met")
+
+    root.set_height(my_max(get_height(root.get_left()), get_height(root.get_right())) + 1)
     return root
 
 


### PR DESCRIPTION
### Describe your change:
This PR fixes the assertion error in the `del_node` function of the AVL tree implementation. The issue occurred during RL rotation when deleting a node. The fix ensures that the correct height calculations and rotations are performed, preventing the assertion error.

* [x] Fix a bug or typo in an existing algorithm

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #11502".
