### PR TITLE
Add doctests to chaos machine

### DIFF
--- a/hashes/chaos_machine.py
+++ b/hashes/chaos_machine.py
@@ -14,6 +14,25 @@ machine_time = 0
 
 
 def push(seed):
+    """
+    Push data into the chaos machine buffer.
+
+    Updates the buffer space and parameters space using chaotic dynamics
+    based on the input seed value.
+
+    Args:
+        seed: Input value to push into the chaos machine
+
+    >>> reset()
+    >>> initial_time = machine_time
+    >>> push(12345)
+    >>> machine_time == initial_time + 1
+    True
+    >>> len(buffer_space) == m
+    True
+    >>> all(0 <= x < 1 for x in buffer_space)
+    True
+    """
     global buffer_space, params_space, machine_time, K, m, t
 
     # Choosing Dynamical Systems (All)
@@ -73,6 +92,20 @@ def pull():
 
 
 def reset():
+    """
+    Reset the chaos machine to initial state.
+
+    Resets buffer space to initial values K, clears parameters space,
+    and resets machine time to 0.
+
+    >>> reset()
+    >>> buffer_space == K
+    True
+    >>> machine_time
+    0
+    >>> len(params_space)
+    5
+    """
     global buffer_space, params_space, machine_time, K, m, t
 
     buffer_space = K


### PR DESCRIPTION
### Describe your change:
Added doctests to hashes/chaos_machine.py for push and reset functions.

Tests verify state transitions and initialization behavior.

Contributes to #9943

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

### Checklist:
* [x] I have read CONTRIBUTING.md
* [x] This pull request is all my own work -- I have not plagiarized
* [x] I know that pull requests will not be merged if they fail the automated tests
* [x] This PR only changes one algorithm file
* [x] All functions have doctests that pass the automated testing