### PR TITLE
searches: improve linear search type hints

### DIFF
--- a/searches/linear_search.py
+++ b/searches/linear_search.py
@@ -8,8 +8,10 @@ For manual testing run:
 python3 linear_search.py
 """
 
+from collections.abc import Sequence
 
-def linear_search(sequence: list, target: int) -> int:
+
+def linear_search[T](sequence: Sequence[T], target: T) -> int:
     """A pure Python implementation of a linear search algorithm
 
     :param sequence: a collection with comparable items (sorting is not required for
@@ -33,7 +35,9 @@ def linear_search(sequence: list, target: int) -> int:
     return -1
 
 
-def rec_linear_search(sequence: list, low: int, high: int, target: int) -> int:
+def rec_linear_search[T](
+    sequence: Sequence[T], low: int, high: int, target: T
+) -> int:
     """
     A pure Python implementation of a recursive linear search algorithm
 


### PR DESCRIPTION
Fixes #14592

Refines the type annotations in `searches/linear_search.py` by using generic `Sequence` inputs and matching target types for both `linear_search` and `rec_linear_search`. This keeps the implementation behavior unchanged while making the type hints more precise and consistent with the repository typing style.