### PR TITLE
fix(strings): reject multi-char split separators

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,7 +17,14 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+    ValueError: separator must be a single character
     """
+
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
 
     split_words = []
 


### PR DESCRIPTION
Closes #14649.

Summary:
- raise a ValueError when split() gets a separator longer than 1 character
- add doctest coverage for the new failure case

Checks:
- python3 -m doctest strings/split.py
- python3 - <<'PY' ... split('a--b--c', '--') raises ValueError ... PY