### PR TITLE
fix: use adjoint matrix for 3x3 inverse

### DIFF
--- a/matrix/inverse_of_matrix.py
+++ b/matrix/inverse_of_matrix.py
@@ -31,7 +31,7 @@ def inverse_of_matrix(matrix: list[list[float]]) -> list[list[float]]:
 
     Doctests for 3x3
     >>> inverse_of_matrix([[2, 5, 7], [2, 0, 1], [1, 2, 3]])
-    [[2.0, 5.0, -4.0], [1.0, 1.0, -1.0], [-5.0, -12.0, 10.0]]
+    [[2.0, 1.0, -5.0], [5.0, 1.0, -12.0], [-4.0, -1.0, 10.0]]
     >>> inverse_of_matrix([[1, 2, 2], [1, 2, 2], [3, 2, -1]])
     Traceback (most recent call last):
         ...
@@ -145,7 +145,7 @@ def inverse_of_matrix(matrix: list[list[float]]) -> list[list[float]]:
                 adjoint_matrix[i][j] = cofactor_matrix[j][i]
 
         # Inverse of the matrix using the formula (1/determinant) * adjoint matrix
-        inverse_matrix = array(cofactor_matrix)
+        inverse_matrix = array(adjoint_matrix)
         for i in range(3):
             for j in range(3):
                 inverse_matrix[i][j] /= d(determinant)


### PR DESCRIPTION
### Describe your change:

Fixes the 3x3 branch of `inverse_of_matrix()` so it uses the computed adjoint matrix when applying the inverse formula. Previously, the function computed `adjoint_matrix` but seeded `inverse_matrix` from `cofactor_matrix`, returning the transpose of the true inverse for non-symmetric 3x3 matrices.

Fixes #14813

### How tested

- `.\.venv\Scripts\python.exe -m doctest -v matrix\inverse_of_matrix.py`
- `.\.venv\Scripts\python.exe -m pytest --doctest-modules matrix\inverse_of_matrix.py -q`
- `.\.venv\Scripts\ruff.exe check matrix\inverse_of_matrix.py`
- `.\.venv\Scripts\python.exe -m mypy --ignore-missing-imports matrix\inverse_of_matrix.py`
- `git diff --check`

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".