### PR TITLE
feat(euler): Optimize problem 034 with a lower upper bound

### DIFF
--- a/project_euler/problem_034/sol1.py
+++ b/project_euler/problem_034/sol1.py
@@ -31,7 +31,7 @@ def solution() -> int:
     40730
     """
     # The upper bound is 1,499,999, as shown in this proof:
-    # https://math.stackexchange.com/a/112383/89462
+    # https://rosettacode.org/wiki/Talk:Factorions
     limit = 1_499_999
     return sum(i for i in range(3, limit) if sum_of_digit_factorial(i) == i)
 

--- a/project_euler/problem_034/sol1.py
+++ b/project_euler/problem_034/sol1.py
@@ -30,7 +30,9 @@ def solution() -> int:
     >>> solution()
     40730
     """
-    limit = 7 * factorial(9) + 1
+    # The upper bound is 1,499,999, as shown in this proof:
+    # https://math.stackexchange.com/a/112383/89462
+    limit = 1_499_999
     return sum(i for i in range(3, limit) if sum_of_digit_factorial(i) == i)
 
 


### PR DESCRIPTION
Contributes to #8594

## Description

This pull request optimizes the solution for Project Euler Problem 34 (`problem_034/sol1.py`).

The change replaces the previous, larger upper bound calculation with a more efficient, mathematically proven limit of `1,499,999`. This significantly reduces the number of iterations required to find the solution, making the code much faster.

This optimization is based on the proof referenced in the original issue.

## How I Tested It

The updated solution's correctness has been verified by running the project's validation script:
`python scripts/validate_solutions.py 34`