### PR TITLE
fix(machine_learning): prevent log(0) and divide-by-zero warnings/NaN in kullback_leibler_divergence

### DIFF
--- a/machine_learning/loss_functions.py
+++ b/machine_learning/loss_functions.py
@@ -655,12 +655,26 @@ def kullback_leibler_divergence(y_true: np.ndarray, y_pred: np.ndarray) -> float
     Traceback (most recent call last):
         ...
     ValueError: Input arrays must have the same length.
+    >>> # Zero values in y_true and y_pred are handled correctly without warnings
+    >>> true_labels = np.array([0.0, 1.0])
+    >>> predicted_probs = np.array([0.1, 0.9])
+    >>> float(kullback_leibler_divergence(true_labels, predicted_probs))
+    0.10536051565782635
+    >>> true_labels = np.array([0.5, 0.5])
+    >>> predicted_probs = np.array([0.0, 1.0])
+    >>> float(kullback_leibler_divergence(true_labels, predicted_probs))
+    16.576241016895395
     """
     if len(y_true) != len(y_pred):
         raise ValueError("Input arrays must have the same length.")
 
-    kl_loss = y_true * np.log(y_true / y_pred)
-    return np.sum(kl_loss)
+    kl_loss = np.zeros_like(y_true, dtype=float)
+    mask = y_true > 0
+    if np.any(mask):
+        kl_loss[mask] = y_true[mask] * np.log(
+            y_true[mask] / np.clip(y_pred[mask], 1e-15, 1.0)
+        )
+    return float(np.sum(kl_loss))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your change:

This PR fixes a bug where `kullback_leibler_divergence` raises `RuntimeWarning` and returns `nan` or `inf` under zero probabilities:
- Implements boolean masking to calculate the KL divergence contribution only for non-zero elements of `y_true` (since \(0 \log 0 = 0\) by definition).
- Clips predicted probabilities `y_pred` to a small value (e.g. `1e-15`) to prevent division by zero or log of zero.
- Prevents generating `RuntimeWarning` warnings by calculating math operations only on valid masked elements.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.github.com/en/issues/typing.html).
* [x] All functions have [doctests](https://docs.github.com/en/issues/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #12233".