### PR TITLE
Add Morris Traversal (in-order & pre-order) with test cases

### DIFF
--- a/searches/binary_tree_traversal.py
+++ b/searches/binary_tree_traversal.py
@@ -258,6 +258,76 @@ def post_order_iter(node: TreeNode) -> None:
         print(stack2.pop().data, end=",")
 
 
+# Morris Traversal implementations
+def morris_in_order(node: TreeNode) -> None:
+    """
+    Morris In-Order Traversal without recursion or stack
+    >>> root = TreeNode(1)
+    >>> tree_node2 = TreeNode(2)
+    >>> tree_node3 = TreeNode(3)
+    >>> tree_node4 = TreeNode(4)
+    >>> tree_node5 = TreeNode(5)
+    >>> tree_node6 = TreeNode(6)
+    >>> tree_node7 = TreeNode(7)
+    >>> root.left, root.right = tree_node2, tree_node3
+    >>> tree_node2.left, tree_node2.right = tree_node4 , tree_node5
+    >>> tree_node3.left, tree_node3.right = tree_node6 , tree_node7
+    >>> morris_in_order(root)
+    4,2,5,1,6,3,7,
+    """
+    current = node
+    while current:
+        if not current.left:
+            print(current.data, end=",")
+            current = current.right
+        else:
+            pre = current.left
+            while pre.right and pre.right != current:
+                pre = pre.right
+            if not pre.right:
+                pre.right = current
+                current = current.left
+            else:
+                pre.right = None
+                print(current.data, end=",")
+                current = current.right
+
+
+def morris_pre_order(node: TreeNode) -> None:
+    """
+    Morris Pre-Order Traversal without recursion or stack
+    >>> root = TreeNode(1)
+    >>> tree_node2 = TreeNode(2)
+    >>> tree_node3 = TreeNode(3)
+    >>> tree_node4 = TreeNode(4)
+    >>> tree_node5 = TreeNode(5)
+    >>> tree_node6 = TreeNode(6)
+    >>> tree_node7 = TreeNode(7)
+    >>> root.left, root.right = tree_node2, tree_node3
+    >>> tree_node2.left, tree_node2.right = tree_node4 , tree_node5
+    >>> tree_node3.left, tree_node3.right = tree_node6 , tree_node7
+    >>> morris_pre_order(root)
+    1,2,4,5,3,6,7,
+    """
+    current = node
+    while current:
+        if not current.left:
+            print(current.data, end=",")
+            current = current.right
+        else:
+            pre = current.left
+            while pre.right and pre.right != current:
+                pre = pre.right
+            if not pre.right:
+                print(current.data, end=",")
+                pre.right = current
+                current = current.left
+            else:
+                pre.right = None
+                current = current.right
+
+
+
 def prompt(s: str = "", width=50, char="*") -> str:
     if not s:
         return "\n" + width * char
@@ -302,4 +372,11 @@ if __name__ == "__main__":
 
     print(prompt("Post Order Traversal - Iteration Version"))
     post_order_iter(node)
+    print(prompt())
+
+    morris_in_order(node)
+    print(prompt() + "\n")
+
+    print(prompt("Morris Pre-Order Traversal"))
+    morris_pre_order(node)
     print(prompt())


### PR DESCRIPTION
### Describe your change:

Add an algorithm

Summary:

Added Morris Traversal implementations for in-order and pre-order traversals of binary trees. These traversals:
-Do not use recursion or a stack (O(1) space complexity)
-Include doctests similar to existing tree traversal algorithms
-Work with the interactive build_tree() function
-Maintain consistency with existing traversal function styles and output formatting

References / Explanation:

Morris Traversal: https://en.wikipedia.org/wiki/Threaded_binary_tree#Morris_traversal

Checklist:
 I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
 This pull request is all my own work -- I have not plagiarized.
 I know that pull requests will not be merged if they fail the automated tests.
 This PR only changes one algorithm file.
 All new Python files are placed inside an existing directory.
 All filenames are in all lowercase characters with no spaces or dashes.
 All functions and variable names follow Python naming conventions.
 All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
 All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
 All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
 If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".