### PR TITLE
Fix typo: x_demonimator -> x_denominator in lamberts_ellipsoidal_dist…

### DIFF
--- a/geodesy/lamberts_ellipsoidal_distance.py
+++ b/geodesy/lamberts_ellipsoidal_distance.py
@@ -95,8 +95,8 @@ def lamberts_ellipsoidal_distance(
     # Intermediate X value
     # X = (sigma - sin(sigma)) * sin^2Pcos^2Q / cos^2(sigma/2)
     x_numerator = (sin(p_value) ** 2) * (cos(q_value) ** 2)
-    x_demonimator = cos(sigma / 2) ** 2
-    x_value = (sigma - sin(sigma)) * (x_numerator / x_demonimator)
+    x_denominator = cos(sigma / 2) ** 2
+    x_value = (sigma - sin(sigma)) * (x_numerator / x_denominator)
 
     # Intermediate Y value
     # Y = (sigma + sin(sigma)) * cos^2Psin^2Q / sin^2(sigma/2)


### PR DESCRIPTION
Fixes a typo in variable name in lamberts_ellipsoidal_distance.py

`x_demonimator` → `x_denominator`

The misspelled variable name is misleading when reading the code.

Fixes #11308

### Describe your change:
* [x] Fix a bug or typo in an existing algorithm?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.
* [x] All functions and variable names follow Python naming conventions.