### PR TITLE
fix: raise ValueError for multi-character separator in split

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,7 +17,14 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+        ...
+    ValueError: separator must be a single character
     """
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
 
     split_words = []
 


### PR DESCRIPTION
### Describe your change:

`strings/split.py` previously iterated character by character comparing each char to `separator`, so any multi-character separator silently failed to match and the whole string was returned as a single element.

Now `split` validates `len(separator) == 1` up front and raises `ValueError("separator must be a single character")` when it isn't, matching the actual capability of the implementation. Added a doctest covering the new error path.

Fixes #14649

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: `Fixes #ISSUE-NUMBER`.