### PR TITLE
Replace urllib with requests to Restrict Unsafe Protocol Handling

### DIFF
--- a/machine_learning/sequential_minimum_optimization.py
+++ b/machine_learning/sequential_minimum_optimization.py
@@ -30,7 +30,7 @@ Reference:
 
 import os
 import sys
-import urllib.request
+import requests
 
 import numpy as np
 import pandas as pd
@@ -451,12 +451,12 @@ def test_cancer_data():
     print("Hello!\nStart test SVM using the SMO algorithm!")
     # 0: download dataset and load into pandas' dataframe
     if not os.path.exists(r"cancer_data.csv"):
-        request = urllib.request.Request(  # noqa: S310
+        response = requests.get(
             CANCER_DATASET_URL,
             headers={"User-Agent": "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)"},
         )
-        response = urllib.request.urlopen(request)  # noqa: S310
-        content = response.read().decode("utf-8")
+        response.raise_for_status()  # Raise an exception for bad status codes
+        content = response.text
         with open(r"cancer_data.csv", "w") as f:
             f.write(content)
 


### PR DESCRIPTION
### Describe your change:
* [x] Fix a bug or typo in an existing algorithm?

"Fixes #ISSUE-NUMBER".
This PR replaces the use of urllib.request.urlopen() with requests.get() for fetching the dataset URL.
While the current URL is hardcoded and safe, urllib supports additional protocols such as file:// and ftp://. If the URL ever becomes dynamic or user-controlled in the future, this could introduce a risk of unintended local file access or data exposure.The requests library only allows http:// and https:// by default, which helps prevent entire classes of protocol-based vulnerabilities. This change improves security posture through defense-in-depth while preserving identical functionality for valid web requests.This update is a proactive, preventive security improvement aligned with best practices.


