### PR TITLE
feat: add confusion matrix with precision, recall, and F1 score

### DIFF
--- a/machine_learning/confusion_matrix.py
+++ b/machine_learning/confusion_matrix.py
@@ -69,8 +69,16 @@ def precision(actual: list, predicted: list, positive_label: int = 1) -> float:
     >>> precision(actual, predicted)
     0.6666666666666666
     """
-    tp = sum(1 for a, p in zip(actual, predicted) if a == positive_label and p == positive_label)
-    fp = sum(1 for a, p in zip(actual, predicted) if a != positive_label and p == positive_label)
+    tp = sum(
+        1
+        for a, p in zip(actual, predicted)
+        if a == positive_label and p == positive_label
+    )
+    fp = sum(
+        1
+        for a, p in zip(actual, predicted)
+        if a != positive_label and p == positive_label
+    )
     return tp / (tp + fp) if (tp + fp) > 0 else 0.0
 
 
@@ -97,8 +105,16 @@ def recall(actual: list, predicted: list, positive_label: int = 1) -> float:
     >>> recall(actual, predicted)
     1.0
     """
-    tp = sum(1 for a, p in zip(actual, predicted) if a == positive_label and p == positive_label)
-    fn = sum(1 for a, p in zip(actual, predicted) if a == positive_label and p != positive_label)
+    tp = sum(
+        1
+        for a, p in zip(actual, predicted)
+        if a == positive_label and p == positive_label
+    )
+    fn = sum(
+        1
+        for a, p in zip(actual, predicted)
+        if a == positive_label and p != positive_label
+    )
     return tp / (tp + fn) if (tp + fn) > 0 else 0.0
 
 


### PR DESCRIPTION
### Describe your change:
Added classification evaluation metrics to `machine_learning/`:
- `confusion_matrix`: Binary and multiclass support
- `precision`: TP / (TP + FP)
- `recall`: TP / (TP + FN)
- `f1_score`: Harmonic mean of precision and recall

The existing `scoring_functions.py` only has regression metrics (MAE, MSE, RMSE). Classification metrics were missing.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change documentation?
* [ ] An existing implementation is improved

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request is for a pre-existing algorithm, I have linked to the issue.