### PR TITLE
fix: correct docstrings in prime_numbers.py (list -> generator, grammar fix)

### DIFF
--- a/maths/prime_numbers.py
+++ b/maths/prime_numbers.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 
 def slow_primes(max_n: int) -> Generator[int]:
     """
-    Return a list of all primes numbers up to max.
+    Return a generator of all prime numbers up to max_n.
     >>> list(slow_primes(0))
     []
     >>> list(slow_primes(-1))
@@ -31,7 +31,7 @@ def slow_primes(max_n: int) -> Generator[int]:
 
 def primes(max_n: int) -> Generator[int]:
     """
-    Return a list of all primes numbers up to max.
+    Return a generator of all prime numbers up to max_n.
     >>> list(primes(0))
     []
     >>> list(primes(-1))
@@ -60,7 +60,7 @@ def primes(max_n: int) -> Generator[int]:
 
 def fast_primes(max_n: int) -> Generator[int]:
     """
-    Return a list of all primes numbers up to max.
+    Return a generator of all prime numbers up to max_n.
     >>> list(fast_primes(0))
     []
     >>> list(fast_primes(-1))


### PR DESCRIPTION
## Description
The docstrings for `slow_primes()`, `primes()`, and `fast_primes()` in `maths/prime_numbers.py` incorrectly stated:

> "Return a list of all primes numbers up to max."

There are two issues:
1. **Incorrect return type description**: All three functions are annotated as `-> Generator[int]` and `yield` values — they return a generator, not a list.
2. **Grammar error**: "primes numbers" should be "prime numbers".

## Fix
Changed all three occurrences from:
```
Return a list of all primes numbers up to max.
```
to:
```
Return a generator of all prime numbers up to max_n.
```

## Checklist
- [x] The fix is in documentation/docstrings only
- [x] No logic changes
- [x] Consistent with the actual return type annotation `Generator[int]`
- [x] Grammar corrected
