### PR TITLE
Fix is_palindrome_recursive logic in strings/palindrome.py

### DIFF
--- a/strings/palindrome.py
+++ b/strings/palindrome.py
@@ -11,6 +11,7 @@ test_data = {
     "BB": True,
     "ABC": False,
     "amanaplanacanalpanama": True,  # "a man a plan a canal panama"
+    "abcdba": False,
 }
 # Ensure our test data is valid
 assert all((key == key[::-1]) is value for key, value in test_data.items())
@@ -61,7 +62,7 @@ def is_palindrome_recursive(s: str) -> bool:
     >>> all(is_palindrome_recursive(key) is value for key, value in test_data.items())
     True
     """
-    if len(s) <= 1:
+    if len(s) <= 2:
         return True
     if s[0] == s[len(s) - 1]:
         return is_palindrome_recursive(s[1:-1])

--- a/strings/palindrome.py
+++ b/strings/palindrome.py
@@ -12,6 +12,7 @@ test_data = {
     "ABC": False,
     "amanaplanacanalpanama": True,  # "a man a plan a canal panama"
     "abcdba": False,
+    "AB": False,
 }
 # Ensure our test data is valid
 assert all((key == key[::-1]) is value for key, value in test_data.items())

--- a/strings/palindrome.py
+++ b/strings/palindrome.py
@@ -62,7 +62,7 @@ def is_palindrome_recursive(s: str) -> bool:
     >>> all(is_palindrome_recursive(key) is value for key, value in test_data.items())
     True
     """
-    if len(s) <= 2:
+    if len(s) <= 1:
         return True
     if s[0] == s[len(s) - 1]:
         return is_palindrome_recursive(s[1:-1])

--- a/strings/palindrome.py
+++ b/strings/palindrome.py
@@ -61,7 +61,7 @@ def is_palindrome_recursive(s: str) -> bool:
     >>> all(is_palindrome_recursive(key) is value for key, value in test_data.items())
     True
     """
-    if len(s) <= 2:
+    if len(s) <= 1:
         return True
     if s[0] == s[len(s) - 1]:
         return is_palindrome_recursive(s[1:-1])


### PR DESCRIPTION
Fix #12941 : Corrected base case in is_palindrome_recursive in strings/palindrome.py of Python directory.

Previously, the base case used `if len(s) <= 2: return True`, which incorrectly treated any 2-character string as a palindrome (for example, "AB" returned True). Updated the base case to `len(s) <= 1` so that two-character strings are compared for equality and only empty/single-character strings auto-pass.


