### PR TITLE
Fix type hint consistency in rotate_array docstring

### DIFF
--- a/data_structures/arrays/rotate_array.py
+++ b/data_structures/arrays/rotate_array.py
@@ -3,11 +3,11 @@ def rotate_array(arr: list[int], steps: int) -> list[int]:
     Rotates a list to the right by steps positions.
 
     Parameters:
-    arr (List[int]): The list of integers to rotate.
+    arr (list[int]): The list of integers to rotate.
     steps (int): Number of positions to rotate. Can be negative for left rotation.
 
     Returns:
-    List[int]: Rotated list.
+    list[int]: Rotated list.
 
     Examples:
     >>> rotate_array([1, 2, 3, 4, 5], 2)


### PR DESCRIPTION
Updated List[int] to list[int] in docstring for consistency with function type hints.

### Describe your change:



* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
