### PR TITLE
Fix sphinx/build_docs warnings for physics/newtons_second_law_of_motion

### DIFF
--- a/physics/newtons_second_law_of_motion.py
+++ b/physics/newtons_second_law_of_motion.py
@@ -13,8 +13,7 @@ Description:
 
 Source: https://www.physicsclassroom.com/class/newtlaws/Lesson-3/Newton-s-Second-Law
 
-Formulation:
-    .. math:: F_{net} = m \cdot a
+Formulation: F_net = m • a
 
 Diagrammatic Explanation::
 
@@ -38,8 +37,7 @@ Diagrammatic Explanation::
    |                  |    | mass               |
    |__________________|    |____________________|
 
-Units:
-    .. math:: 1 \  Newton = 1 \  kg \times \frac{meters}{seconds^2}
+Units: 1 Newton = 1 kg • meters/seconds^2
 
 How to use?
 

--- a/physics/newtons_second_law_of_motion.py
+++ b/physics/newtons_second_law_of_motion.py
@@ -2,8 +2,8 @@ r"""
 Description:
     Newton's second law of motion pertains to the behavior of objects for which
     all existing forces are not balanced.
-    The second law states that the acceleration of an object is dependent upon two variables
-    - the net force acting upon the object and the mass of the object.
+    The second law states that the acceleration of an object is dependent upon
+    two variables - the net force acting upon the object and the mass of the object.
     The acceleration of an object depends directly
     upon the net force acting upon the object,
     and inversely upon the mass of the object.

--- a/physics/newtons_second_law_of_motion.py
+++ b/physics/newtons_second_law_of_motion.py
@@ -34,7 +34,7 @@ Diagrammatic Explanation::
     __________________      ____________________
    | The acceleration |    | The acceleration   |
    | depends directly |    | depends inversely  |
-   | on the net Force |    | upon the object's  |
+   | on the net force |    | upon the object's  |
    |                  |    | mass               |
    |__________________|    |____________________|
 
@@ -66,6 +66,8 @@ Output::
 
 def newtons_second_law_of_motion(mass: float, acceleration: float) -> float:
     """
+    Calculates force from `mass` and `acceleration`
+
     >>> newtons_second_law_of_motion(10, 10)
     100
     >>> newtons_second_law_of_motion(2.0, 1)

--- a/physics/newtons_second_law_of_motion.py
+++ b/physics/newtons_second_law_of_motion.py
@@ -1,18 +1,23 @@
-"""
-Description :
-Newton's second law of motion pertains to the behavior of objects for which
-all existing forces are not balanced.
-The second law states that the acceleration of an object is dependent upon two variables
-- the net force acting upon the object and the mass of the object.
-The acceleration of an object depends directly
-upon the net force acting upon the object,
-and inversely upon the mass of the object.
-As the force acting upon an object is increased,
-the acceleration of the object is increased.
-As the mass of an object is increased, the acceleration of the object is decreased.
+r"""
+Description:
+    Newton's second law of motion pertains to the behavior of objects for which
+    all existing forces are not balanced.
+    The second law states that the acceleration of an object is dependent upon two variables
+    - the net force acting upon the object and the mass of the object.
+    The acceleration of an object depends directly
+    upon the net force acting upon the object,
+    and inversely upon the mass of the object.
+    As the force acting upon an object is increased,
+    the acceleration of the object is increased.
+    As the mass of an object is increased, the acceleration of the object is decreased.
+
 Source: https://www.physicsclassroom.com/class/newtlaws/Lesson-3/Newton-s-Second-Law
-Formulation: Fnet = m • a
-Diagrammatic Explanation:
+
+Formulation:
+    .. math:: F_{net} = m \cdot a
+
+Diagrammatic Explanation::
+
               Forces are unbalanced
                         |
                         |
@@ -26,29 +31,35 @@ Diagrammatic Explanation:
                     /        \
                    /          \
                   /            \
-        __________________   ____ ________________
-        |The acceleration |  |The acceleration   |
-        |depends directly |  |depends inversely  |
-        |on the net Force |  |upon the object's  |
-        |_________________|  |mass_______________|
-Units:
-1 Newton = 1 kg X meters / (seconds^2)
-How to use?
-Inputs:
-    ___________________________________________________
-   |Name         | Units                   | Type      |
-   |-------------|-------------------------|-----------|
-   |mass         | (in kgs)                | float     |
-   |-------------|-------------------------|-----------|
-   |acceleration | (in meters/(seconds^2)) | float     |
-   |_____________|_________________________|___________|
+    __________________      ____________________
+   | The acceleration |    | The acceleration   |
+   | depends directly |    | depends inversely  |
+   | on the net Force |    | upon the object's  |
+   |                  |    | mass               |
+   |__________________|    |____________________|
 
-Output:
-    ___________________________________________________
-   |Name         | Units                   | Type      |
-   |-------------|-------------------------|-----------|
-   |force        | (in Newtons)            | float     |
-   |_____________|_________________________|___________|
+Units:
+    .. math:: 1 \  Newton = 1 \  kg \times \frac{meters}{seconds^2}
+
+How to use?
+
+Inputs::
+
+    ______________ _____________________ ___________
+   | Name         | Units               | Type      |
+   |--------------|---------------------|-----------|
+   | mass         | in kgs              | float     |
+   |--------------|---------------------|-----------|
+   | acceleration | in meters/seconds^2 | float     |
+   |______________|_____________________|___________|
+
+Output::
+
+    ______________ _______________________ ___________
+   | Name         | Units                 | Type      |
+   |--------------|-----------------------|-----------|
+   | force        | in Newtons            | float     |
+   |______________|_______________________|___________|
 
 """
 


### PR DESCRIPTION
### Describe your change:

Fix sphinx/build_docs warnings for physics/newtons_second_law_of_motion

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
