### PR TITLE
Fix ZeroDivisionError on zero operands in least_common_multiple

### DIFF
--- a/maths/least_common_multiple.py
+++ b/maths/least_common_multiple.py
@@ -75,8 +75,11 @@ class TestLeastCommonMultiple(unittest.TestCase):
         (12, 25),
         (10, 25),
         (6, 9),
+        (0, 5),
+        (5, 0),
+        (0, 0),
     )
-    expected_results = (20, 195, 124, 210, 1462, 60, 300, 50, 18)
+    expected_results = (20, 195, 124, 210, 1462, 60, 300, 50, 18, 0, 0, 0)
 
     def test_lcm_function(self):
         for i, (first_num, second_num) in enumerate(self.test_inputs):

--- a/maths/least_common_multiple.py
+++ b/maths/least_common_multiple.py
@@ -14,7 +14,15 @@ def least_common_multiple_slow(first_num: int, second_num: int) -> int:
     10
     >>> least_common_multiple_slow(12, 76)
     228
+    >>> least_common_multiple_slow(0, 5)
+    0
+    >>> least_common_multiple_slow(5, 0)
+    0
+    >>> least_common_multiple_slow(0, 0)
+    0
     """
+    if first_num == 0 or second_num == 0:
+        return 0
     max_num = first_num if first_num >= second_num else second_num
     common_mult = max_num
     while (common_mult % first_num > 0) or (common_mult % second_num > 0):
@@ -30,7 +38,15 @@ def least_common_multiple_fast(first_num: int, second_num: int) -> int:
     10
     >>> least_common_multiple_fast(12,76)
     228
+    >>> least_common_multiple_fast(0, 5)
+    0
+    >>> least_common_multiple_fast(5, 0)
+    0
+    >>> least_common_multiple_fast(0, 0)
+    0
     """
+    if first_num == 0 or second_num == 0:
+        return 0
     return first_num // greatest_common_divisor(first_num, second_num) * second_num
 
 


### PR DESCRIPTION
### Describe your change:

`least_common_multiple_slow` and `least_common_multiple_fast` raise `ZeroDivisionError` when either operand is `0`:

- `least_common_multiple_slow(0, 5)`, `least_common_multiple_slow(5, 0)`, and `least_common_multiple_slow(0, 0)` divide by zero in the `common_mult % first_num` / `common_mult % second_num` loop guard.
- `least_common_multiple_fast(0, 0)` divides by `greatest_common_divisor(0, 0) == 0`.

The least common multiple is `0` whenever an operand is `0`, which matches the standard library (`math.lcm(0, 5) == 0`, `math.lcm(0, 0) == 0`). Both functions now return `0` in that case before the division, so they agree with `math.lcm` and with each other. Behavior for non-zero inputs is unchanged. Doctests for the zero cases are added.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Documentation change?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
