### PR TITLE
Add knapsack variant to count optimal-value subsets

### DIFF
--- a/knapsack/knapsack.py
+++ b/knapsack/knapsack.py
@@ -4,7 +4,7 @@ https://en.wikipedia.org/wiki/Knapsack_problem
 
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 
 
 def knapsack(
@@ -37,7 +37,7 @@ def knapsack(
     got the weight of 10*5 which is the limit of the capacity.
     """
 
-    @lru_cache(maxsize=None)
+    @cache
     def knapsack_recur(capacity: int, counter: int) -> int:
         # Base Case
         if counter == 0 or capacity == 0:
@@ -93,7 +93,7 @@ def knapsack_with_count(
     (2, 2)
     """
 
-    @lru_cache(maxsize=None)
+    @cache
     def knapsack_recur(remaining_capacity: int, item_count: int) -> tuple[int, int]:
         # Base Case: one empty subset yields value 0.
         if item_count == 0 or remaining_capacity == 0:

--- a/knapsack/knapsack.py
+++ b/knapsack/knapsack.py
@@ -37,7 +37,7 @@ def knapsack(
     got the weight of 10*5 which is the limit of the capacity.
     """
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def knapsack_recur(capacity: int, counter: int) -> int:
         # Base Case
         if counter == 0 or capacity == 0:
@@ -70,10 +70,14 @@ def knapsack_with_count(
     allow_repetition: bool = False,
 ) -> tuple[int, int]:
     """
-    Return both the maximum knapsack value and the number of optimal subsets.
+    Return both the maximum knapsack value and number of optimal selections.
 
-    The return value is ``(max_value, number_of_optimal_subsets)``.
+    The return value is ``(max_value, number_of_optimal_selections)``.
     If multiple choices produce the same maximum value, their counts are added.
+    Distinct selections are order-insensitive:
+    - with ``allow_repetition=False`` these are distinct subsets by item index;
+    - with ``allow_repetition=True`` these are distinct multisets by item index
+      multiplicity.
 
     >>> cap = 50
     >>> val = [60, 100, 120]
@@ -89,7 +93,7 @@ def knapsack_with_count(
     (2, 2)
     """
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def knapsack_recur(remaining_capacity: int, item_count: int) -> tuple[int, int]:
         # Base Case: one empty subset yields value 0.
         if item_count == 0 or remaining_capacity == 0:

--- a/knapsack/knapsack.py
+++ b/knapsack/knapsack.py
@@ -12,7 +12,7 @@ def knapsack(
     weights: list[int],
     values: list[int],
     counter: int,
-    allow_repetition=False,
+    allow_repetition: bool = False,
 ) -> int:
     """
     Returns the maximum value that can be put in a knapsack of a capacity cap,
@@ -58,6 +58,61 @@ def knapsack(
             )
             without_new_value = knapsack_recur(capacity, counter - 1)
             return max(new_value_included, without_new_value)
+
+    return knapsack_recur(capacity, counter)
+
+
+def knapsack_with_count(
+    capacity: int,
+    weights: list[int],
+    values: list[int],
+    counter: int,
+    allow_repetition: bool = False,
+) -> tuple[int, int]:
+    """
+    Return both the maximum knapsack value and the number of optimal subsets.
+
+    The return value is ``(max_value, number_of_optimal_subsets)``.
+    If multiple choices produce the same maximum value, their counts are added.
+
+    >>> cap = 50
+    >>> val = [60, 100, 120]
+    >>> w = [10, 20, 30]
+    >>> c = len(val)
+    >>> knapsack_with_count(cap, w, val, c)
+    (220, 1)
+    >>> knapsack_with_count(cap, w, val, c, True)
+    (300, 1)
+    >>> knapsack_with_count(3, [1, 2, 3], [1, 2, 3], 3)
+    (3, 2)
+    >>> knapsack_with_count(2, [1, 2], [1, 2], 2, True)
+    (2, 2)
+    """
+
+    @lru_cache
+    def knapsack_recur(remaining_capacity: int, item_count: int) -> tuple[int, int]:
+        # Base Case: one empty subset yields value 0.
+        if item_count == 0 or remaining_capacity == 0:
+            return 0, 1
+
+        if weights[item_count - 1] > remaining_capacity:
+            return knapsack_recur(remaining_capacity, item_count - 1)
+
+        left_capacity = remaining_capacity - weights[item_count - 1]
+        included_value, included_count = knapsack_recur(
+            left_capacity, item_count if allow_repetition else item_count - 1
+        )
+        included_value += values[item_count - 1]
+
+        excluded_value, excluded_count = knapsack_recur(
+            remaining_capacity, item_count - 1
+        )
+
+        if included_value > excluded_value:
+            return included_value, included_count
+        if excluded_value > included_value:
+            return excluded_value, excluded_count
+        return included_value, included_count + excluded_count
 
     return knapsack_recur(capacity, counter)
 

--- a/knapsack/tests/test_knapsack.py
+++ b/knapsack/tests/test_knapsack.py
@@ -60,7 +60,7 @@ class Test(unittest.TestCase):
 
     def test_knapsack_with_count(self):
         """
-        test for maximum value and number of optimal subsets
+        test for maximum value and number of optimal selections
         """
         cap = 50
         val = [60, 100, 120]
@@ -68,6 +68,8 @@ class Test(unittest.TestCase):
         c = len(val)
         assert k.knapsack_with_count(cap, w, val, c) == (220, 1)
         assert k.knapsack_with_count(cap, w, val, c, True) == (300, 1)
+        assert k.knapsack_with_count(0, w, val, c) == (0, 1)
+        assert k.knapsack_with_count(50, w, val, 0) == (0, 1)
 
     def test_knapsack_with_count_ties(self):
         """

--- a/knapsack/tests/test_knapsack.py
+++ b/knapsack/tests/test_knapsack.py
@@ -58,6 +58,24 @@ class Test(unittest.TestCase):
         c = len(val)
         assert k.knapsack(cap, w, val, c, True) == 300
 
+    def test_knapsack_with_count(self):
+        """
+        test for maximum value and number of optimal subsets
+        """
+        cap = 50
+        val = [60, 100, 120]
+        w = [10, 20, 30]
+        c = len(val)
+        assert k.knapsack_with_count(cap, w, val, c) == (220, 1)
+        assert k.knapsack_with_count(cap, w, val, c, True) == (300, 1)
+
+    def test_knapsack_with_count_ties(self):
+        """
+        test tie handling for counting optimal subsets
+        """
+        assert k.knapsack_with_count(3, [1, 2, 3], [1, 2, 3], 3) == (3, 2)
+        assert k.knapsack_with_count(2, [1, 2], [1, 2], 2, True) == (2, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Describe your change:
Add a knapsack variation that returns both the maximum achievable value and the number of distinct optimal selections.

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

### Validation
- `python -m doctest -v knapsack/knapsack.py` (pass)
- `python -m unittest knapsack.tests.test_knapsack -v` (pass)

Fixes #14463
