### PR TITLE
Fix bug for data_structures/linked_list/doubly_linked_list_two.py

### DIFF
--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -244,7 +244,7 @@ def create_linked_list() -> None:
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
     LinkedList(head=Node(data=10, previous=None, next=None),
-    tail=Node(data=10, previous=None, next=None))
+     tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -237,17 +237,24 @@ def create_linked_list() -> None:
     8
     9
     >>> linked_list = LinkedList()
+    >>> linked_list
+    >>> str(linked_list)
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
+    >>> str(linked_list)
     LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     >>> linked_list.insert_at_position(position=2, value=20)
     >>> linked_list
+    >>> str(linked_list)
     >>> linked_list.insert_at_position(position=1, value=30)
     >>> linked_list
+    >>> str(linked_list)
     >>> linked_list.insert_at_position(position=2, value=40)
     >>> linked_list
+    >>> str(linked_list)
     >>> linked_list.insert_at_position(position=3, value=50)
     >>> linked_list
+    >>> str(linked_list)
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -245,18 +245,23 @@ def create_linked_list() -> None:
     >>> linked_list
     LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
+    '10'
     >>> linked_list.insert_at_position(position=2, value=20)
     >>> linked_list
     >>> str(linked_list)
+    '10 20'
     >>> linked_list.insert_at_position(position=1, value=30)
     >>> linked_list
     >>> str(linked_list)
-    >>> linked_list.insert_at_position(position=2, value=40)
+    '30 10 20'
+    >>> linked_list.insert_at_position(position=3, value=40)
     >>> linked_list
     >>> str(linked_list)
-    >>> linked_list.insert_at_position(position=3, value=50)
+    '30 10 40 20'
+    >>> linked_list.insert_at_position(position=5, value=50)
     >>> linked_list
     >>> str(linked_list)
+    '30 10 40 20 50'
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -244,7 +244,7 @@ def create_linked_list() -> None:
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
     LinkedList(head=Node(data=10, previous=None, next=None),
-     tail=Node(data=10, previous=None, next=None))
+    ... tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -126,7 +126,7 @@ class LinkedList:
                 return
             current_position += 1
             node = node.next
-        self.insert_after_node(self.tail, new_node)
+        self.set_tail(new_node)
 
     def get_node(self, item: int) -> Node:
         node = self.head
@@ -238,6 +238,7 @@ def create_linked_list() -> None:
     9
     >>> linked_list = LinkedList()
     >>> linked_list.insert_at_position(position=1, value=10)
+    >>> linked_list
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -243,7 +243,7 @@ def create_linked_list() -> None:
     ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
-    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
+    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))  # noqa: E501
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -243,9 +243,8 @@ def create_linked_list() -> None:
     ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
-    LinkedList(
-        head=Node(data=10, previous=None, next=None),
-        tail=Node(data=10, previous=None, next=None))
+    LinkedList(head=Node(data=10, previous=None, next=None),
+    tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -241,9 +241,13 @@ def create_linked_list() -> None:
     >>> linked_list
     LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     >>> linked_list.insert_at_position(position=2, value=20)
+    >>> linked_list
     >>> linked_list.insert_at_position(position=1, value=30)
+    >>> linked_list
     >>> linked_list.insert_at_position(position=2, value=40)
+    >>> linked_list
     >>> linked_list.insert_at_position(position=3, value=50)
+    >>> linked_list
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -236,6 +236,8 @@ def create_linked_list() -> None:
     7
     8
     9
+    >>> linked_list = LinkedList()
+    >>> linked_list.insert_at_position(position=1, value=10)
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -243,8 +243,7 @@ def create_linked_list() -> None:
     ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
-    LinkedList(head=Node(data=10, previous=None, next=None),
-    ... tail=Node(data=10, previous=None, next=None))
+    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -240,6 +240,7 @@ def create_linked_list() -> None:
     >>> linked_list
     LinkedList(head=None, tail=None)
     >>> str(linked_list)
+    ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
     >>> str(linked_list)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -243,23 +243,20 @@ def create_linked_list() -> None:
     ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
-    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
+    LinkedList(
+        head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)
-    >>> linked_list
     >>> str(linked_list)
     '10 20'
     >>> linked_list.insert_at_position(position=1, value=30)
-    >>> linked_list
     >>> str(linked_list)
     '30 10 20'
     >>> linked_list.insert_at_position(position=3, value=40)
-    >>> linked_list
     >>> str(linked_list)
     '30 10 40 20'
     >>> linked_list.insert_at_position(position=5, value=50)
-    >>> linked_list
     >>> str(linked_list)
     '30 10 40 20 50'
     """

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -244,7 +244,8 @@ def create_linked_list() -> None:
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
     LinkedList(
-        head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
+        head=Node(data=10, previous=None, next=None),
+        tail=Node(data=10, previous=None, next=None))
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -81,8 +81,9 @@ class LinkedList:
             self.insert_before_node(self.head, node)
 
     def set_tail(self, node: Node) -> None:
-        if self.head is None:
-            self.set_head(node)
+        if self.tail is None:
+            self.head = node
+            self.tail = node
         else:
             self.insert_after_node(self.tail, node)
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -238,6 +238,7 @@ def create_linked_list() -> None:
     9
     >>> linked_list = LinkedList()
     >>> linked_list
+    LinkedList(head=None, tail=None)
     >>> str(linked_list)
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -237,13 +237,7 @@ def create_linked_list() -> None:
     8
     9
     >>> linked_list = LinkedList()
-    >>> linked_list
-    LinkedList(head=None, tail=None)
-    >>> str(linked_list)
-    ''
     >>> linked_list.insert_at_position(position=1, value=10)
-    >>> linked_list
-    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))  # noqa: E501
     >>> str(linked_list)
     '10'
     >>> linked_list.insert_at_position(position=2, value=20)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -243,8 +243,8 @@ def create_linked_list() -> None:
     ''
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
-    >>> str(linked_list)
     LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
+    >>> str(linked_list)
     >>> linked_list.insert_at_position(position=2, value=20)
     >>> linked_list
     >>> str(linked_list)

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -239,6 +239,7 @@ def create_linked_list() -> None:
     >>> linked_list = LinkedList()
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
+    LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -240,6 +240,10 @@ def create_linked_list() -> None:
     >>> linked_list.insert_at_position(position=1, value=10)
     >>> linked_list
     LinkedList(head=Node(data=10, previous=None, next=None), tail=Node(data=10, previous=None, next=None))
+    >>> linked_list.insert_at_position(position=2, value=20)
+    >>> linked_list.insert_at_position(position=1, value=30)
+    >>> linked_list.insert_at_position(position=2, value=40)
+    >>> linked_list.insert_at_position(position=3, value=50)
     """
 
 

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -104,9 +104,7 @@ class LinkedList:
 
         node.previous = node_to_insert
 
-    def insert_after_node(self, node: Node | None, node_to_insert: Node) -> None:
-        assert node is not None
-
+    def insert_after_node(self, node: Node, node_to_insert: Node) -> None:
         node_to_insert.previous = node
         node_to_insert.next = node.next
 


### PR DESCRIPTION
### Describe your change:

Related to #12647

Bug was when calling `insert_at_position` method on empty list
```
239 >>> linked_list = LinkedList()
240 >>> linked_list.insert_at_position(position=1, value=10)
UNEXPECTED EXCEPTION: AttributeError("'NoneType' object has no attribute 'next'")
```

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
