### PR TITLE
fix: reject multi-character separators in split() (Closes #14649)

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,7 +17,20 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+        ...
+    ValueError: separator must be a single character
+
+    >>> split("hello world", separator="")
+    Traceback (most recent call last):
+        ...
+    ValueError: separator must be a single character
     """
+
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
 
     split_words = []
 


### PR DESCRIPTION
### Describe your change

This PR fixes the bug where the custom `split` function in `strings/split.py` silently returns the unsplit string when a multi-character separator is provided.

The function was comparing each individual character against the full separator string, so multi-character separators like `"--"` were never matched.

**Fix:** Added validation at the beginning of the function to raise a `ValueError` when `separator` is not exactly one character. This matches the expected behavior described in the issue.

Closes #14649

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: "Closes #14649".