### PR TITLE
Fix num_digits_fast for powers of ten

### DIFF
--- a/maths/number_of_digits.py
+++ b/maths/number_of_digits.py
@@ -44,13 +44,17 @@ def num_digits_fast(n: int) -> int:
     5
     >>> num_digits_fast(123)
     3
+    >>> num_digits_fast(1000)
+    4
+    >>> num_digits_fast(10**15)
+    16
     >>> num_digits_fast(0)
     1
     >>> num_digits_fast(-1)
     1
     >>> num_digits_fast(-123456)
     6
-    >>> num_digits('123')  # Raises a TypeError for non-integer input
+    >>> num_digits_fast('123')  # Raises a TypeError for non-integer input
     Traceback (most recent call last):
         ...
     TypeError: Input must be an integer
@@ -59,7 +63,12 @@ def num_digits_fast(n: int) -> int:
     if not isinstance(n, int):
         raise TypeError("Input must be an integer")
 
-    return 1 if n == 0 else math.floor(math.log(abs(n), 10) + 1)
+    if n == 0:
+        return 1
+
+    abs_n = abs(n)
+    digits = math.floor(math.log10(abs_n)) + 1
+    return digits + 1 if 10**digits <= abs_n else digits
 
 
 def num_digits_faster(n: int) -> int:
@@ -77,7 +86,7 @@ def num_digits_faster(n: int) -> int:
     1
     >>> num_digits_faster(-123456)
     6
-    >>> num_digits('123')  # Raises a TypeError for non-integer input
+    >>> num_digits_faster('123')  # Raises a TypeError for non-integer input
     Traceback (most recent call last):
         ...
     TypeError: Input must be an integer


### PR DESCRIPTION
### Describe your change:

Fix `num_digits_fast()` so it returns the correct digit count for powers of ten affected by floating-point logarithm rounding, such as `1000` and `10**15`.

The function still uses `math.log10()` for the fast estimate, then corrects exact power-of-ten boundaries with an integer comparison. I also updated the related doctests so each function tests its own non-integer input path.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://github.com/python/typing).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

### Local verification

```bash
python3 -m doctest -v maths/number_of_digits.py
uvx ruff check maths/number_of_digits.py
```

Both checks passed locally.