### PR TITLE
Add Functional Programming Pipeline with Unix Pipeline Syntax

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -856,6 +856,7 @@
   * [Nested Brackets](other/nested_brackets.py)
   * [Number Container System](other/number_container_system.py)
   * [Password](other/password.py)
+  * [Pipeline](other/pipeline.py)
   * [Quine](other/quine.py)
   * [Scoring Algorithm](other/scoring_algorithm.py)
   * [Sdes](other/sdes.py)

--- a/other/pipeline.py
+++ b/other/pipeline.py
@@ -1,0 +1,46 @@
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+class Pipeline:
+    """
+    Functional Programming implementation of a Pipeline with Unix Pipe Syntax.
+    Instead of using the "dot" notation for applying a function on a given object,
+    it uses `|` inspired from unix pipeline.
+
+    Examples:
+        >>> pipeline = Pipeline()
+        >>> pipeline = pipeline | (lambda x: x + 1) | (lambda x: x * 2)
+        >>> pipeline(1)
+        4
+        >>> pipeline = Pipeline() | (lambda x: x * x) | (lambda x: x - 3)
+        >>> pipeline(3)
+        6
+        >>> from functools import reduce
+        >>> def f1(ls): return map(lambda x: x**2, ls)
+        >>> def f2(ls): return filter(lambda x: x % 2 == 0, ls)
+        >>> def f3(ls): return reduce(lambda x, y: x + y, ls)
+        >>> pipeline = Pipeline() | f1 | f2 | f3
+        >>> pipeline([1, 2, 3, 4])
+        20
+    """
+
+    def __init__(self, f_ls: Sequence[Callable] | None = None):
+        self._f_ls = f_ls or []
+
+    def __or__(self, other: Callable) -> "Pipeline":
+        return Pipeline(f_ls=[*self._f_ls, other])
+
+    def __call__(self, x: T, f_ls_: Sequence[Callable] | None = None) -> Any:
+        f_ls = f_ls_ or self._f_ls
+        if len(f_ls) == 1:
+            return f_ls[0](x)
+        return self(f_ls[0](x), f_ls_=f_ls[1:])
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/other/pipeline.py
+++ b/other/pipeline.py
@@ -27,17 +27,17 @@ class Pipeline:
         20
     """
 
-    def __init__(self, f_ls: Sequence[Callable] | None = None):
+    def __init__(self, f_ls: Sequence[Callable] | None = None) -> None:
         self._f_ls = f_ls or []
 
     def __or__(self, other: Callable) -> "Pipeline":
         return Pipeline(f_ls=[*self._f_ls, other])
 
-    def __call__(self, x: T, f_ls_: Sequence[Callable] | None = None) -> Any:
+    def __call__(self, input_object: T, f_ls_: Sequence[Callable] | None = None) -> Any:
         f_ls = f_ls_ or self._f_ls
         if len(f_ls) == 1:
-            return f_ls[0](x)
-        return self(f_ls[0](x), f_ls_=f_ls[1:])
+            return f_ls[0](input_object)
+        return self(f_ls[0](input_object), f_ls_=f_ls[1:])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your change:
Functional Programming implementation of a Pipeline with Unix Pipe Syntax. Instead of using the "dot" notation for applying a function on a given object, it uses `|` inspired from unix pipeline.

* [X] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [X] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [X] All new Python files are placed inside an existing directory.
* [X] All filenames are in all lowercase characters with no spaces or dashes.
* [X] All functions and variable names follow Python naming conventions.
* [X] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [X] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [X] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [X] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
