### PR TITLE
fix(simplex): raise error instead of silent failure on max iterations

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,7 +302,9 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+        raise ValueError(
+            f"Simplex did not converge within {Tableau.maxiter} iterations. "
+             "The problem may be cycling or unbounded.")
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic

--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -304,7 +304,8 @@ class Tableau:
                 self.tableau = self.pivot(row_idx, col_idx)
         raise ValueError(
             f"Simplex did not converge within {Tableau.maxiter} iterations. "
-             "The problem may be cycling or unbounded.")
+            "The problem may be cycling or unbounded."
+        )
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic


### PR DESCRIPTION
Fixes silent failure in run_simplex().

Previously, when the maximum iteration limit was reached, the function returned an empty dictionary, making debugging impossible.

This change raises a ValueError instead, making the failure explicit and easier to debug.

Behavior change:
- Before: return {}
- After: raise ValueError with descriptive message