### PR TITLE
Enhance softmax with numerical stability and axis parameter

### DIFF
--- a/maths/softmax.py
+++ b/maths/softmax.py
@@ -62,6 +62,7 @@ def softmax(vector: np.ndarray, axis: int = -1) -> np.ndarray:
     softmax_vector = exponent_vector / sum_of_exponents
     return softmax_vector
 
+
 if __name__ == "__main__":
     # Single value
     print(softmax((0,)))

--- a/maths/softmax.py
+++ b/maths/softmax.py
@@ -1,44 +1,44 @@
 """
 This script demonstrates the implementation of the Softmax function.
 
-Its a function that takes as input a vector of K real numbers, and normalizes
-it into a probability distribution consisting of K probabilities proportional
-to the exponentials of the input numbers. After softmax, the elements of the
-vector always sum up to 1.
+It takes as input a vector of K real numbers and normalizes it into a
+probability distribution consisting of K probabilities proportional
+to the exponentials of the input numbers. After applying softmax,
+the elements of the vector always sum up to 1.
 
-Script inspired from its corresponding Wikipedia article
+Script inspired by its corresponding Wikipedia article:
 https://en.wikipedia.org/wiki/Softmax_function
 """
 
 import numpy as np
+from numpy.exceptions import AxisError
 
 
-def softmax(vector, axis=-1):
+def softmax(vector: np.ndarray, axis: int = -1) -> np.ndarray:
     """
-    Implements the softmax function
+    Implements the softmax function.
 
     Parameters:
-        vector (np.array,list,tuple): A  numpy array of shape (1,n)
-        consisting of real values or a similar list,tuple
-        axis (int, optional): Axis along which to compute softmax. Default is -1.
+        vector (np.ndarray | list | tuple): A numpy array of shape (1, n)
+            consisting of real values or a similar list/tuple.
+        axis (int, optional): Axis along which to compute softmax.
+            Default is -1.
 
     Returns:
-        softmax_vec (np.array): The input numpy array  after applying
-        softmax.
+        np.ndarray: The input numpy array after applying softmax.
 
-    The softmax vector adds up to one. We need to ceil to mitigate for
-    precision
-    >>> float(np.ceil(np.sum(softmax([1,2,3,4]))))
+    The softmax vector adds up to one. We need to ceil to mitigate precision.
+
+    >>> float(np.ceil(np.sum(softmax([1, 2, 3, 4]))))
     1.0
 
-    >>> vec = np.array([5,5])
+    >>> vec = np.array([5, 5])
     >>> softmax(vec)
     array([0.5, 0.5])
 
     >>> softmax([0])
     array([1.])
     """
-
     # Convert input to numpy array of floats
     vector = np.asarray(vector, dtype=float)
 
@@ -47,11 +47,10 @@ def softmax(vector, axis=-1):
         raise ValueError("softmax input must be non-empty")
 
     # Validate axis
-    if not (-vector.ndim <= axis < vector.ndim):
-        raise np.AxisError(
-            f"axis {axis} is out of bounds for array of dimension {vector.ndim}"
-        )
-
+    ndim = vector.ndim
+    if axis >= ndim or axis < -ndim:
+        error_message = f"axis {axis} is out of bounds for array of dimension {ndim}"
+        raise AxisError(error_message)
     # Subtract max for numerical stability
     vector_max = np.max(vector, axis=axis, keepdims=True)
     exponent_vector = np.exp(vector - vector_max)
@@ -61,20 +60,15 @@ def softmax(vector, axis=-1):
 
     # Divide each exponent by the sum along the axis
     softmax_vector = exponent_vector / sum_of_exponents
-
     return softmax_vector
-
 
 if __name__ == "__main__":
     # Single value
     print(softmax((0,)))
-
     # Vector
     print(softmax([1, 2, 3]))
-
     # Matrix along last axis
     mat = np.array([[1, 2, 3], [4, 5, 6]])
     print("Softmax along last axis:\n", softmax(mat))
-
     # Matrix along axis 0
     print("Softmax along axis 0:\n", softmax(mat, axis=0))

--- a/maths/softmax.py
+++ b/maths/softmax.py
@@ -48,7 +48,9 @@ def softmax(vector, axis=-1):
 
     # Validate axis
     if not (-vector.ndim <= axis < vector.ndim):
-        raise np.AxisError(f"axis {axis} is out of bounds for array of dimension {vector.ndim}")
+        raise np.AxisError(
+            f"axis {axis} is out of bounds for array of dimension {vector.ndim}"
+        )
 
     # Subtract max for numerical stability
     vector_max = np.max(vector, axis=axis, keepdims=True)

--- a/maths/softmax.py
+++ b/maths/softmax.py
@@ -13,14 +13,14 @@ https://en.wikipedia.org/wiki/Softmax_function
 import numpy as np
 
 
-def softmax(vector):
+def softmax(vector, axis=-1):
     """
     Implements the softmax function
 
     Parameters:
         vector (np.array,list,tuple): A  numpy array of shape (1,n)
         consisting of real values or a similar list,tuple
-
+        axis (int, optional): Axis along which to compute softmax. Default is -1.
 
     Returns:
         softmax_vec (np.array): The input numpy array  after applying
@@ -39,18 +39,40 @@ def softmax(vector):
     array([1.])
     """
 
-    # Calculate e^x for each x in your vector where e is Euler's
-    # number (approximately 2.718)
-    exponent_vector = np.exp(vector)
+    # Convert input to numpy array of floats
+    vector = np.asarray(vector, dtype=float)
 
-    # Add up the all the exponentials
-    sum_of_exponents = np.sum(exponent_vector)
+    # Handle empty input
+    if vector.size == 0:
+        raise ValueError("softmax input must be non-empty")
 
-    # Divide every exponent by the sum of all exponents
+    # Validate axis
+    if not (-vector.ndim <= axis < vector.ndim):
+        raise np.AxisError(f"axis {axis} is out of bounds for array of dimension {vector.ndim}")
+
+    # Subtract max for numerical stability
+    vector_max = np.max(vector, axis=axis, keepdims=True)
+    exponent_vector = np.exp(vector - vector_max)
+
+    # Sum of exponentials along the axis
+    sum_of_exponents = np.sum(exponent_vector, axis=axis, keepdims=True)
+
+    # Divide each exponent by the sum along the axis
     softmax_vector = exponent_vector / sum_of_exponents
 
     return softmax_vector
 
 
 if __name__ == "__main__":
+    # Single value
     print(softmax((0,)))
+
+    # Vector
+    print(softmax([1, 2, 3]))
+
+    # Matrix along last axis
+    mat = np.array([[1, 2, 3], [4, 5, 6]])
+    print("Softmax along last axis:\n", softmax(mat))
+
+    # Matrix along axis 0
+    print("Softmax along axis 0:\n", softmax(mat, axis=0))


### PR DESCRIPTION
### Describe your change:

* [ ] Add an algorithm?
* [x] Fix a bug or improve an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

This pull request improves the existing **softmax** implementation by:
- Adding numerical stability using `vector - max(vector)` before exponentiation.
- Adding `axis` support for computing softmax along a specified dimension.
- Adding input validation for empty arrays and invalid axes.
- Ensuring compatibility with NumPy arrays, lists, and tuples.

These improvements make the function more robust and consistent with modern deep learning implementations while preserving backward compatibility and documentation style.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All function and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
