### PR TITLE
fix: correct treap split() comparison to match docstring behavior

### DIFF
--- a/data_structures/binary_tree/treap.py
+++ b/data_structures/binary_tree/treap.py
@@ -5,7 +5,7 @@ from random import random
 
 class Node:
     """
-    Treap's node
+    Treap's nodeh
     Treap is a binary tree by value and heap by priority
     """
 
@@ -41,7 +41,7 @@ def split(root: Node | None, value: int) -> tuple[Node | None, Node | None]:
     """
     if root is None or root.value is None:  # None tree is split into 2 Nones
         return None, None
-    elif value < root.value:
+    elif value <= root.value:
         """
         Right tree's root will be current node.
         Now we split(with the same value) current node's left son

--- a/data_structures/binary_tree/treap.py
+++ b/data_structures/binary_tree/treap.py
@@ -5,7 +5,7 @@ from random import random
 
 class Node:
     """
-    Treap's nodeh
+    Treap's node
     Treap is a binary tree by value and heap by priority
     """
 

--- a/data_structures/binary_tree/treap.py
+++ b/data_structures/binary_tree/treap.py
@@ -101,8 +101,8 @@ def erase(root: Node | None, value: int) -> Node | None:
     Split all nodes with values greater into right.
     Merge left, right
     """
-    left, right = split(root, value - 1)
-    _, right = split(right, value)
+    left, right = split(root, value)
+    _, right = split(right, value + 1)
     return merge(left, right)
 
 


### PR DESCRIPTION
### Describe your change:

The `split()` function in `data_structures/binary_tree/treap.py` uses a strict `<` comparison, but the docstring states:

> Left tree contains all values less than split value.
> Right tree contains all values greater or equal, than split value

This means when splitting by a value that already exists in the treap, the existing node ends up in the LEFT subtree instead of the RIGHT subtree, which contradicts the documented behavior.

**Fix:** Changed `elif value < root.value:` to `elif value <= root.value:` so that equal values go to the right subtree as documented.

Fixes #7854

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
