### PR TITLE
fix(simplex): raise ValueError instead of returning empty dict when max iterations reached

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,7 +302,13 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+
+        max_iterations = Tableau.maxiter
+        raise ValueError(
+            "Simplex did not converge within "
+            + str(max_iterations)
+            + " iterations. The problem may be cycling or unbounded."
+        )
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic


### PR DESCRIPTION
## Fixes #14584

### Problem

The `run_simplex()` method in `linear_programming/simplex.py` silently returned an empty dict `{}` when the maximum iteration limit (`Tableau.maxiter`) was reached, with no indication of why it failed. This made it impossible for callers to distinguish between:
- A valid converging solution (returning `{"P": 0.0}`)
- A cycling or unbounded problem that failed to converge

### Solution

Modified `run_simplex()` to raise a descriptive `ValueError` when the maximum iterations are exhausted:

```python
raise ValueError(
    "Simplex did not converge within "
    + str(max_iterations)
    + " iterations. The problem may be cycling or unbounded."
)
```

### Testing

- All existing doctests pass
- The change is minimal and targeted (7 lines added, 1 line removed)

---

*This contribution was developed with AI assistance.*