### PR TITLE
fix: Boyer-Moore bad character shift was dead code in for-loop

### DIFF
--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -83,18 +83,30 @@ class BoyerMooreSearch:
         >>> bms = BoyerMooreSearch(text="ABAABA", pattern="AB")
         >>> bms.bad_character_heuristic()
         [0, 3]
+
+        >>> bms = BoyerMooreSearch(text="AAAAA", pattern="AB")
+        >>> bms.bad_character_heuristic()
+        []
+
+        >>> bms = BoyerMooreSearch(text="ABABAB", pattern="ABA")
+        >>> bms.bad_character_heuristic()
+        [0, 2]
+
+        >>> bms = BoyerMooreSearch(text="", pattern="AB")
+        >>> bms.bad_character_heuristic()
+        []
         """
 
         positions = []
-        for i in range(self.textLen - self.patLen + 1):
+        i = 0
+        while i <= self.textLen - self.patLen:
             mismatch_index = self.mismatch_in_text(i)
             if mismatch_index == -1:
                 positions.append(i)
+                i += 1
             else:
                 match_index = self.match_in_pattern(self.text[mismatch_index])
-                i = (
-                    mismatch_index - match_index
-                )  # shifting index lgtm [py/multiple-definition]
+                i = max(i + 1, mismatch_index - match_index)
         return positions
 
 


### PR DESCRIPTION
## Description

The `bad_character_heuristic()` method used a `for`-loop with an assignment to the loop variable `i`, which was immediately overwritten by the next iteration. This caused the algorithm to degrade from **O(n/m)** to **O(n*m)** naive search -- the bad character shift was effectively dead code.

## Changes

- Changed `for i in range(...)` to a `while` loop so the shift actually takes effect
- Added `max(i + 1, mismatch_index - match_index)` guard to prevent backward skips when the mismatched character appears to the right of the mismatch in the pattern
- Added 3 edge case doctests: no match, overlapping matches, empty text

## Verification

All 12 doctests pass:
```
python -m doctest strings/boyer_moore_search.py
```
Closes #13039