### PR TITLE
fix: validate scores length is a power of 2 in minimax

### DIFF
--- a/backtracking/minimax.py
+++ b/backtracking/minimax.py
@@ -46,6 +46,10 @@ def minimax(
     Traceback (most recent call last):
         ...
     ValueError: Scores cannot be empty
+    >>> minimax(0, 0, True, [1, 2, 3], 2)
+    Traceback (most recent call last):
+        ...
+    ValueError: Number of scores must be a power of 2
     >>> scores = [3, 5, 2, 9, 12, 5, 23, 23]
     >>> height = math.log(len(scores), 2)
     >>> minimax(0, 0, True, scores, height)
@@ -56,6 +60,8 @@ def minimax(
         raise ValueError("Depth cannot be less than 0")
     if len(scores) == 0:
         raise ValueError("Scores cannot be empty")
+    if len(scores) & (len(scores) - 1) != 0:
+        raise ValueError("Number of scores must be a power of 2")
 
     # Base case: If the current depth equals the height of the tree,
     # return the score of the current node.


### PR DESCRIPTION
Fixes #14886
Fixes #15001
Fixes #15042

### Describe your change:
- Fixed a `RecursionError` for `scores` lengths that aren't powers of 2 by validating and raising a `ValueError` instead
- Added a doctest covering the new error case

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
