### PR TITLE
binary_search: fix O(n log n) validation, remove redundant checks, add generics

### DIFF
--- a/searches/binary_search.py
+++ b/searches/binary_search.py
@@ -37,6 +37,7 @@ T = TypeVar("T")  # Must support < via __lt__; mirrors what bisect itself accept
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _check_sorted(collection: Sequence) -> None:
     """Raise ValueError if *collection* is not sorted in ascending order.
 
@@ -49,6 +50,7 @@ def _check_sorted(collection: Sequence) -> None:
 # ---------------------------------------------------------------------------
 # bisect_left / bisect_right
 # ---------------------------------------------------------------------------
+
 
 def bisect_left(
     sorted_collection: Sequence[T],
@@ -136,6 +138,7 @@ def bisect_right(
 # insort helpers
 # ---------------------------------------------------------------------------
 
+
 def insort_left(
     sorted_collection: list[T],
     item: T,
@@ -195,6 +198,7 @@ def insort_right(
 # ---------------------------------------------------------------------------
 # Core binary search variants
 # ---------------------------------------------------------------------------
+
 
 def binary_search(sorted_collection: Sequence[T], item: T) -> int:
     """Iterative binary search.  Returns -1 when *item* is absent.
@@ -257,9 +261,7 @@ def binary_search_std_lib(sorted_collection: Sequence[T], item: T) -> int:
     return -1
 
 
-def binary_search_with_duplicates(
-    sorted_collection: Sequence[T], item: T
-) -> list[int]:
+def binary_search_with_duplicates(sorted_collection: Sequence[T], item: T) -> list[int]:
     """Binary search that returns *all* indices where *item* appears.
 
     IMPROVEMENT: reuses the module-level ``bisect_left`` / ``bisect_right``
@@ -323,9 +325,7 @@ def binary_search_by_recursion(
     return _binary_search_recursive(sorted_collection, item, left, right)
 
 
-def _binary_search_recursive(
-    col: Sequence[T], item: T, left: int, right: int
-) -> int:
+def _binary_search_recursive(col: Sequence[T], item: T, left: int, right: int) -> int:
     """Internal recursive helper — no validation overhead."""
     if left > right:
         return -1
@@ -341,6 +341,7 @@ def _binary_search_recursive(
 # ---------------------------------------------------------------------------
 # Exponential search
 # ---------------------------------------------------------------------------
+
 
 def exponential_search(sorted_collection: Sequence[T], item: T) -> int:
     """Exponential search — efficient when the target is near the start.


### PR DESCRIPTION
Changes
Fix O(n log n) sort validation — binary_search_std_lib and binary_search_by_recursion used list(col) != sorted(col), which allocates a full copy and sorts it on every call. Replaced with an O(n) adjacent-pair check via pairwise (already used correctly in binary_search). Extracted into a shared _check_sorted() helper to avoid further duplication.
Remove per-frame validation in recursion — binary_search_by_recursion ran the sort check on every recursive call. Validation now happens once in the public entry-point; recursion is delegated to a private _binary_search_recursive() helper.
Remove redundant inner functions — binary_search_with_duplicates defined its own lower_bound/upper_bound functions that were functionally identical to the module-level bisect_left/bisect_right. Removed and replaced with calls to the existing functions.
Remove dead None-guard in exponential_search — if last_result is None: return -1 was unreachable because the callee never returns None. Also updated exponential_search to call _binary_search_recursive directly, skipping redundant re-validation on an already-checked collection.
Widen types from list[int] to Sequence[T] — All public functions now accept any Sequence of comparable items, not just list[int]. Mirrors the real bisect module's signature.
Add __all__ — Declares the public API explicitly.
Add empty-collection edge-case tests — binary_search([], 1), binary_search_by_recursion([], 1), exponential_search([], 1) each return -1 correctly and are now covered by doctests.