### PR TITLE
Fix Boyer-Moore bad character shift to use while loop

### DIFF
--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -86,15 +86,15 @@ class BoyerMooreSearch:
         """
 
         positions = []
-        for i in range(self.textLen - self.patLen + 1):
+        i = 0
+        while i <= self.textLen - self.patLen:
             mismatch_index = self.mismatch_in_text(i)
             if mismatch_index == -1:
                 positions.append(i)
+                i += 1
             else:
                 match_index = self.match_in_pattern(self.text[mismatch_index])
-                i = (
-                    mismatch_index - match_index
-                )  # shifting index lgtm [py/multiple-definition]
+                i = max(i + 1, mismatch_index - match_index)
         return positions
 
 


### PR DESCRIPTION
Fixes #14844. Replaces for loop with while loop in bad_character_heuristic to allow the shift to take effect. All doctests pass and performance improved from 29 to 9 iterations.