### PR TITLE
Clarify 1-based indexing in a1z26.py docstring

### DIFF
--- a/ciphers/a1z26.py
+++ b/ciphers/a1z26.py
@@ -1,4 +1,4 @@
-"""
+""" (1-based)
 Convert a string of characters to a sequence of numbers
 corresponding to the character's position in the alphabet.
 

--- a/ciphers/a1z26.py
+++ b/ciphers/a1z26.py
@@ -1,4 +1,4 @@
-""" (1-based)
+"""(1-based)
 Convert a string of characters to a sequence of numbers
 corresponding to the character's position in the alphabet.
 


### PR DESCRIPTION
Added (1-based) to the module docstring to clarify that the a1z26 cipher uses a 1-based index (a=1, b=2, etc.).