### PR TITLE
docs: fix badge alt text to match ruff formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
     <img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=flat-square" height="20" alt="pre-commit">
   </a>
   <a href="https://docs.astral.sh/ruff/formatter/">
-    <img src="https://img.shields.io/static/v1?label=code%20style&message=ruff&color=black&style=flat-square" height="20" alt="code style: black">
+    <img src="https://img.shields.io/static/v1?label=code%20style&message=ruff&color=black&style=flat-square" height="20" alt="code style: ruff">
   </a>
 
 <!-- Short description: -->


### PR DESCRIPTION
The code style badge alt text incorrectly said 'black' but the project uses ruff. Fixed alt text to 'code style: ruff' to match the actual formatter.