### PR TITLE
fix: handle empty input in tim_sort

### DIFF
--- a/sorts/tim_sort.py
+++ b/sorts/tim_sort.py
@@ -52,8 +52,12 @@ def tim_sort(lst: list[Any] | tuple[Any, ...] | str) -> list[Any]:
     True
     >>> tim_sort([3, 2, 1]) == sorted([3, 2, 1])
     True
+    >>> tim_sort([])
+    []
     """
     length = len(lst)
+    if length == 0:
+        return []
     runs, sorted_runs = [], []
     new_run = [lst[0]]
     sorted_array: list[Any] = []


### PR DESCRIPTION
### Describe your change:

Fixed `tim_sort([])` so it returns an empty list instead of raising `IndexError` when the implementation tries to read `lst[0]`.

## Why

Sorting an empty sequence should be a valid no-op. Other sort implementations in this repository handle empty input, and Python's `sorted([])` returns `[]`.

## How tested

- RED: `/opt/homebrew/opt/python@3.14/bin/python3.14 -m doctest -v sorts/tim_sort.py` failed with `IndexError: list index out of range` before the fix
- `/opt/homebrew/opt/python@3.14/bin/python3.14 -m doctest -v sorts/tim_sort.py`
- `/tmp/thealgorithms-py314-pytest/bin/python -m pytest --doctest-modules sorts/tim_sort.py -q`
- Randomized comparison of `tim_sort(case)` against `sorted(case)` for 100 generated lists
- `git diff --check`

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
