### PR TITLE
Modernize Documentation Theme with Furo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ docs = [
   "myst-parser>=4",
   "sphinx-autoapi>=3.4",
   "sphinx-pyproject>=0.3",
+      "furo>=2024.1.29",
+          "sphinx-copybutton>=0.5.2",
 ]
 euler-validate = [
   "httpx>=0.28.1",
@@ -239,7 +241,12 @@ extensions = [
   "myst_parser",
 ]
 html_static_path = [ "_static" ]
-html_theme = "alabaster"
+html_theme = "furo"
+html_theme_options = {
+    "source_repository": "https://github.com/TheAlgorithms/Python/",
+        "source_branch": "master",
+            "source_directory": "docs/",
+            }
 myst_enable_extensions = [
   "amsmath",
   "attrs_inline",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,11 @@ test = [
 ]
 
 docs = [
+  "furo>=2024.1.29",
   "myst-parser>=4",
   "sphinx-autoapi>=3.4",
+  "sphinx-copybutton>=0.5.2",
   "sphinx-pyproject>=0.3",
-      "furo>=2024.1.29",
-          "sphinx-copybutton>=0.5.2",
 ]
 euler-validate = [
   "httpx>=0.28.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,11 +242,7 @@ extensions = [
 ]
 html_static_path = [ "_static" ]
 html_theme = "furo"
-html_theme_options = {
-    "source_repository": "https://github.com/TheAlgorithms/Python/",
-        "source_branch": "master",
-            "source_directory": "docs/",
-            }
+html_theme_options = { "source_repository" = "https://github.com/TheAlgorithms/Python/", "source_branch" = "master", "source_directory" = "docs/" }
 myst_enable_extensions = [
   "amsmath",
   "attrs_inline",


### PR DESCRIPTION
Fixes #12826

## Changes Made

This PR modernizes the documentation theme by switching from Alabaster to Furo, a modern and clean Sphinx theme.

### Updated `pyproject.toml`:

1. **Added Furo theme and Sphinx-copybutton** to the `[dependency-groups]` docs section:
   - `"furo>=2024.1.29"`
   - `"sphinx-copybutton>=0.5.2"` (optional UX enhancement)

2. **Changed documentation theme** from `alabaster` to `furo`

3. **Added theme configuration** with repository links:
   ```python
   html_theme_options = {
       "source_repository": "https://github.com/TheAlgorithms/Python/",
       "source_branch": "master",
       "source_directory": "docs/",
   }
   ```

## Benefits

- Modern, clean, and responsive design
- Better mobile support
- Improved navigation and search
- Dark mode support
- Enhanced copy button for code blocks