### PR TITLE
fix(split): support multi-character separators

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,17 +17,31 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    ['a', 'b', 'c']
+
+    >>> split("apple##banana##cherry", separator="##")
+    ['apple', 'banana', 'cherry']
     """
 
     split_words = []
+    separator_length = len(separator)
+
+    if separator_length == 0:
+        return [string]
 
     last_index = 0
-    for index, char in enumerate(string):
-        if char == separator:
+    index = 0
+    while index < len(string):
+        if string[index : index + separator_length] == separator:
             split_words.append(string[last_index:index])
-            last_index = index + 1
-        if index + 1 == len(string):
-            split_words.append(string[last_index : index + 1])
+            last_index = index + separator_length
+            index += separator_length
+        else:
+            index += 1
+
+    split_words.append(string[last_index:])
     return split_words
 
 


### PR DESCRIPTION
## Description

The custom `split` function in `strings/split.py` compares each character in the input string against the full separator string, which means multi-character separators such as `"--"` are never matched and the string is returned unsplit.

### Root Cause

The function iterates over individual characters with `for index, char in enumerate(string): if char == separator:`, which only works for single-character separators.

### Fix

Replace character-by-character iteration with substring matching at each position, comparing `string[index:index + separator_length]` against the separator. This correctly handles separators of any length.

### Testing

- All existing doctests pass
- Added doctests for multi-character separators: `"--"` and `"##"`

Fixes #14649
