### PR TITLE
fix: int_to_roman silently returns wrong values for out-of-range input

### DIFF
--- a/conversions/roman_numerals.py
+++ b/conversions/roman_numerals.py
@@ -40,12 +40,37 @@ def roman_to_int(roman: str) -> int:
 
 def int_to_roman(number: int) -> str:
     """
-    Given a integer, convert it to an roman numeral.
+    Given an integer, convert it to a Roman numeral.
+    Input must be an integer in the range 1 to 3999.
     https://en.wikipedia.org/wiki/Roman_numerals
     >>> tests = {"III": 3, "CLIV": 154, "MIX": 1009, "MMD": 2500, "MMMCMXCIX": 3999}
     >>> all(int_to_roman(value) == key for key, value in tests.items())
     True
+    >>> int_to_roman(0)
+    Traceback (most recent call last):
+        ...
+    ValueError: int_to_roman only accepts integers in the range 1 to 3999, got 0
+    >>> int_to_roman(-1)
+    Traceback (most recent call last):
+        ...
+    ValueError: int_to_roman only accepts integers in the range 1 to 3999, got -1
+    >>> int_to_roman(4000)
+    Traceback (most recent call last):
+        ...
+    ValueError: int_to_roman only accepts integers in the range 1 to 3999, got 4000
+    >>> int_to_roman(True)
+    Traceback (most recent call last):
+        ...
+    TypeError: int_to_roman only accepts integers, got bool
     """
+    if not isinstance(number, int) or isinstance(number, bool):
+        raise TypeError(
+            f"int_to_roman only accepts integers, got {type(number).__name__}"
+        )
+    if not 1 <= number <= 3999:
+        raise ValueError(
+            f"int_to_roman only accepts integers in the range 1 to 3999, got {number}"
+        )
     result = []
     for arabic, roman in ROMAN:
         (factor, number) = divmod(number, arabic)

--- a/conversions/roman_numerals.py
+++ b/conversions/roman_numerals.py
@@ -64,13 +64,11 @@ def int_to_roman(number: int) -> str:
     TypeError: int_to_roman only accepts integers, got bool
     """
     if not isinstance(number, int) or isinstance(number, bool):
-        raise TypeError(
-            f"int_to_roman only accepts integers, got {type(number).__name__}"
-        )
+        msg = f"int_to_roman only accepts integers, got {type(number).__name__}"
+        raise TypeError(msg)
     if not 1 <= number <= 3999:
-        raise ValueError(
-            f"int_to_roman only accepts integers in the range 1 to 3999, got {number}"
-        )
+        msg = f"int_to_roman only accepts integers in the range 1 to 3999, got {number}"
+        raise ValueError(msg)
     result = []
     for arabic, roman in ROMAN:
         (factor, number) = divmod(number, arabic)


### PR DESCRIPTION
## Problem

`int_to_roman` performed no input validation. Python's floor-division semantics silently corrupted results for out-of-range inputs:

```python
# Before this fix:
int_to_roman(0)    # ''          <- silent wrong output
int_to_roman(-1)   # 'CMXCIX'   <- silently returns 999 (WRONG)
int_to_roman(-5)   # 'CMXCV'    <- silently returns 995 (WRONG)
int_to_roman(4000) # 'MMMM'     <- not a valid standard Roman numeral
int_to_roman(True) # 'I'        <- bool silently accepted as 1
```

Root cause: `divmod(-1, 1000)` returns `(-1, 999)` in Python, so `'M' * -1` yields `''` and the remainder `999` propagates through the ROMAN lookup table, producing a plausible-looking but completely wrong answer.

## Fix

Added early validation guards:

1. **TypeError** for non-integer types (including `bool`, which is a subclass of `int`)
2. **ValueError** for integers outside the valid range [1, 3999]
3. Added four doctest error cases so the guards are exercised by the doctest runner

## Describe your change:

* [x] Fix a bug or typo in an existing algorithm?

## Checklist:

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.