### PR TITLE
fix: handle empty inputs in search algorithms

### DIFF
--- a/searches/exponential_search.py
+++ b/searches/exponential_search.py
@@ -81,10 +81,19 @@ def exponential_search(sorted_collection: list[int], item: int) -> int:
     1
     >>> exponential_search([0, 5, 7, 10, 15], 6)
     -1
+    >>> exponential_search([], 1)
+    -1
+    >>> exponential_search([1, 1], -1)
+    -1
     """
     if list(sorted_collection) != sorted(sorted_collection):
         raise ValueError("sorted_collection must be sorted in ascending order")
 
+    if not sorted_collection:
+        return -1
+
+    if sorted_collection[0] > item:
+        return -1
     if sorted_collection[0] == item:
         return 0
 

--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -33,9 +33,14 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     10
     >>> jump_search(["aa", "bb", "cc", "dd", "ee", "ff"], "ee")
     4
+    >>> jump_search([], 1)
+    -1
     """
 
     arr_size = len(arr)
+    if arr_size == 0:
+        return -1
+
     block_size = int(math.sqrt(arr_size))
 
     prev = 0


### PR DESCRIPTION
## What changed

Fixed edge cases in two search algorithms:

- `exponential_search([], item)` now returns `-1` instead of raising `IndexError`
- `jump_search([], item)` now returns `-1` instead of raising `IndexError`
- `exponential_search` now returns `-1` immediately when the target is smaller than the first sorted value, avoiding an infinite recursive binary search path

## Why

Both functions document that they return `-1` when an item is not found. Empty collections and targets below the first sorted value are valid not-found cases and should not raise runtime exceptions.

## How tested

- RED: `/opt/homebrew/opt/python@3.14/bin/python3.14 -m doctest -v searches/exponential_search.py searches/jump_search.py` failed with `IndexError` before the empty-input fix
- RED: `/opt/homebrew/opt/python@3.14/bin/python3.14 -m doctest -v searches/exponential_search.py` failed with `RecursionError` before the below-first-value fix
- `/opt/homebrew/opt/python@3.14/bin/python3.14 -m doctest -v searches/exponential_search.py searches/jump_search.py`
- `/tmp/thealgorithms-py314-pytest/bin/python -m pytest --doctest-modules searches/exponential_search.py searches/jump_search.py -q`
- Randomized comparison against expected search results for 200 generated sorted lists
- `git diff --check`