### PR TITLE
fix: add explicit encoding to open() calls for cross-platform portability

### DIFF
--- a/data_compression/huffman.py
+++ b/data_compression/huffman.py
@@ -26,7 +26,7 @@ def parse_file(file_path: str) -> list[Letter]:
     frequencies, then convert the dict into a list of Letters.
     """
     chars: dict[str, int] = {}
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         while True:
             c = f.read(1)
             if not c:
@@ -78,7 +78,7 @@ def huffman(file_path: str) -> None:
         k: v for letter in traverse_tree(root, "") for k, v in letter.bitstring.items()
     }
     print(f"Huffman Coding  of {file_path}: ")
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         while True:
             c = f.read(1)
             if not c:

--- a/data_structures/arrays/sudoku_solver.py
+++ b/data_structures/arrays/sudoku_solver.py
@@ -206,7 +206,7 @@ def solved(values):
 
 def from_file(filename, sep="\n"):
     "Parse a file into a list of strings, separated by sep."
-    with open(filename) as file:
+    with open(filename, encoding="utf-8") as file:
         return file.read().strip().split(sep)
 
 

--- a/searches/tabu_search.py
+++ b/searches/tabu_search.py
@@ -49,7 +49,7 @@ def generate_neighbours(path):
 
     dict_of_neighbours = {}
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         for line in f:
             if line.split()[0] not in dict_of_neighbours:
                 _list = []
@@ -88,7 +88,7 @@ def generate_first_solution(path, dict_of_neighbours):
         will travel, if he follows the path in first_solution.
     """
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         start_node = f.read(1)
     end_node = start_node
 

--- a/strings/detecting_english_programmatically.py
+++ b/strings/detecting_english_programmatically.py
@@ -7,7 +7,7 @@ LETTERS_AND_SPACE = ascii_letters + " \t\n"
 def load_dictionary() -> dict[str, None]:
     path = os.path.split(os.path.realpath(__file__))
     english_words: dict[str, None] = {}
-    with open(path[0] + "/dictionary.txt") as dictionary_file:
+    with open(path[0] + "/dictionary.txt", encoding="utf-8") as dictionary_file:
         for word in dictionary_file.read().split("\n"):
             english_words[word] = None
     return english_words

--- a/strings/word_patterns.py
+++ b/strings/word_patterns.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     import time
 
     start_time = time.time()
-    with open("dictionary.txt") as in_file:
+    with open("dictionary.txt", encoding="utf-8") as in_file:
         word_list = in_file.read().splitlines()
 
     all_patterns: dict = {}


### PR DESCRIPTION
## Problem

Python's `open()` uses locale-dependent encoding by default, which varies across platforms:
- **macOS/Linux**: typically UTF-8
- **Windows**: typically cp1252 or other locale-specific encoding

This means code that works perfectly on macOS/Linux can silently corrupt data on Windows (and vice versa). Since Python 3.15, the default will change to UTF-8, but for now it's best practice to be explicit.

PEP 686 (Python 3.15+) will make UTF-8 the default, but explicit encoding is recommended for all current Python versions.

## Changes

Added `encoding="utf-8"` to text-mode `open()` calls in 5 files:

| File | Line | Purpose |
|------|------|---------|
| `searches/tabu_search.py` | 52, 91 | Reading graph adjacency data |
| `data_structures/arrays/sudoku_solver.py` | 209 | Parsing Sudoku puzzles |
| `strings/word_patterns.py` | 49 | Loading dictionary file |
| `data_compression/huffman.py` | 29, 81 | Reading/writing compressed text |
| `strings/detecting_english_programmatically.py` | 10 | Loading English dictionary |

## Testing

All existing tests pass — no behavioral change for correct UTF-8 files.
