### PR TITLE
Fix incorrect handling of zero input in binary_count_trailing_zeros

### DIFF
--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -51,4 +51,5 @@ def binary_count_trailing_zeros(a: int) -> int:
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -3,8 +3,7 @@ from math import log2
 
 def binary_count_trailing_zeros(a: int) -> int:
     """
-    Take in 1 integer, return a number that is
-    the number of trailing zeros in binary representation of that number.
+    Take in 1 integer, return the number of trailing zeros in binary representation.
 
     >>> binary_count_trailing_zeros(25)
     0
@@ -17,7 +16,9 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros(4294967296)
     32
     >>> binary_count_trailing_zeros(0)
-    0
+    Traceback (most recent call last):
+        ...
+    ValueError: Trailing zeros for 0 are undefined
     >>> binary_count_trailing_zeros(-10)
     Traceback (most recent call last):
         ...
@@ -25,20 +26,29 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros(0.8)
     Traceback (most recent call last):
         ...
-    TypeError: Input value must be a 'int' type
+    TypeError: Input value must be an integer
     >>> binary_count_trailing_zeros("0")
     Traceback (most recent call last):
         ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
+    TypeError: Input value must be an integer
     """
+
+    # Type check
+    if not isinstance(a, int):
+        raise TypeError("Input value must be an integer")
+
+    # Edge case: zero
+    if a == 0:
+        raise ValueError("Trailing zeros for 0 are undefined")
+
+    # Negative numbers not allowed
     if a < 0:
         raise ValueError("Input value must be a positive integer")
-    elif isinstance(a, float):
-        raise TypeError("Input value must be a 'int' type")
-    return 0 if (a == 0) else int(log2(a & -a))
+
+    # Core logic
+    return int(log2(a & -a))
 
 
 if __name__ == "__main__":
     import doctest
-
     doctest.testmod()


### PR DESCRIPTION
### Description
Fixed incorrect behavior for input value `0`.

### Changes Made
- Added check for zero input
- Improved type validation
- Updated doctests

### Checklist
- [x] I have read the contributing guidelines
- [x] This PR is not a duplicate
- [x] I have added/updated tests