### PR TITLE
Add insertion sort complexity details

### DIFF
--- a/sorts/insertion_sort.py
+++ b/sorts/insertion_sort.py
@@ -31,6 +31,9 @@ def insertion_sort[T: Comparable](collection: MutableSequence[T]) -> MutableSequ
     comparable items inside
     :return: the same collection ordered by ascending
 
+    Time complexity: O(n) in the best case, O(n^2) in the average and worst cases
+    Space complexity: O(1)
+
     Examples:
     >>> insertion_sort([0, 5, 3, 2, 2])
     [0, 2, 2, 3, 5]


### PR DESCRIPTION
## Summary
- Add best, average, and worst case time complexity to the insertion_sort docstring
- Add constant auxiliary space complexity to the same docstring

Closes #14866

## Tests
- py -3.14 -m doctest -v sorts\\insertion_sort.py
- uvx ruff@0.15.15 check sorts\\insertion_sort.py
- uvx ruff@0.15.15 format --check sorts\\insertion_sort.py