### PR TITLE
Fix doctest in factorial_recursive to use correct function

### DIFF
--- a/maths/factorial.py
+++ b/maths/factorial.py
@@ -41,7 +41,7 @@ def factorial_recursive(n: int) -> int:
     https://en.wikipedia.org/wiki/Factorial
 
     >>> import math
-    >>> all(factorial(i) == math.factorial(i) for i in range(20))
+    >>> all(factorial_recursive(i) == math.factorial(i) for i in range(20))
     True
     >>> factorial(0.1)
     Traceback (most recent call last):


### PR DESCRIPTION
This PR fixes the doctest in `factorial_recursive` which was incorrectly testing the `factorial()` function instead of `factorial_recursive()`.

This ensures that the documentation accurately reflects the behavior of the recursive implementation.