### PR TITLE
Catboost regressor

### DIFF
--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -1,0 +1,83 @@
+# CatBoost Classifier Example
+import numpy as np
+from matplotlib import pyplot as plt
+from sklearn.datasets import load_iris
+from sklearn.metrics import ConfusionMatrixDisplay
+from sklearn.model_selection import train_test_split
+from catboost import CatBoostClassifier
+
+
+def data_handling(data: dict) -> tuple:
+    """
+    Extracts the features and target values from the provided dataset.
+
+    Args:
+        data (dict): A dictionary containing the dataset's features and targets.
+
+    Returns:
+        tuple: A tuple with features and targets.
+
+    Example:
+    >>> data_handling({'data':'[5.1, 3.5, 1.4, 0.2]', 'target': [0]})
+    ('[5.1, 3.5, 1.4, 0.2]', [0])
+    """
+    return data["data"], data["target"]
+
+
+def catboost(features: np.ndarray, target: np.ndarray) -> CatBoostClassifier:
+    """
+    Trains a CatBoostClassifier using the provided features and target.
+
+    Args:
+        features (np.ndarray): The input features for training the classifier.
+        target (np.ndarray): The target labels corresponding to the features.
+
+    Returns:
+        CatBoostClassifier: A trained CatBoost classifier.
+
+    Example:
+    >>> catboost(np.array([[5.1, 3.6, 1.4, 0.2]]), np.array([0]))
+    CatBoostClassifier(...)
+    """
+    classifier = CatBoostClassifier(verbose=0)  # Suppressing verbose output
+    classifier.fit(features, target)
+    return classifier
+
+
+def main() -> None:
+    """
+    Demonstrates the training and evaluation of a CatBoost classifier
+    on the Iris dataset, displaying a confusion matrix of the results.
+
+    The dataset is split into training and testing sets, the model is
+    trained on the training data, and then evaluated on the test data.
+    A normalized confusion matrix is displayed.
+    """
+
+    # Load the Iris dataset
+    iris = load_iris()
+    features, targets = data_handling(iris)
+    x_train, x_test, y_train, y_test = train_test_split(
+        features, targets, test_size=0.25
+    )
+
+    # Train a CatBoost classifier
+    catboost_classifier = catboost(x_train, y_train)
+
+    # Display the confusion matrix for the test data
+    ConfusionMatrixDisplay.from_estimator(
+        catboost_classifier,
+        x_test,
+        y_test,
+        display_labels=iris["target_names"],
+        cmap="Blues",
+        normalize="true",
+    )
+    plt.title("Normalized Confusion Matrix - IRIS Dataset")
+    plt.show()
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod(verbose=True)
+    main()

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -1,80 +1,91 @@
-# CatBoost Classifier Example
+"""
+CatBoost Regressor Example.
+
+This script demonstrates the usage of the CatBoost Regressor for a simple regression task.
+CatBoost is a powerful gradient boosting library that handles categorical features automatically
+and is highly efficient.
+
+Make sure to install CatBoost using:
+    pip install catboost
+
+Contributed by: @AHuzail
+"""
+
 import numpy as np
-from matplotlib import pyplot as plt
-from sklearn.datasets import load_iris
-from sklearn.metrics import ConfusionMatrixDisplay
+from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
-from catboost import CatBoostClassifier
+from sklearn.metrics import mean_squared_error
+from catboost import CatBoostRegressor
 
 
-def data_handling(data: dict) -> tuple:
+def data_handling() -> tuple:
     """
-    Extracts the features and target values from the provided dataset.
+    Loads and handles the dataset, splitting it into features and targets.
 
-    Args:
-        data (dict): A dictionary containing the dataset's features and targets.
-
+    The Boston dataset is used as a regression example.
+    
     Returns:
-        tuple: A tuple with features and targets.
+        tuple: A tuple of (features, target), where both are numpy arrays.
 
     Example:
-    >>> data_handling({'data':'[5.1, 3.5, 1.4, 0.2]', 'target': [0]})
-    ('[5.1, 3.5, 1.4, 0.2]', [0])
+    >>> features, target = data_handling()
+    >>> features.shape
+    (506, 13)
+    >>> target.shape
+    (506,)
     """
