### PR TITLE
Add tt entails

### DIFF
--- a/machine_learning/ttentails.py
+++ b/machine_learning/ttentails.py
@@ -9,6 +9,7 @@ using truth tables. Returns True if KB entails a, False otherwise.
 
 import itertools
 
+
 def tt_entails(kb: list[str], query: str, symbols: list[str]) -> bool:
     """
     Check if the knowledge base entails the query using truth tables.
@@ -29,7 +30,9 @@ def tt_entails(kb: list[str], query: str, symbols: list[str]) -> bool:
         model: dict[str, bool] = dict(zip(symbols, values))
         # Check if KB is true under this model
         # # If query is false in this model, KB does not entail query
-        if all(eval(sentence, {}, model) for sentence in kb) and not eval(query, {}, model):
+        if all(eval(sentence, {}, model) for sentence in kb) and not eval(
+            query, {}, model
+        ):
             return False
     return True
 


### PR DESCRIPTION
This PR adds the TT-ENTAILS algorithm for propositional logic.
It allows users to check if a knowledge base (KB) entails a query sentence using truth tables.
Two examples are included to show both cases: when KB entails the query (True) and when it does not (False).

This is a beginner friendly implementation in Python with example use cases.

Reference: Russell & Norvig, Artificial Intelligence: A Modern Approach, Ch. 7

* [x] Add an algorithm

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
