### PR TITLE
fix: raise ValueError when run_simplex exhausts maxiter

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,7 +302,10 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+        raise ValueError(
+            f"Simplex did not converge within {Tableau.maxiter} iterations. "
+            "The problem may be cycling or unbounded."
+        )
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic

--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,10 +302,11 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        raise ValueError(
+        msg = (
             f"Simplex did not converge within {Tableau.maxiter} iterations. "
             "The problem may be cycling or unbounded."
         )
+        raise ValueError(msg)
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic


### PR DESCRIPTION
### Describe your change:

`Tableau.run_simplex` was silently returning an empty dict `{}` after exhausting `Tableau.maxiter` iterations, making it impossible for callers to tell convergence failure apart from a problem whose optimum is genuinely all-zero. The empty-dict path also masked cycling/unboundedness.

Now it raises `ValueError` with the iteration limit so the caller gets an actionable signal. All existing doctests still pass.

Fixes #14584

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: `Fixes #ISSUE-NUMBER`.