### PR TITLE
Add graph generation algorithm for Knapsack problems

### DIFF
--- a/knapsack/knapsack_graph_generation.py
+++ b/knapsack/knapsack_graph_generation.py
@@ -1,0 +1,112 @@
+"""
+This function builds a Directed Acyclic Graph representation of the Knapsack problem.
+This allows us to solve knapsack-style problems with Shortest Path algorithms.
+See https://github.com/Matti02co/graph-based-scheduling for more details.
+
+The graph consists of n+2 layers:
+- Layer 0 contains the source node 's'.
+- Layer n+1 contains the sink node 't'.
+- Intermediate layers (1..n) correspond to the n items.
+
+Each intermediate layer j has (capacity + 1) nodes: j0, j1, ..., jC,
+where jk represents the state of having considered the first j items
+with a total weight of k so far.
+
+From each node jk there are at most two outgoing edges:
+- Skip item j+1 (weight and cost remain the same).
+- Take item j+1 (only if total weight + item's weight ≤ capacity), with a cost
+  equal to the negative of the item's value (we solve via shortest path).
+
+All nodes in the last layer are connected to 't' with zero-cost edges.
+
+In this representation, every path from 's' to 't' corresponds to a feasible
+Knapsack solution, and the shortest path (negative costs) corresponds to
+the maximum total value selection.
+"""
+
+from typing import Any
+
+
+def generate_knapsack_graph(
+    capacity: int, weights: list[int], values: list[int]
+) -> list[dict[str, Any]]:
+    """
+    Generate a Directed Acyclic Graph (DAG) representation of the 0/1 Knapsack problem.
+
+    Parameters
+    ----------
+    capacity : int
+        Maximum weight capacity of the knapsack.
+    weights : list[int]
+        List of item weights.
+    values : list[int]
+        List of item values.
+
+    Returns
+    -------
+    list[dict]
+        List of edges, each represented as a dictionary with:
+        - 'from': start node
+        - 'to': end node
+        - 'cost': edge cost (negative item value when item is included)
+        - 'label': description of the decision
+
+    Test
+    --------
+    >>> edges = generate_knapsack_graph(5, [2, 3], [10, 20])
+    >>> len(edges) > 0
+    True
+    >>> any(edge['label'].startswith("take_item") for edge in edges)
+    True
+    >>> any(edge['label'].startswith("skip_item") for edge in edges)
+    True
+    >>> edges[-1]['to'] == 't'
+    True
+    >>> # Check a specific edge: first item, weight 2, value 10
+    >>> first_take_edge = next(edge for edge in edges if edge['label'] == "take_item_0")
+    >>> first_take_edge['from'] == (0, 0)
+    True
+    >>> first_take_edge['to'] == (1, 2)
+    True
+    >>> first_take_edge['cost'] == -10
+    True
+    """
+
+    n = len(weights)
+    edges = []
+
+    # Generate a layer for each item, with (capacity + 1) nodes
+    for i in range(n):
+        for w in range(capacity + 1):
+            weight = weights[i]
+            value = values[i]
+
+            # Edge for skipping the current item
+            edges.append(
+                {
+                    "from": (i, w),
+                    "to": (i + 1, w),
+                    "cost": 0,  # no value added
+                    "label": f"skip_item_{i}",
+                }
+            )
+
+            # Edge for taking the item, only if within capacity
+            if w + weight <= capacity:
+                edges.append(
+                    {
+                        "from": (i, w),
+                        "to": (i + 1, w + weight),
+                        "cost": -value,  # negative cost to solve SPP
+                        "label": f"take_item_{i}",
+                    }
+                )
+
+    # Source node and initial edge
+    edges.append({"from": "s", "to": (0, 0), "cost": 0, "label": "start"})
+
+    # Edges from all final states to the sink node
+    for w in range(capacity + 1):
+        edges.append({"from": (n, w), "to": "t", "cost": 0, "label": f"end_{w}"})
+
+    return edges


### PR DESCRIPTION
### Description:
This pull request adds a function to generate a directed acyclic graph (DAG) representation of a classic 0/1 Knapsack problem.
The graph representation enables solving the problem using shortest/longest path algorithms in DAGs, providing an alternative approach to traditional dynamic programming solutions.
Each path from the source node s to the sink node t corresponds to a valid subset of items.

### Key points:

#### Input:

- capacity — maximum knapsack capacity (integer)

- weights — list of item weights (list of integers)

- values — list of item values (list of integers)

#### Output:

- List of edges, each represented as a dictionary containing "from", "to", "cost", and "label".

Implements Python type hints and doctests.

Code style follows PEP 8 and is Black-formatted.

Passes Ruff tests.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
