### PR TITLE
Add doubly_to_singly() method to convert a doubly linked list to a singly linked list

### DIFF
--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -210,9 +210,9 @@ class DoublyLinkedList:
         >>> head = dll.doubly_to_singly()
         >>> head.data
         1
-        >>> head.next.data
+        >>> head.next_node.data
         2
-        >>> head.next.next.data
+        >>> head.next_node.next_node.data
         3
         """
 

--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -1,3 +1,5 @@
+from data_structures.linked_list import singly_linked_list
+
 """
 https://en.wikipedia.org/wiki/Doubly_linked_list
 """
@@ -187,6 +189,47 @@ class DoublyLinkedList:
         """
         return len(self) == 0
 
+    def doubly_to_singly(self) -> singly_linked_list.Node | None:
+        """
+        Convert this doubly linked list into a singly linked list.
+
+        A new singly linked list is created by copying the data from
+        each node in the doubly linked list.
+
+        Returns
+        -------
+        singly_linked_list.Node | None
+            The head node of the newly created singly linked list.
+
+        Example
+        -------
+        >>> dll = DoublyLinkedList()
+        >>> dll.insert_at_tail(1)
+        >>> dll.insert_at_tail(2)
+        >>> dll.insert_at_tail(3)
+        >>> head = dll.doubly_to_singly()
+        >>> head.data
+        1
+        >>> head.next.data
+        2
+        >>> head.next.next.data
+        3
+        """
+
+        if self.head is None:
+            return None
+
+        doubly_current: Node | None = self.head.next
+        new_head = singly_linked_list.Node(self.head.data)
+        singly_current = new_head
+
+        while doubly_current:
+            singly_current.next_node = singly_linked_list.Node(doubly_current.data)
+            singly_current = singly_current.next_node
+            doubly_current = doubly_current.next
+
+        return new_head
+
 
 def test_doubly_linked_list() -> None:
     """
@@ -222,6 +265,25 @@ def test_doubly_linked_list() -> None:
     assert linked_list.delete_tail() == 11
     assert len(linked_list) == 9
     assert str(linked_list) == "->".join(str(i) for i in range(1, 10))
+
+    # Test doubly_to_singly conversion
+    dll = DoublyLinkedList()
+    dll.insert_at_tail(1)
+    dll.insert_at_tail(2)
+    dll.insert_at_tail(3)
+
+    head = dll.doubly_to_singly()
+
+    assert head is not None
+    s_head = head  # type: singly_linked_list.Node
+
+    assert s_head.data == 1
+
+    assert s_head.next_node is not None
+    assert s_head.next_node.data == 2
+
+    assert s_head.next_node.next_node is not None
+    assert s_head.next_node.next_node.data == 3
 
 
 if __name__ == "__main__":

--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -1,4 +1,4 @@
-from data_structures.linked_list import singly_linked_list
+from data_structures.linked_list.singly_linked_list import Node as SinglyNode
 
 """
 https://en.wikipedia.org/wiki/Doubly_linked_list
@@ -189,7 +189,7 @@ class DoublyLinkedList:
         """
         return len(self) == 0
 
-    def doubly_to_singly(self) -> singly_linked_list.Node | None:
+    def doubly_to_singly(self) -> SinglyNode | None:
         """
         Convert this doubly linked list into a singly linked list.
 
@@ -198,7 +198,7 @@ class DoublyLinkedList:
 
         Returns
         -------
-        singly_linked_list.Node | None
+        SinglyNode | None
             The head node of the newly created singly linked list.
 
         Example
@@ -220,11 +220,11 @@ class DoublyLinkedList:
             return None
 
         doubly_current: Node | None = self.head.next
-        new_head = singly_linked_list.Node(self.head.data)
+        new_head = SinglyNode(self.head.data)
         singly_current = new_head
 
         while doubly_current:
-            singly_current.next_node = singly_linked_list.Node(doubly_current.data)
+            singly_current.next_node = SinglyNode(doubly_current.data)
             singly_current = singly_current.next_node
             doubly_current = doubly_current.next
 
@@ -275,7 +275,7 @@ def test_doubly_linked_list() -> None:
     head = dll.doubly_to_singly()
 
     assert head is not None
-    s_head = head  # type: singly_linked_list.Node
+    s_head = head  # type: SinglyNode
 
     assert s_head.data == 1
 


### PR DESCRIPTION
### Describe your change:

* [x] Add an algorithm

This pull request adds a new method `doubly_to_singly()` to the `DoublyLinkedList` class.

The method converts a doubly linked list into a singly linked list by creating a new singly linked list and copying the data from each node.

The implementation includes:
- type hints
- doctest examples
- a unit test in `test_doubly_linked_list()`

### Checklist:
* [x] I have read CONTRIBUTING.md
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass automated testing.
* [x] A Wikipedia reference has been included for the algorithm.