### PR TITLE
feat(blockchain): add all_diophantine_solutions with type hints & doctests

### DIFF
--- a/blockchain/diophantine_equation.py
+++ b/blockchain/diophantine_equation.py
@@ -107,3 +107,48 @@ if __name__ == "__main__":
     testmod(name="diophantine_all_soln", verbose=True)
     testmod(name="extended_gcd", verbose=True)
     testmod(name="greatest_common_divisor", verbose=True)
+
+from __future__ import annotations
+
+def all_diophantine_solutions(a: int, b: int, c: int, n: int = 2) -> list[tuple[int, int]]:
+    """
+    Return up to `n` integer solutions (x, y) to the linear Diophantine equation
+    a*x + b*y = c using the extended Euclidean algorithm.
+
+    Raises:
+        ValueError: If no integer solutions exist.
+
+    Time complexity: O(log(max(|a|, |b|))) to compute one base solution via extended_gcd,
+    plus O(n) to enumerate `n` solutions.
+    Space complexity: O(1) beyond the returned list.
+
+    Examples
+    --------
+    >>> all_diophantine_solutions(10, 6, 14, n=2)
+    [(-7, 14), (-4, 9)]
+    >>> all_diophantine_solutions(10, 6, 14, n=4)
+    [(-7, 14), (-4, 9), (-1, 4), (2, -1)]
+    >>> all_diophantine_solutions(3, 6, 10, n=1)
+    Traceback (most recent call last):
+    ...
+    ValueError: No integer solutions exist for a=3, b=6, c=10
+    """
+    if a == 0 and b == 0:
+        if c == 0:
+            return [(0, 0)][: min(1, n)]
+        raise ValueError("No integer solutions exist for a=0, b=0, c!=0")
+
+    g, xg, yg = extended_gcd(abs(a), abs(b))
+    if c % g != 0:
+        raise ValueError(f"No integer solutions exist for a={a}, b={b}, c={c}")
+
+    # Scale a particular solution to ax + by = c
+    x0, y0 = xg * (c // g), yg * (c // g)
+    if a < 0:
+        x0 = -x0
+    if b < 0:
+        y0 = -y0
+
+    # General solution: x = x0 + t*(b/g), y = y0 - t*(a/g)
+    dx, dy = b // g, a // g
+    return [(x0 + t * dx, y0 - t * dy) for t in range(n)]

--- a/blockchain/diophantine_equation.py
+++ b/blockchain/diophantine_equation.py
@@ -100,27 +100,29 @@ def extended_gcd(a: int, b: int) -> tuple[int, int, int]:
     return (d, x, y)
 
 
-if __name__ == "__main__":
-    from doctest import testmod
-
-    testmod(name="diophantine", verbose=True)
-    testmod(name="diophantine_all_soln", verbose=True)
-    testmod(name="extended_gcd", verbose=True)
-    testmod(name="greatest_common_divisor", verbose=True)
-
-from __future__ import annotations
-
-def all_diophantine_solutions(a: int, b: int, c: int, n: int = 2) -> list[tuple[int, int]]:
+def all_diophantine_solutions(
+    a: int,
+    b: int,
+    c: int,
+    n: int = 2,
+) -> list[tuple[int, int]]:
     """
     Return up to `n` integer solutions (x, y) to the linear Diophantine equation
     a*x + b*y = c using the extended Euclidean algorithm.
 
-    Raises:
-        ValueError: If no integer solutions exist.
+    Raises
+    ------
+    ValueError
+        If no integer solutions exist.
 
-    Time complexity: O(log(max(|a|, |b|))) to compute one base solution via extended_gcd,
+    Time complexity
+    ---------------
+    O(log(max(|a|, |b|))) to compute a base solution using extended_gcd;
     plus O(n) to enumerate `n` solutions.
-    Space complexity: O(1) beyond the returned list.
+
+    Space complexity
+    ----------------
+    O(1) beyond the returned list.
 
     Examples
     --------
@@ -135,12 +137,14 @@ def all_diophantine_solutions(a: int, b: int, c: int, n: int = 2) -> list[tuple[
     """
     if a == 0 and b == 0:
         if c == 0:
+            # Infinite solutions; return one canonical solution.
             return [(0, 0)][: min(1, n)]
         raise ValueError("No integer solutions exist for a=0, b=0, c!=0")
 
     g, xg, yg = extended_gcd(abs(a), abs(b))
     if c % g != 0:
-        raise ValueError(f"No integer solutions exist for a={a}, b={b}, c={c}")
+        msg = f"No integer solutions exist for a={a}, b={b}, c={c}"
+        raise ValueError(msg)
 
     # Scale a particular solution to ax + by = c
     x0, y0 = xg * (c // g), yg * (c // g)
@@ -152,3 +156,12 @@ def all_diophantine_solutions(a: int, b: int, c: int, n: int = 2) -> list[tuple[
     # General solution: x = x0 + t*(b/g), y = y0 - t*(a/g)
     dx, dy = b // g, a // g
     return [(x0 + t * dx, y0 - t * dy) for t in range(n)]
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod(name="diophantine", verbose=True)
+    testmod(name="diophantine_all_soln", verbose=True)
+    testmod(name="extended_gcd", verbose=True)
+    testmod(name="greatest_common_divisor", verbose=True)


### PR DESCRIPTION
### What does this PR do?
Adds `all_diophantine_solutions(a: int, b: int, c: int, n: int = 2) -> list[tuple[int, int]]`
to `blockchain/diophantine_equation.py`. It returns up to `n` integer solutions to
the linear Diophantine equation `a*x + b*y = c`, using `extended_gcd`.

### Why is this needed?
- Follows project guidelines (return values, no prints).
- Improves usability: callers can programmatically get multiple solutions.
- Includes type hints, clear docstring, doctests, and proper errors.

### How has this been tested?
- Doctests included in the function’s docstring.
- Ran locally:
  - `python3 -m doctest -v blockchain/diophantine_equation.py` ✅
  - `pre-commit run --all-files` ✅
  - `ruff check` ✅

### Implementation details
- If `g = gcd(a, b)` does not divide `c`, raises `ValueError`.
- Computes one particular solution from `extended_gcd`, then enumerates general
  solutions: `x = x0 + t*(b/g)`, `y = y0 - t*(a/g)` for `t = 0..n-1`.
- Time complexity: `O(log(max(|a|,|b|)))` for base solution + `O(n)` enumeration.
- Space complexity: `O(1)` besides the returned list.

### Breaking changes?
None.

### Dependencies added/removed?
None.

### Related issues / references
N/A (can add `Closes #<id>` if there’s a related issue).

### Checklist
- [x] I read the project’s CONTRIBUTING guidelines.
- [x] My code follows the style rules (pre-commit / ruff).
- [x] I added/kept type hints for public functions.
- [x] I added doctests (and/or unit tests) covering normal & edge cases.
- [x] I documented time/space complexity in the docstring.
- [x] File is in the correct directory and imports remain intact.