### PR TITLE
 Add `partition_linked_list` algorithm with doctests

### DIFF
--- a/data_structures/linked_list/partition_linked_list.py
+++ b/data_structures/linked_list/partition_linked_list.py
@@ -3,6 +3,8 @@ Partitions a linked list around a value x such that all nodes less than x come b
 nodes greater than or equal to x. The original relative order of the nodes in each
 partition should be preserved. The partition value x can appear anywhere in the "right
 partition" and it does not need to appear between the left and right partitions.
+
+Explanation from GeeksforGeeks: https://www.geeksforgeeks.org/dsa/partitioning-a-linked-list-around-a-given-value-and-keeping-the-original-order/
 """
 
 from __future__ import annotations
@@ -17,7 +19,19 @@ class ListNode:
 
 
 def create_linked_list(values: list[int]) -> ListNode | None:
-    """Helper function to create a linked list from a list of values."""
+    """
+    Helper function to create a linked list from a list of values.
+
+    >>> head = create_linked_list([1, 2, 3])
+    >>> head.value
+    1
+    >>> head.next_node.value
+    2
+    >>> head.next_node.next_node.value
+    3
+    >>> create_linked_list([]) is None
+    True
+    """
     if not values:
         return None
     head = ListNode(values[0])
@@ -29,7 +43,17 @@ def create_linked_list(values: list[int]) -> ListNode | None:
 
 
 def linked_list_to_list(head: ListNode | None) -> list[int]:
-    """Helper function to convert a linked list to a list of values."""
+    """
+    Helper function to convert a linked list to a list of values.
+
+    >>> head = ListNode(1)
+    >>> head.next_node = ListNode(2)
+    >>> head.next_node.next_node = ListNode(3)
+    >>> linked_list_to_list(head)
+    [1, 2, 3]
+    >>> linked_list_to_list(None)
+    []
+    """
     values = []
     current = head
     while current:

--- a/data_structures/linked_list/partition_linked_list.py
+++ b/data_structures/linked_list/partition_linked_list.py
@@ -1,0 +1,104 @@
+"""
+Partitions a linked list around a value x such that all nodes less than x come before
+nodes greater than or equal to x. The original relative order of the nodes in each
+partition should be preserved. The partition value x can appear anywhere in the "right
+partition" and it does not need to appear between the left and right partitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ListNode:
+    value: int = 0
+    next_node: ListNode | None = None
+
+
+def create_linked_list(values: list[int]) -> ListNode | None:
+    """Helper function to create a linked list from a list of values."""
+    if not values:
+        return None
+    head = ListNode(values[0])
+    current = head
+    for value in values[1:]:
+        current.next_node = ListNode(value)
+        current = current.next_node
+    return head
+
+
+def linked_list_to_list(head: ListNode | None) -> list[int]:
+    """Helper function to convert a linked list to a list of values."""
+    values = []
+    current = head
+    while current:
+        values.append(current.value)
+        current = current.next_node
+    return values
+
+
+def partition_linked_list(head: ListNode | None, x: int) -> ListNode | None:
+    """
+    Args:
+        head: The head of the linked list.
+        x: The partition value.
+
+    Returns:
+        The head of the partitioned linked list.
+
+    Examples:
+    >>> linked_list_to_list(
+    ...     partition_linked_list(create_linked_list([1, 4, 3, 2, 5, 2]), 3)
+    ... )
+    [1, 2, 2, 4, 3, 5]
+    >>> linked_list_to_list(
+    ...     partition_linked_list(create_linked_list([1, 2, 3]), 10)
+    ... )
+    [1, 2, 3]
+    >>> linked_list_to_list(
+    ...     partition_linked_list(create_linked_list([5, 6, 7]), 3)
+    ... )
+    [5, 6, 7]
+    >>> linked_list_to_list(
+    ...     partition_linked_list(create_linked_list([3, 5, 8, 5, 10, 2, 1]), 5)
+    ... )
+    [3, 2, 1, 5, 8, 5, 10]
+    >>> linked_list_to_list(
+    ...     partition_linked_list(create_linked_list([1]), 5)
+    ... )
+    [1]
+    >>> linked_list_to_list(partition_linked_list(None, 5))
+    []
+    """
+    if head is None:
+        return None
+
+    if head.next_node is None:
+        return head
+
+    left_head = ListNode(0)  # Dummy head for the left partition
+    right_head = ListNode(0)  # Dummy head for the right partition
+    left = left_head
+    right = right_head
+
+    current: ListNode | None = head
+    while current:
+        if current.value < x:
+            left.next_node = current
+            left = current
+        else:
+            right.next_node = current
+            right = current
+        current = current.next_node
+
+    right.next_node = None  # Terminate the right partition
+    left.next_node = right_head.next_node  # Connect the two partitions
+
+    return left_head.next_node  # Return the head of the new partitioned list
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
### In this PR, I implemented an algorithm to partition a linked list around a value `x` such that all nodes less than `x` come before nodes greater than or equal to `x`, while preserving the original relative order within each partition. I used an approach that creates two linked lists and adds nodes to them based on the criteria. At the end, the two lists are joined. Time complexity O(n), space complexity O(n).

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
