### PR TITLE
feat(conversions): add input validation and fix bugs in Roman Numerals and Excel Column Title conversions

### DIFF
--- a/conversions/excel_title_to_column.py
+++ b/conversions/excel_title_to_column.py
@@ -12,8 +12,25 @@ def excel_title_to_column(column_title: str) -> int:
     28
     >>> excel_title_to_column("Z")
     26
+    >>> excel_title_to_column("a")
+    1
+    >>> excel_title_to_column("ab")
+    28
+    >>> excel_title_to_column("")
+    Traceback (most recent call last):
+        ...
+    ValueError: Column title must be a non-empty string containing only alphabetic characters.
+    >>> excel_title_to_column("A1")
+    Traceback (most recent call last):
+        ...
+    ValueError: Column title must be a non-empty string containing only alphabetic characters.
     """
-    assert column_title.isupper()
+    if not column_title or not column_title.isalpha():
+        raise ValueError(
+            "Column title must be a non-empty string containing only alphabetic characters."
+        )
+
+    column_title = column_title.upper()
     answer = 0
     index = len(column_title) - 1
     power = 0

--- a/conversions/roman_numerals.py
+++ b/conversions/roman_numerals.py
@@ -24,8 +24,25 @@ def roman_to_int(roman: str) -> int:
     >>> tests = {"III": 3, "CLIV": 154, "MIX": 1009, "MMD": 2500, "MMMCMXCIX": 3999}
     >>> all(roman_to_int(key) == value for key, value in tests.items())
     True
+    >>> roman_to_int("iii")
+    3
+    >>> roman_to_int("")
+    Traceback (most recent call last):
+        ...
+    ValueError: Input cannot be an empty string
+    >>> roman_to_int("MIX-abc")
+    Traceback (most recent call last):
+        ...
+    ValueError: Invalid Roman numeral character: -
     """
     vals = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    roman = roman.upper()
+    if not roman:
+        raise ValueError("Input cannot be an empty string")
+    for char in roman:
+        if char not in vals:
+            raise ValueError(f"Invalid Roman numeral character: {char}")
+
     total = 0
     place = 0
     while place < len(roman):
@@ -40,12 +57,31 @@ def roman_to_int(roman: str) -> int:
 
 def int_to_roman(number: int) -> str:
     """
-    Given a integer, convert it to an roman numeral.
+    Given an integer, convert it to a roman numeral.
     https://en.wikipedia.org/wiki/Roman_numerals
     >>> tests = {"III": 3, "CLIV": 154, "MIX": 1009, "MMD": 2500, "MMMCMXCIX": 3999}
     >>> all(int_to_roman(value) == key for key, value in tests.items())
     True
+    >>> int_to_roman(0)
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be an integer between 1 and 3999
+    >>> int_to_roman(-5)
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be an integer between 1 and 3999
+    >>> int_to_roman(4000)
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be an integer between 1 and 3999
+    >>> int_to_roman(1.5)  # type: ignore[arg-type]
+    Traceback (most recent call last):
+        ...
+    ValueError: Input must be an integer between 1 and 3999
     """
+    if not isinstance(number, int) or not (0 < number < 4000):
+        raise ValueError("Input must be an integer between 1 and 3999")
+
     result = []
     for arabic, roman in ROMAN:
         (factor, number) = divmod(number, arabic)


### PR DESCRIPTION
This PR improves input validation, adds lowercase input support, and fixes boundary bugs across two conversion files:

1. **roman_numerals.py**:
   - `roman_to_int`: Seamlessly converts lowercase input strings (e.g. "iii" -> 3) and raises a proper `ValueError` with clear messages for empty or invalid inputs.
   - `int_to_roman`: Validates that the input is an integer in the range `1 <= number <= 3999`. Raises `ValueError` for out-of-range/non-integer inputs instead of returning incorrect values (e.g., `int_to_roman(-5)` used to return `"CMXCV"`).

2. **excel_title_to_column.py**:
   - `excel_title_to_column`: Replaces the bypassable `assert column_title.isupper()` with a proper input validation raising `ValueError` for empty or non-alphabetic inputs. Added lowercase title support.