-    return data["data"], data["target"]
+    # Load Boston dataset (note: this dataset may be deprecated, replace if needed)
+    boston = load_boston()
+    features = boston.data
+    target = boston.target
+    return features, target
 
 
-def catboost(features: np.ndarray, target: np.ndarray) -> CatBoostClassifier:
+def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegressor:
     """
-    Trains a CatBoostClassifier using the provided features and target.
+    Trains a CatBoostRegressor using the provided features and target values.
 
     Args:
-        features (np.ndarray): The input features for training the classifier.
-        target (np.ndarray): The target labels corresponding to the features.
+        features (np.ndarray): The input features for the regression model.
+        target (np.ndarray): The target values for the regression model.
 
     Returns:
-        CatBoostClassifier: A trained CatBoost classifier.
+        CatBoostRegressor: A trained CatBoost regressor model.
 
     Example:
-    >>> catboost(np.array([[5.1, 3.6, 1.4, 0.2]]), np.array([0]))
-    CatBoostClassifier(...)
+    >>> features, target = data_handling()
+    >>> model = catboost_regressor(features, target)
+    >>> isinstance(model, CatBoostRegressor)
+    True
     """
-    classifier = CatBoostClassifier(verbose=0)  # Suppressing verbose output
-    classifier.fit(features, target)
-    return classifier
+    regressor = CatBoostRegressor(iterations=100, learning_rate=0.1, depth=6, verbose=0)
+    regressor.fit(features, target)
+    return regressor
 
 
 def main() -> None:
     """
-    Demonstrates the training and evaluation of a CatBoost classifier
-    on the Iris dataset, displaying a confusion matrix of the results.
+    Main function to run the CatBoost Regressor example.
 
-    The dataset is split into training and testing sets, the model is
-    trained on the training data, and then evaluated on the test data.
-    A normalized confusion matrix is displayed.
+    It loads the data, splits it into training and testing sets,
+    trains the regressor on the training data, and evaluates its performance
+    on the test data.
     """
-
-    # Load the Iris dataset
-    iris = load_iris()
-    features, targets = data_handling(iris)
+    # Load and split the dataset
+    features, target = data_handling()
     x_train, x_test, y_train, y_test = train_test_split(
-        features, targets, test_size=0.25
+        features, target, test_size=0.25, random_state=42
     )
 
-    # Train a CatBoost classifier
-    catboost_classifier = catboost(x_train, y_train)
+    # Train CatBoost Regressor
+    regressor = catboost_regressor(x_train, y_train)
 
-    # Display the confusion matrix for the test data
-    ConfusionMatrixDisplay.from_estimator(
-        catboost_classifier,
-        x_test,
-        y_test,
-        display_labels=iris["target_names"],
-        cmap="Blues",
-        normalize="true",
-    )
-    plt.title("Normalized Confusion Matrix - IRIS Dataset")
-    plt.show()
+    # Predict on the test set
+    predictions = regressor.predict(x_test)
+
+    # Evaluate the performance using Mean Squared Error
+    mse = mean_squared_error(y_test, predictions)
+    print(f"Mean Squared Error on Test Set: {mse:.4f}")
 
 
 if __name__ == "__main__":

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -21,7 +21,7 @@ from catboost import CatBoostRegressor
 def data_handling() -> tuple:
     """
     Loads and handles the California Housing dataset (replacement for deprecated Boston dataset).
-    
+
     Returns:
         tuple: A tuple of (features, target), where both are numpy arrays.
 
@@ -45,11 +45,11 @@ def data_handling() -> tuple:
 def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegressor:
     """
     Trains a CatBoostRegressor using the provided features and target values.
-    
+
     Args:
         features (np.ndarray): The input features for the regression model.
         target (np.ndarray): The target values for the regression model.
-    
+
     Returns:
         CatBoostRegressor: A trained CatBoost regressor model.
 
@@ -67,7 +67,7 @@ def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegr
 def main() -> None:
     """
     Main function to run the CatBoost Regressor example.
-    
+
     It loads the data, splits it into training and testing sets,
     trains the regressor on the training data, and evaluates its performance
     on the test data.
@@ -95,5 +95,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(verbose=True)
     main()

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -23,7 +23,7 @@ def data_handling() -> tuple:
     Loads and handles the dataset, splitting it into features and targets.
 
     The Boston dataset is used as a regression example.
-    
+
     Returns:
         tuple: A tuple of (features, target), where both are numpy arrays.
 
@@ -90,5 +90,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(verbose=True)
     main()

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -2,8 +2,8 @@
 CatBoost Regressor Example.
 
 This script demonstrates the usage of the CatBoost Regressor for a simple regression task.
-CatBoost is a powerful gradient boosting library that handles categorical features automatically
-and is highly efficient.
+CatBoost is a powerful gradient boosting library that handles categorical features
+automatically and is highly efficient.
 
 Make sure to install CatBoost using:
     pip install catboost
@@ -13,8 +13,8 @@ Contributed by: @AHuzail
 
 import numpy as np
 from sklearn.datasets import fetch_california_housing
-from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
 from catboost import CatBoostRegressor
 
 
@@ -59,7 +59,9 @@ def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegr
     >>> isinstance(model, CatBoostRegressor)
     True
     """
