### PR TITLE
Fix broken doctests in xgboost_classifier.py

### DIFF
--- a/machine_learning/xgboost_classifier.py
+++ b/machine_learning/xgboost_classifier.py
@@ -73,5 +73,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(verbose=True)
     main()

--- a/machine_learning/xgboost_classifier.py
+++ b/machine_learning/xgboost_classifier.py
@@ -8,32 +8,33 @@ from xgboost import XGBClassifier
 
 
 def data_handling(data: dict) -> tuple:
-    # Split dataset into features and target
-    # data is features
     """
-    >>> data_handling(({'data':'[5.1, 3.5, 1.4, 0.2]','target':([0])}))
-    ('[5.1, 3.5, 1.4, 0.2]', [0])
-    >>> data_handling(
-    ...     {'data': '[4.9, 3.0, 1.4, 0.2], [4.7, 3.2, 1.3, 0.2]', 'target': ([0, 0])}
-    ... )
-    ('[4.9, 3.0, 1.4, 0.2], [4.7, 3.2, 1.3, 0.2]', [0, 0])
+    Split dataset into features and target.
+    
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> features, targets = data_handling(iris)
+    >>> features.shape
+    (150, 4)
+    >>> targets.shape
+    (150,)
     """
     return (data["data"], data["target"])
 
 
 def xgboost(features: np.ndarray, target: np.ndarray) -> XGBClassifier:
     """
-    # THIS TEST IS BROKEN!! >>> xgboost(np.array([[5.1, 3.6, 1.4, 0.2]]), np.array([0]))
-    XGBClassifier(base_score=0.5, booster='gbtree', callbacks=None,
-                  colsample_bylevel=1, colsample_bynode=1, colsample_bytree=1,
-                  early_stopping_rounds=None, enable_categorical=False,
-                  eval_metric=None, gamma=0, gpu_id=-1, grow_policy='depthwise',
-                  importance_type=None, interaction_constraints='',
-                  learning_rate=0.300000012, max_bin=256, max_cat_to_onehot=4,
-                  max_delta_step=0, max_depth=6, max_leaves=0, min_child_weight=1,
-                  missing=nan, monotone_constraints='()', n_estimators=100,
-                  n_jobs=0, num_parallel_tree=1, predictor='auto', random_state=0,
-                  reg_alpha=0, reg_lambda=1, ...)
+    Train an XGBoost classifier.
+    
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> X_train, y_train = iris.data[:100], iris.target[:100]
+    >>> classifier = xgboost(X_train, y_train)
+    >>> predictions = classifier.predict(iris.data[:5])
+    >>> len(predictions)
+    5
+    >>> all(pred in [0, 1, 2] for pred in predictions)
+    True
     """
     classifier = XGBClassifier()
     classifier.fit(features, target)
@@ -46,20 +47,18 @@ def main() -> None:
     https://xgboost.readthedocs.io/en/stable/
     Iris type dataset is used to demonstrate algorithm.
     """
-
     # Load Iris dataset
     iris = load_iris()
     features, targets = data_handling(iris)
     x_train, x_test, y_train, y_test = train_test_split(
-        features, targets, test_size=0.25
+        features, targets, test_size=0.25, random_state=42
     )
-
     names = iris["target_names"]
-
+    
     # Create an XGBoost Classifier from the training data
     xgboost_classifier = xgboost(x_train, y_train)
-
-    # Display the confusion matrix of the classifier with both training and test sets
+    
+    # Display the confusion matrix of the classifier with test set
     ConfusionMatrixDisplay.from_estimator(
         xgboost_classifier,
         x_test,
@@ -74,6 +73,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
-
     doctest.testmod(verbose=True)
     main()

--- a/machine_learning/xgboost_classifier.py
+++ b/machine_learning/xgboost_classifier.py
@@ -10,7 +10,7 @@ from xgboost import XGBClassifier
 def data_handling(data: dict) -> tuple:
     """
     Split dataset into features and target.
-    
+
     >>> from sklearn.datasets import load_iris
     >>> iris = load_iris()
     >>> features, targets = data_handling(iris)
@@ -25,7 +25,7 @@ def data_handling(data: dict) -> tuple:
 def xgboost(features: np.ndarray, target: np.ndarray) -> XGBClassifier:
     """
     Train an XGBoost classifier.
-    
+
     >>> from sklearn.datasets import load_iris
     >>> iris = load_iris()
     >>> X_train, y_train = iris.data[:100], iris.target[:100]
@@ -54,10 +54,10 @@ def main() -> None:
         features, targets, test_size=0.25, random_state=42
     )
     names = iris["target_names"]
-    
+
     # Create an XGBoost Classifier from the training data
     xgboost_classifier = xgboost(x_train, y_train)
-    
+
     # Display the confusion matrix of the classifier with test set
     ConfusionMatrixDisplay.from_estimator(
         xgboost_classifier,
@@ -73,5 +73,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(verbose=True)
     main()

--- a/machine_learning/xgboost_classifier.py
+++ b/machine_learning/xgboost_classifier.py
@@ -73,6 +73,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     import doctest
-
     doctest.testmod(verbose=True)
     main()


### PR DESCRIPTION
### Describe your change:

Fixed broken doctests in `machine_learning/xgboost_classifier.py` that were causing test failures.

**Issues fixed:**
1. `data_handling()` had incorrect doctests using string inputs instead of actual arrays
2. `xgboost()` had a broken doctest (marked with "THIS TEST IS BROKEN!!") that tried to train on a single sample, causing `XGBoostError`

**Changes made:**
- Replaced doctests in `data_handling()` with tests that verify array shapes using the actual iris dataset
- Replaced broken doctest in `xgboost()` with a proper test using 100 training samples
- Added `random_state=42` to `train_test_split()` for reproducibility
- Removed comments marking tests as broken

**Testing:**
- ✅ All 12 doctests now pass successfully
- ✅ Main function runs without errors and displays confusion matrix

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/2a3857a0-a0ad-41c6-8f5a-005771e844b6" />
