### PR TITLE
Fix fuzzy set union boundaries

### DIFF
--- a/fuzzy_logic/fuzzy_operations.py
+++ b/fuzzy_logic/fuzzy_operations.py
@@ -57,7 +57,7 @@ class FuzzySet:
 
     # Union Operations
     >>> siya.union(sheru)
-    FuzzySet(name='Siya U Sheru', left_boundary=0.4, peak=0.7, right_boundary=1.0)
+    FuzzySet(name='Siya U Sheru', left_boundary=0.4, peak=1, right_boundary=0.7)
     """
 
     name: str
@@ -147,13 +147,13 @@ class FuzzySet:
             FuzzySet: A new fuzzy set representing the union.
 
         >>> FuzzySet("a", 0.1, 0.2, 0.3).union(FuzzySet("b", 0.4, 0.5, 0.6))
-        FuzzySet(name='a U b', left_boundary=0.1, peak=0.6, right_boundary=0.35)
+        FuzzySet(name='a U b', left_boundary=0.1, peak=0.5, right_boundary=0.6)
         """
         return FuzzySet(
             f"{self.name} U {other.name}",
             min(self.left_boundary, other.left_boundary),
+            max(self.peak, other.peak),
             max(self.right_boundary, other.right_boundary),
-            (self.peak + other.peak) / 2,
         )
 
     def plot(self):


### PR DESCRIPTION
### Describe your change:

Fixes #11871.

This fixes `FuzzySet.union()` so the returned triangular fuzzy set keeps its fields in boundary order:

- `left_boundary`: minimum left boundary
- `peak`: maximum peak
- `right_boundary`: maximum right boundary

Rationale: the usual fuzzy set union is the pointwise maximum, `mu_A∪B(x) = max(mu_A(x), mu_B(x))`. Since this class stores a simplified triangular representation instead of the full pointwise membership curve, the updated values form an enclosing triangular approximation using the minimum left boundary and the maximum peak/right boundary. The previous average was not following a fuzzy-union convention and could produce invalid triangular parameters such as `peak=0.6, right_boundary=0.35`.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

Local checks:
- `.venv/bin/python -m doctest -v fuzzy_logic/fuzzy_operations.py`
- `.venv/bin/python -m pytest fuzzy_logic/fuzzy_operations.py`
- `.venv/bin/ruff check fuzzy_logic/fuzzy_operations.py`
- `.venv/bin/ruff format --check fuzzy_logic/fuzzy_operations.py`
- `.venv/bin/mypy --ignore-missing-imports fuzzy_logic/fuzzy_operations.py`
- `git diff --check`