-    regressor = CatBoostRegressor(iterations=100, learning_rate=0.1, depth=6, verbose=0)
+    regressor = CatBoostRegressor(
+        iterations=100, learning_rate=0.1, depth=6, verbose=0
+    )
     regressor.fit(features, target)
     return regressor
 

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -59,9 +59,7 @@ def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegr
     >>> isinstance(model, CatBoostRegressor)
     True
     """
-    regressor = CatBoostRegressor(
-        iterations=100, learning_rate=0.1, depth=6, verbose=0
-    )
+    regressor = CatBoostRegressor(iterations=100, learning_rate=0.1, depth=6, verbose=0)
     regressor.fit(features, target)
     return regressor
 

--- a/machine_learning/catboost_regressor.py
+++ b/machine_learning/catboost_regressor.py
@@ -12,7 +12,7 @@ Contributed by: @AHuzail
 """
 
 import numpy as np
-from sklearn.datasets import load_boston
+from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_squared_error
 from catboost import CatBoostRegressor
@@ -20,35 +20,36 @@ from catboost import CatBoostRegressor
 
 def data_handling() -> tuple:
     """
-    Loads and handles the dataset, splitting it into features and targets.
-
-    The Boston dataset is used as a regression example.
-
+    Loads and handles the California Housing dataset (replacement for deprecated Boston dataset).
+    
     Returns:
         tuple: A tuple of (features, target), where both are numpy arrays.
 
     Example:
     >>> features, target = data_handling()
+    >>> isinstance(features, np.ndarray)
+    True
+    >>> isinstance(target, np.ndarray)
+    True
     >>> features.shape
-    (506, 13)
+    (20640, 8)
     >>> target.shape
-    (506,)
+    (20640,)
     """
-    # Load Boston dataset (note: this dataset may be deprecated, replace if needed)
-    boston = load_boston()
-    features = boston.data
-    target = boston.target
+    housing = fetch_california_housing()
+    features = housing.data
+    target = housing.target
     return features, target
 
 
 def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegressor:
     """
     Trains a CatBoostRegressor using the provided features and target values.
-
+    
     Args:
         features (np.ndarray): The input features for the regression model.
         target (np.ndarray): The target values for the regression model.
-
+    
     Returns:
         CatBoostRegressor: A trained CatBoost regressor model.
 
@@ -66,10 +67,14 @@ def catboost_regressor(features: np.ndarray, target: np.ndarray) -> CatBoostRegr
 def main() -> None:
     """
     Main function to run the CatBoost Regressor example.
-
+    
     It loads the data, splits it into training and testing sets,
     trains the regressor on the training data, and evaluates its performance
     on the test data.
+
+    Example:
+    >>> main()
+    Mean Squared Error on Test Set:
     """
     # Load and split the dataset
     features, target = data_handling()
@@ -90,6 +95,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
-
     doctest.testmod(verbose=True)
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+catboost
 fake_useragent
 imageio
 keras
@@ -22,4 +23,3 @@ tweepy
 # yulewalker  # uncomment once audio_filters/equal_loudness_filter.py is fixed
 typing_extensions
 xgboost
-catboost

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tweepy
 # yulewalker  # uncomment once audio_filters/equal_loudness_filter.py is fixed
 typing_extensions
 xgboost
+catboost

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-catboost
+catboost == 1.2
 fake_useragent
 imageio
 keras

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-catboost == 1.2
+catboost
 fake_useragent
 imageio
 keras


### PR DESCRIPTION
# Add CatBoost Regressor Example
[x] Added Algorithm
### Changes:
- Added a Python script `catboost_regressor.py` that implements a CatBoost Regressor using the California Housing dataset.
- Included doctests to validate the `data_handling` and `catboost_regressor` functions.
- Used Mean Squared Error (MSE) to evaluate model performance.

### Doctests:
- Included for `data_handling()` and `catboost_regressor()` functions.

### Dependencies:
- `catboost`, `scikit-learn`, `numpy`

### Example Output:
```bash
Mean Squared Error on Test Set: <calculated_value>
