### PR TITLE
Add integer to roman v2

### DIFF
--- a/strings/integer_to_roman.py
+++ b/strings/integer_to_roman.py
@@ -49,3 +49,4 @@ def integer_to_roman(n: int) -> str:
 if __name__ == "__main__":
     import doctest
     doctest.testmod()
+    

--- a/strings/integer_to_roman.py
+++ b/strings/integer_to_roman.py
@@ -1,4 +1,4 @@
-def integer_to_roman(n: int) -> str:
+def integer_to_roman(number: int) -> str:
     """
     Convert an integer to a Roman numeral.
 
@@ -18,7 +18,7 @@ def integer_to_roman(n: int) -> str:
         ...
     ValueError: number must be between 1 and 3999
     """
-    if not (1 <= n <= 3999):
+    if not (1 <= number <= 3999):
         raise ValueError("number must be between 1 and 3999")
 
     symbols = [
@@ -39,9 +39,9 @@ def integer_to_roman(n: int) -> str:
 
     result = []
     for value, numeral in symbols:
-        while n >= value:
+        while number >= value:
             result.append(numeral)
-            n -= value
+            number -= value
 
     return "".join(result)
 
@@ -49,4 +49,3 @@ def integer_to_roman(n: int) -> str:
 if __name__ == "__main__":
     import doctest
     doctest.testmod()
-    

--- a/strings/integer_to_roman.py
+++ b/strings/integer_to_roman.py
@@ -1,0 +1,51 @@
+def integer_to_roman(n: int) -> str:
+    """
+    Convert an integer to a Roman numeral.
+
+    Examples:
+    >>> integer_to_roman(1)
+    'I'
+    >>> integer_to_roman(4)
+    'IV'
+    >>> integer_to_roman(9)
+    'IX'
+    >>> integer_to_roman(58)
+    'LVIII'
+    >>> integer_to_roman(1994)
+    'MCMXCIV'
+    >>> integer_to_roman(0)
+    Traceback (most recent call last):
+        ...
+    ValueError: number must be between 1 and 3999
+    """
+    if not (1 <= n <= 3999):
+        raise ValueError("number must be between 1 and 3999")
+
+    symbols = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+
+    result = []
+    for value, numeral in symbols:
+        while n >= value:
+            result.append(numeral)
+            n -= value
+
+    return "".join(result)
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/strings/integer_to_roman.py
+++ b/strings/integer_to_roman.py
@@ -48,4 +48,5 @@ def integer_to_roman(number: int) -> str:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()


### PR DESCRIPTION
### Checklist
 [x] I have read the contributing guidelines
 [x] I have added doctests
 [x] My code follows the project style
 [x] This algorithm is not a duplicate
 [x] All doctests pass locally

### Summary
This PR adds the `integer_to_roman` algorithm to the `strings` directory. It
converts an integer to a Roman numeral and includes doctests and input
validation.

### Description
 Reversible integer-to-Roman mapping logic
 Valid for numbers 1–3999
 Clear, descriptive parameter names as required by algorithms-keeper
 Pure Python implementation with tests

Thank you!
