### PR TITLE
Fixes #14817

### DIFF
--- a/linear_algebra/src/polynom_for_points.py
+++ b/linear_algebra/src/polynom_for_points.py
@@ -33,6 +33,12 @@ def points_to_polynomial(coordinates: list[list[int]]) -> str:
     Traceback (most recent call last):
         ...
     ValueError: The program cannot work out a fitting polynomial.
+    >>> points_to_polynomial([[0, 1], [1, 2], [2, 5]])
+    'f(x)=x^2*1.0+x^1*0.0+x^0*1.0'
+    >>> points_to_polynomial([[1, 2], [0, 1], [2, 5]])
+    Traceback (most recent call last):
+        ...
+    ValueError: The program cannot work out a fitting polynomial.
     """
     if len(coordinates) == 0 or not all(len(pair) == 2 for pair in coordinates):
         raise ValueError("The program cannot work out a fitting polynomial.")
@@ -65,6 +71,41 @@ def points_to_polynomial(coordinates: list[list[int]]) -> str:
         for number in range(x):
             if count == number:
                 continue
+            if matrix[count][count] == 0:
+                # Diagonal element is zero which results in zero-division-error
+                # as per bug #14817.
+                # Using partial pivoting: before each elimination step, swap in a row
+                # whose matrix[r][count] is non-zero (largest magnitude).
+                # This removes the zero-pivot crash and improves numerical stability.
+
+                swap_row_index = count
+                max_col_value = matrix[count][count]
+                # Search downwards from current row as earlier rows are
+                # already processed.
+                for row in range(count, x):
+                    if matrix[row][count] > max_col_value:
+                        swap_row_index = row
+                        max_col_value = matrix[row][count]
+
+                # If maximum value found in the current column is
+                # again zero, raise error.
+                if int(max_col_value) == 0:
+                    raise ValueError(
+                        "The program cannot work out a fitting polynomial."
+                    )
+
+                # Swap pivot row with row index found in previous step,
+                # with maximum value present in matrix[r][count] column.
+                matrix[count], matrix[swap_row_index] = (
+                    matrix[swap_row_index],
+                    matrix[count],
+                )
+                vector[count], vector[swap_row_index] = (
+                    vector[swap_row_index],
+                    vector[count],
+                )
+                # Continue to perform scaling row reduction.
+
             fraction = matrix[number][count] / matrix[count][count]
             for counting_columns, item in enumerate(matrix[count]):
                 # manipulating all the values in the matrix
@@ -101,3 +142,7 @@ if __name__ == "__main__":
     print(points_to_polynomial([[1, 3], [2, 6], [3, 11]]))
     print(points_to_polynomial([[1, -3], [2, -6], [3, -11]]))
     print(points_to_polynomial([[1, 5], [2, 2], [3, 9]]))
+
+    # Added under bug fix: #14817
+    print(points_to_polynomial([[0, 1], [1, 2], [2, 5]]))
+    print(points_to_polynomial([[1, 2], [0, 1], [2, 5]]))


### PR DESCRIPTION
**### Describe your change:**
This PR fixes open issue reported #14817 .

Below is suggested fix as per issue description:
_Use partial pivoting: before each elimination step, swap in a row whose matrix[r][count] is non-zero (largest magnitude). This removes the zero-pivot crash and also improves numerical stability. A doctest with an x = 0 point (e.g. points_to_polynomial([[0, 1], [1, 2], [2, 5]])) should be added to cover it._
This PR implements the above suggested fix.

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
