### PR TITLE
Fix: handle zero input in binary_count_trailing_zeros

### DIFF
--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -17,7 +17,9 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros(4294967296)
     32
     >>> binary_count_trailing_zeros(0)
-    0
+    Traceback (most recent call last):
+        ...
+    ValueError: Trailing zeros undefined for zero
     >>> binary_count_trailing_zeros(-10)
     Traceback (most recent call last):
         ...
@@ -29,13 +31,18 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros("0")
     Traceback (most recent call last):
         ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
+    TypeError: Input value must be a 'int' type
     """
+    if not isinstance(a, int):
+        raise TypeError("Input value must be a 'int' type")
+
     if a < 0:
         raise ValueError("Input value must be a positive integer")
-    elif isinstance(a, float):
-        raise TypeError("Input value must be a 'int' type")
-    return 0 if (a == 0) else int(log2(a & -a))
+
+    if a == 0:
+        raise ValueError("Trailing zeros undefined for zero")
+
+    return int(log2(a & -a))
 
 
 if __name__ == "__main__":

--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -49,3 +49,4 @@ if __name__ == "__main__":
     import doctest
 
     doctest.testmod()
+    

--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -49,4 +49,3 @@ if __name__ == "__main__":
     import doctest
 
     doctest.testmod()
-    


### PR DESCRIPTION
### Description
This PR fixes an issue in the function `binary_count_trailing_zeros`.

Previously, the function returned `0` for input value `0`. However, mathematically, trailing zeros for `0` are undefined, and returning `0` can lead to incorrect behavior in dependent algorithms.

### Changes made
- Added validation for input `0`
- Raised `ValueError` when input is zero
- Improved type checking
- Updated doctest examples accordingly

Fixes #14479

---

### Type of change
* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

---

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.
* [x] All filenames are in lowercase with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with type hints.
* [x] All functions have doctests that pass automated testing.
* [x] This PR includes the related issue number (Fixes #14479).
