### PR TITLE
Fix binary_search to return first occurrence with duplicates

### DIFF
--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -196,22 +196,26 @@ def binary_search(sorted_collection: list[int], item: int) -> int:
     1
     >>> binary_search([0, 5, 7, 10, 15], 6)
     -1
+    >>> binary_search([1, 2, 2, 2, 3], 2)
+    1
     """
     if any(a > b for a, b in pairwise(sorted_collection)):
         raise ValueError("sorted_collection must be sorted in ascending order")
     left = 0
     right = len(sorted_collection) - 1
+    result = -1
 
     while left <= right:
         midpoint = left + (right - left) // 2
         current_item = sorted_collection[midpoint]
         if current_item == item:
-            return midpoint
+            result = midpoint
+            right = midpoint - 1  # Continue searching left for first occurrence
         elif item < current_item:
             right = midpoint - 1
         else:
             left = midpoint + 1
-    return -1
+    return result
 
 
 def binary_search_std_lib(sorted_collection: list[int], item: int) -> int:


### PR DESCRIPTION
## Description

Fixes #13840

When binary_search finds a matching element with duplicates, it now returns the first occurrence index instead of the last.

## ✅ Checklist

- [x] I have clicked on "Read the Contributing Guidelines".
- [x] I have read the "Contribution Guidelines".
- [x] I have accepted the Terms and Conditions.
- [x] I have read the "Hacktoberfest" section (if applicable).
- [x] I have followed the guidelines in the "How to contribute".
- [x] The changes I have made are in compliance with the Coding Standards.
- [x] I have tested the changes and found that they work as expected.

## ✅ Types of Changes

- [x] 📖 Documentation (Documentation update)
- [x] 🐛 Bug Fix (Non-breaking change which fixes an issue)

## ✅ Changes Made

- Modified binary_search to return first occurrence of duplicates
- Added test case for duplicate handling

## Additional Info

The issue #13840 reports that binary_search([1, 2, 2, 2, 3], 2) returns 2 (last occurrence) but should return 1 (first occurrence).