### PR TITLE
add basic crypto price converter in accordance with #13008

### DIFF
--- a/web_programming/crypto_price.py
+++ b/web_programming/crypto_price.py
@@ -11,7 +11,10 @@ Convert ETH to USD using real-time price data from CoinGecko.
 
 import httpx
 
-COINGECKO_URL = "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
+COINGECKO_URL = (
+    "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
+)
+
 
 def get_eth_price_usd() -> float:
     """Fetch the current ETH price in USD."""
@@ -20,9 +23,11 @@ def get_eth_price_usd() -> float:
     data = response.json()
     return data["ethereum"]["usd"]
 
+
 def eth_to_usd(eth_amount: float) -> float:
     """Convert ETH amount to USD."""
     return eth_amount * get_eth_price_usd()
+
 
 if __name__ == "__main__":
     eth_amount = float(input("Enter ETH amount: "))

--- a/web_programming/crypto_price.py
+++ b/web_programming/crypto_price.py
@@ -1,0 +1,30 @@
+"""
+Convert ETH to USD using real-time price data from CoinGecko.
+"""
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+
+import httpx
+
+COINGECKO_URL = "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
+
+def get_eth_price_usd() -> float:
+    """Fetch the current ETH price in USD."""
+    response = httpx.get(COINGECKO_URL, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data["ethereum"]["usd"]
+
+def eth_to_usd(eth_amount: float) -> float:
+    """Convert ETH amount to USD."""
+    return eth_amount * get_eth_price_usd()
+
+if __name__ == "__main__":
+    eth_amount = float(input("Enter ETH amount: "))
+    usd_value = eth_to_usd(eth_amount)
+    print(f"{eth_amount} ETH = ${usd_value:.2f} USD")


### PR DESCRIPTION
This PR adds a simple script crypto_price.py under web_programming/ that fetches the current Ethereum (ETH) price in USD. Users can input the amount of ETH, and the script returns the equivalent USD value.

Its a beginner friendly example, suitable for newcomers.