### PR TITLE
docs: add time and space complexity to selection_sort docstring

### DIFF
--- a/sorts/selection_sort.py
+++ b/sorts/selection_sort.py
@@ -5,6 +5,12 @@ def selection_sort(collection: list[int]) -> list[int]:
     :param collection: A list of integers to be sorted.
     :return: The sorted list.
 
+
+    Time Complexity: O(n^2) - Due to the nested loops, where n is the length
+        of the collection. The outer loop runs n-1 times, and the inner loop
+        runs n-i-1 times for each iteration.
+    Space Complexity: O(1) - Only a constant amount of extra space is used
+        for variables (length, i, min_index, k).
     Examples:
     >>> selection_sort([0, 5, 3, 2, 2])
     [0, 2, 2, 3, 5]


### PR DESCRIPTION
Added Time Complexity O(n^2) and Space Complexity O(1) documentation to the selection_sort function docstring, improving code documentation for beginners as requested in issue #13948.

### Describe your change:
This PR adds time and space complexity information to the `selection_sort` function docstring in `sorts/selection_sort.py`. The documentation now includes:
- **Time Complexity: O(n^2)** - with explanation of the nested loops
- **Space Complexity: O(1)** - noting that only constant extra space is used

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests?
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.

Related to issue #13948