### PR TITLE
fix(maths): correct recursive call in sum_of_digits_recursion

### DIFF
--- a/maths/sum_of_digits.py
+++ b/maths/sum_of_digits.py
@@ -31,7 +31,7 @@ def sum_of_digits_recursion(n: int) -> int:
     0
     """
     n = abs(n)
-    return n if n < 10 else n % 10 + sum_of_digits(n // 10)
+    return n if n < 10 else n % 10 + sum_of_digits_recursion(n // 10)
 
 
 def sum_of_digits_compact(n: int) -> int:


### PR DESCRIPTION
## Summary

Fix a bug where `sum_of_digits_recursion()` was calling `sum_of_digits()` (the iterative version) instead of itself in the recursive case.

## Bug
In `maths/sum_of_digits.py` line 34:
```python
# Before (bug): calls the iterative function, not itself
return n if n < 10 else n % 10 + sum_of_digits(n // 10)

# After (fix): properly calls itself recursively
return n if n < 10 else n % 10 + sum_of_digits_recursion(n // 10)
```

## Impact
- The function was not actually recursive as its name and documentation suggest
- The result was correct (it fell back to the iterative version), but the intent was wrong
- This is a correctness fix for the algorithm implementation

## Checklist
- [x] All doctests pass
- [x] No behavioral change in output (the function still produces correct results)