### PR TITLE
linear_programming: raise on simplex non-convergence

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -285,6 +285,15 @@ class Tableau:
         ... [1, 0, 0, 0, 0, 0, -1, 0, 1, 2.0]
         ... ]), 2, 2).run_simplex().items()} # doctest: +ELLIPSIS
         {'P': 132.0, 'x1': 12.000... 'x2': 5.999...}
+
+        >>> original_maxiter = Tableau.maxiter
+        >>> Tableau.maxiter = 0
+        >>> Tableau(np.array([[-1, -1, 0, 0, 0], [1, 3, 1, 0, 4],
+        ... [3, 1, 0, 1, 4.0]]), 2, 0).run_simplex()
+        Traceback (most recent call last):
+        ...
+        ValueError: No convergence within 0 iterations; may be cycling/unbounded.
+        >>> Tableau.maxiter = original_maxiter
         """
         # Stop simplex algorithm from cycling.
         for _ in range(Tableau.maxiter):
@@ -302,7 +311,11 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+        msg = (
+            f"No convergence within {Tableau.maxiter} iterations; "
+            "may be cycling/unbounded."
+        )
+        raise ValueError(msg)
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic


### PR DESCRIPTION
### Describe your change:

Fixes #14584
Fixes #15047
Fixes #15243

`Tableau.run_simplex()` now raises a descriptive `ValueError` when `Tableau.maxiter` is exhausted instead of silently returning `{}`. This lets callers distinguish a non-converged or cycling tableau from a real empty solution.

The doctest temporarily sets `Tableau.maxiter = 0` to cover the non-convergence path deterministically.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

Testing:
- `python3 -m pytest linear_programming/simplex.py`
- `python3 -m ruff check linear_programming/simplex.py`