### PR TITLE
Fix/tree sort iterable type hint

### DIFF
--- a/sorts/tree_sort.py
+++ b/sorts/tree_sort.py
@@ -50,14 +50,17 @@ def tree_sort(arr: Iterable[int]) -> tuple[int, ...]:
     (-4, 2, 5, 7, 9)
     >>> tree_sort([5, 6, 1, -1, 4, 37, 2, 7])
     (-1, 1, 2, 4, 5, 6, 7, 37)
-
     >>> tree_sort(range(10, -10, -1)) == tuple(sorted(range(10, -10, -1)))
     True
     """
-    if len(arr) == 0:
-        return tuple(arr)
-    root = Node(arr[0])
-    for item in arr[1:]:
+    iterator = iter(arr)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return ()
+
+    root = Node(first)
+    for item in iterator:
         root.insert(item)
     return tuple(root)
 

--- a/sorts/tree_sort.py
+++ b/sorts/tree_sort.py
@@ -1,12 +1,10 @@
 """
 Tree_sort algorithm.
-
 Build a Binary Search Tree and then iterate thru it to get a sorted list.
 """
-
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 
@@ -38,8 +36,7 @@ class Node:
             else:
                 self.right.insert(val)
 
-
-def tree_sort(arr: list[int]) -> tuple[int, ...]:
+def tree_sort(arr: Iterable[int]) -> tuple[int, ...]:
     """
     >>> tree_sort([])
     ()
@@ -54,8 +51,8 @@ def tree_sort(arr: list[int]) -> tuple[int, ...]:
     >>> tree_sort([5, 6, 1, -1, 4, 37, 2, 7])
     (-1, 1, 2, 4, 5, 6, 7, 37)
 
-    # >>> tree_sort(range(10, -10, -1)) == tuple(sorted(range(10, -10, -1)))
-    # True
+    >>> tree_sort(range(10, -10, -1)) == tuple(sorted(range(10, -10, -1)))
+    True
     """
     if len(arr) == 0:
         return tuple(arr)

--- a/sorts/tree_sort.py
+++ b/sorts/tree_sort.py
@@ -2,6 +2,7 @@
 Tree_sort algorithm.
 Build a Binary Search Tree and then iterate thru it to get a sorted list.
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
@@ -35,6 +36,7 @@ class Node:
                 self.right = Node(val)
             else:
                 self.right.insert(val)
+
 
 def tree_sort(arr: Iterable[int]) -> tuple[int, ...]:
     """


### PR DESCRIPTION
### Describe your change:
Improve type hint for `tree_sort` to accept any `Iterable[int]` instead of only `list[int]`, and enable the previously commented-out range doctest.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".