### PR TITLE
Add XTEA block cipher implementation

### DIFF
--- a/ciphers/xtea.py
+++ b/ciphers/xtea.py
@@ -16,9 +16,7 @@ DELTA = 0x9E3779B9
 MASK = 0xFFFFFFFF
 
 
-def xtea_encrypt(
-    block: bytes, key: bytes, num_rounds: int = 64
-) -> bytes:
+def xtea_encrypt(block: bytes, key: bytes, num_rounds: int = 64) -> bytes:
     """
     Encrypt a single 64-bit block using XTEA.
 
@@ -65,9 +63,7 @@ def xtea_encrypt(
     return struct.pack("!II", v0, v1)
 
 
-def xtea_decrypt(
-    block: bytes, key: bytes, num_rounds: int = 64
-) -> bytes:
+def xtea_decrypt(block: bytes, key: bytes, num_rounds: int = 64) -> bytes:
     """
     Decrypt a single 64-bit block using XTEA.
 


### PR DESCRIPTION
Implemented the XTEA block cipher from scratch. It's a lightweight 64-bit Feistel cipher that's still used in embedded systems and game protocols. Includes encrypt/decrypt with full doctest coverage and input validation.

- 64-bit block size, 128-bit key, 64 rounds (Feistel network)
- Proper uint32 wrapping throughout
- Only uses the `struct` module from stdlib

Reference: https://en.wikipedia.org/wiki/XTEA