### PR TITLE
Correct typo from 'two large' to 'too large'

### DIFF
--- a/ciphers/caesar_cipher.py
+++ b/ciphers/caesar_cipher.py
@@ -45,7 +45,7 @@ def encrypt(input_string: str, key: int, alphabet: str | None = None) -> str:
     And our shift is ``2``
 
     We can then encode the message, one letter at a time. ``H`` would become ``J``,
-    since ``J`` is two letters away, and so on. If the shift is ever two large, or
+    since ``J`` is two letters away, and so on. If the shift is ever too large, or
     our letter is at the end of the alphabet, we just start at the beginning
     (``Z`` would shift to ``a`` then ``b`` and so on).
 


### PR DESCRIPTION
Fix typo in documentation regarding shift size.

### Describe your change:

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python type hints.
* [ ] All functions have doctests that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword.
