### PR TITLE
Doomsday Algorithm: Fix leap year check

### DIFF
--- a/other/doomsday.py
+++ b/other/doomsday.py
@@ -46,7 +46,7 @@ def get_week_day(year: int, month: int, day: int) -> str:
     ) % 7
     day_anchor = (
         DOOMSDAY_NOT_LEAP[month - 1]
-        if (year % 4 != 0) or (centurian == 0 and (year % 400) == 0)
+        if (year % 4 != 0) or (centurian == 0 and (year % 400) != 0)
         else DOOMSDAY_LEAP[month - 1]
     )
     week_day = (dooms_day + day - day_anchor) % 7

--- a/other/doomsday.py
+++ b/other/doomsday.py
@@ -46,7 +46,7 @@ def get_week_day(year: int, month: int, day: int) -> str:
     ) % 7
     day_anchor = (
         DOOMSDAY_NOT_LEAP[month - 1]
-        if (year % 4 != 0) or (centurian == 0 and (year % 400) != 0)
+        if (year % 4 != 0) or ((centurian == 0) and (year % 400 != 0))
         else DOOMSDAY_LEAP[month - 1]
     )
     week_day = (dooms_day + day - day_anchor) % 7

--- a/other/doomsday.py
+++ b/other/doomsday.py
@@ -46,7 +46,7 @@ def get_week_day(year: int, month: int, day: int) -> str:
     ) % 7
     day_anchor = (
         DOOMSDAY_NOT_LEAP[month - 1]
-        if (year % 4 != 0) or ((centurian == 0) and (year % 400 != 0))
+        if year % 4 != 0 or (centurian == 0 and year % 400 != 0)
         else DOOMSDAY_LEAP[month - 1]
     )
     week_day = (dooms_day + day - day_anchor) % 7


### PR DESCRIPTION
Replace `!=` in `(year % 400) != 0` (line 49) with `==`

Justification: Years that are divisible by 100 (centurian == 100) but not by 400 (year % 400 != 0) are skipped and NOT leap year.

### Describe your change:



* [ ] Add an algorithm?
* [X] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [X] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
