### PR TITLE
Add doctest for circular queue overflow condition

### DIFF
--- a/data_structures/queues/circular_queue.py
+++ b/data_structures/queues/circular_queue.py
@@ -65,7 +65,7 @@ class CircularQueue:
         (2, 'A')
         >>> cq.enqueue("C").enqueue("D").enqueue("E")  # doctest: +ELLIPSIS
         <data_structures.queues.circular_queue.CircularQueue object at ...>
-        >>> cq2.enqueue("F")
+        >>> cq.enqueue("F")
         Traceback (most recent call last):
            ...
         Exception: QUEUE IS FULL


### PR DESCRIPTION
Added a doctest to test the QUEUE IS FULL exception when attempting to enqueue an element into a full circular queue. This improves test coverage for line 67 in data_structures/queues/circular_queue.py.

Related to #9943

### Describe your change:



* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
