### PR TITLE
Fix Bug [#14844] : Boyer-Moore bad character shift has no effect (for-loop variable reassignment)

### DIFF
--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -13,9 +13,12 @@ the point of mismatch in the text.
 
 If there is no mismatch then the pattern matches with text block.
 
-Time Complexity : O(n/m)
+Time Complexity : O(n/m) average case with bad character heuristic
     n=length of main string
     m=length of pattern string
+
+Note: The bad character shift requires a while loop so positions are
+    actually skipped. A for loop ignores loop-variable reassignment.
 """
 
 
@@ -78,23 +81,33 @@ class BoyerMooreSearch:
 
     def bad_character_heuristic(self) -> list[int]:
         """
-        Finds the positions of the pattern location.
+        Finds the positions of the pattern in text using the bad character
+        heuristic. A while loop is used so the shift actually skips
+        positions, achieving O(n/m) average performance instead of the
+        O(nm) brute-force that a for loop would produce.
 
         >>> bms = BoyerMooreSearch(text="ABAABA", pattern="AB")
         >>> bms.bad_character_heuristic()
         [0, 3]
+        >>> bms2 = BoyerMooreSearch(text="AAAAAA", pattern="AA")
+        >>> bms2.bad_character_heuristic()
+        [0, 1, 2, 3, 4]
+        >>> bms3 = BoyerMooreSearch(text="ABCDEF", pattern="XY")
+        >>> bms3.bad_character_heuristic()
+        []
         """
 
         positions = []
-        for i in range(self.textLen - self.patLen + 1):
+        i = 0
+        while i <= self.textLen - self.patLen:
             mismatch_index = self.mismatch_in_text(i)
             if mismatch_index == -1:
                 positions.append(i)
+                i += 1
             else:
                 match_index = self.match_in_pattern(self.text[mismatch_index])
-                i = (
-                    mismatch_index - match_index
-                )  # shifting index lgtm [py/multiple-definition]
+                # Use max to prevent shifting backwards
+                i = max(i + 1, mismatch_index - match_index)
         return positions
 
 


### PR DESCRIPTION
### Describe your change:

Closes #14844
Closes #15010
Closes #15043
Closes #15053

In `strings/boyer_moore_search.py`, the `bad_character_heuristic()` method attempts to skip positions using the bad character rule, but the shift has no effect because it reassigns the `for`-loop variable `i`. In Python, reassigning the loop variable inside a `for` loop does not change the iteration, meaning the algorithm was behaving as brute-force O(nm) instead of Boyer-Moore O(n/m).

This PR fixes the bug by replacing the `for` loop with a `while` loop, allowing the shift to take effect. It also adds a `max()` guard to ensure the algorithm never shifts backwards, and expands the doctests to cover non-matching and overlapping edge cases.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #14844".
