### PR TITLE
Update longest_increasing_subsequence.py

### DIFF
--- a/dynamic_programming/longest_increasing_subsequence.py
+++ b/dynamic_programming/longest_increasing_subsequence.py
@@ -11,6 +11,12 @@ The problem is:
 Example:
     ``[10, 22, 9, 33, 21, 50, 41, 60, 80]`` as input will return
     ``[10, 22, 33, 41, 60, 80]`` as output
+
+Sorry, this doesn't work for this counter-example:
+    ``[28, 26, 12, 23, 35, 39]`` as input will return
+    ``[26, 35, 39]`` as output
+    instead of
+    ``[12, 23, 35, 39]`` as output
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Counter-example that doesn't return the longest increasing subsequence

### Describe your change:
The algorithm longest_increasing_subsequence.py has a bug for the sequence [28, 26, 12, 23, 35, 39] as it returns [26, 35, 39] instead of [12, 23, 35, 39]. (No change in code has been done).

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [X] Indicate a bug in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [X] This pull request is all my own work -- I have not plagiarized.
* [X] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
