### PR TITLE
fix: raise ValueError for zero input in binary_count_trailing_zeros

### DIFF
--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -17,7 +17,9 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros(4294967296)
     32
     >>> binary_count_trailing_zeros(0)
-    0
+    Traceback (most recent call last):
+        ...
+    ValueError: Input value must be a positive integer
     >>> binary_count_trailing_zeros(-10)
     Traceback (most recent call last):
         ...
@@ -29,13 +31,13 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros("0")
     Traceback (most recent call last):
         ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
+    TypeError: '<=' not supported between instances of 'str' and 'int'
     """
-    if a < 0:
+    if a <= 0:
         raise ValueError("Input value must be a positive integer")
     elif isinstance(a, float):
         raise TypeError("Input value must be a 'int' type")
-    return 0 if (a == 0) else int(log2(a & -a))
+    return int(log2(a & -a))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #14479

The `binary_count_trailing_zeros` function previously returned `0` for input `a == 0`, but mathematically the number of trailing zeros in the binary representation of 0 is undefined (infinite). Returning `0` was misleading and could cause bugs in algorithms relying on correct trailing zero counts.

### Changes
- Changed `if a < 0` to `if a <= 0` to catch zero input
- Removed the `0 if (a == 0) else` ternary fallback
- Updated doctest for `binary_count_trailing_zeros(0)` to expect `ValueError`
- Updated string-input doctest error message from `'<'` to `'<='`

### Verification
- ✅ doctest: 9/9 tests passed
- ✅ ruff: All checks passed
- ✅ mypy: No issues found