### PR TITLE
refactor(maths): use direct iteration instead of index-based loops in persistence.py

### DIFF
--- a/maths/persistence.py
+++ b/maths/persistence.py
@@ -28,8 +28,8 @@ def multiplicative_persistence(num: int) -> int:
         numbers = [int(i) for i in num_string]
 
         total = 1
-        for i in range(len(numbers)):
-            total *= numbers[i]
+        for number in numbers:
+            total *= number
 
         num_string = str(total)
 
@@ -67,8 +67,8 @@ def additive_persistence(num: int) -> int:
         numbers = [int(i) for i in num_string]
 
         total = 0
-        for i in range(len(numbers)):
-            total += numbers[i]
+        for number in numbers:
+            total += number
 
         num_string = str(total)
 


### PR DESCRIPTION
## Summary

Replace `for i in range(len(numbers))` with `for number in numbers` in both `multiplicative_persistence()` and `additive_persistence()` functions.

## Changes
- Use direct iteration (`for number in numbers`) instead of index-based loops (`for i in range(len(numbers))`)
- Applies to both `multiplicative_persistence()` and `additive_persistence()`

## Why
Direct iteration is more Pythonic (PEP 20: *Simple is better than complex*) and avoids unnecessary index lookups (`numbers[i]`). The behavior is unchanged and all existing doctests pass.

## Checklist
- [x] All doctests pass
- [x] No behavioral changes