### PR TITLE
Fix sphinx/build_docs warnings for maths/zellers_congruence

### DIFF
--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -4,13 +4,14 @@ import datetime
 
 def zeller(date_input: str) -> str:
     """
-    Zellers Congruence Algorithm
-    Find the day of the week for nearly any Gregorian or Julian calendar date
+    | Zellers Congruence Algorithm
+    | Find the day of the week for nearly any Gregorian or Julian calendar date
 
     >>> zeller('01-31-2010')
     'Your date 01-31-2010, is a Sunday!'
 
-    Validate out of range month
+    Validate out of range month:
+
     >>> zeller('13-31-2010')
     Traceback (most recent call last):
         ...
@@ -21,6 +22,7 @@ def zeller(date_input: str) -> str:
     ValueError: invalid literal for int() with base 10: '.2'
 
     Validate out of range date:
+
     >>> zeller('01-33-2010')
     Traceback (most recent call last):
         ...
@@ -31,30 +33,35 @@ def zeller(date_input: str) -> str:
     ValueError: invalid literal for int() with base 10: '.4'
 
     Validate second separator:
+
     >>> zeller('01-31*2010')
     Traceback (most recent call last):
         ...
     ValueError: Date separator must be '-' or '/'
 
     Validate first separator:
+
     >>> zeller('01^31-2010')
     Traceback (most recent call last):
         ...
     ValueError: Date separator must be '-' or '/'
 
     Validate out of range year:
+
     >>> zeller('01-31-8999')
     Traceback (most recent call last):
         ...
     ValueError: Year out of range. There has to be some sort of limit...right?
 
     Test null input:
+
     >>> zeller()
     Traceback (most recent call last):
         ...
     TypeError: zeller() missing 1 required positional argument: 'date_input'
 
     Test length of date_input:
+
     >>> zeller('')
     Traceback (most recent call last):
         ...

--- a/maths/zellers_congruence.py
+++ b/maths/zellers_congruence.py
@@ -60,7 +60,7 @@ def zeller(date_input: str) -> str:
         ...
     TypeError: zeller() missing 1 required positional argument: 'date_input'
 
-    Test length of date_input:
+    Test length of `date_input`:
 
     >>> zeller('')
     Traceback (most recent call last):


### PR DESCRIPTION
### Describe your change:

Fix sphinx/build_docs warnings for maths/zellers_congruence

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
