### PR TITLE
Add doctest to get_files_url for pull request URL example

### DIFF
--- a/scripts/validate_solutions.py
+++ b/scripts/validate_solutions.py
@@ -67,6 +67,7 @@ def get_files_url() -> str:
         FileNotFoundError: if GITHUB_EVENT_PATH is missing.
     """
     import os, json
+
     with open(os.environ["GITHUB_EVENT_PATH"]) as f:
         event = json.load(f)
     return event["pull_request"]["url"] + "/files"

--- a/scripts/validate_solutions.py
+++ b/scripts/validate_solutions.py
@@ -49,9 +49,26 @@ def all_solution_file_paths() -> list[pathlib.Path]:
 
 
 def get_files_url() -> str:
-    """Return the pull request number which triggered this action."""
-    with open(os.environ["GITHUB_EVENT_PATH"]) as file:
-        event = json.load(file)
+    """
+    Return the pull request files URL from the GitHub event file.
+
+    Example:
+    >>> import os, json, tempfile
+    >>> data = {"pull_request": {"url": "https://github.com/example/repo/pull/42"}}
+    >>> with tempfile.NamedTemporaryFile("w", delete=False) as f:
+    ...     json.dump(data, f)
+    ...     os.environ["GITHUB_EVENT_PATH"] = f.name
+    >>> get_files_url()
+    'https://github.com/example/repo/pull/42/files'
+    >>> os.unlink(f.name)
+
+    Raises:
+        KeyError: if 'pull_request' or 'url' keys are missing in the event file.
+        FileNotFoundError: if GITHUB_EVENT_PATH is missing.
+    """
+    import os, json
+    with open(os.environ["GITHUB_EVENT_PATH"]) as f:
+        event = json.load(f)
     return event["pull_request"]["url"] + "/files"
 
 


### PR DESCRIPTION
Added comprehensive doctest to the get_files_url() function including:
- Example usage with tempfile and environment variables
- Expected output format
- Documentation of potential exceptions (KeyError and FileNotFoundError)

### Describe your change:
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.