### PR TITLE
Fix CNN prediction threshold for binary classification

### DIFF
--- a/computer_vision/cnn_classification.py
+++ b/computer_vision/cnn_classification.py
@@ -94,7 +94,9 @@ if __name__ == "__main__":
     test_image = np.expand_dims(test_image, axis=0)
     result = classifier.predict(test_image)
     # training_set.class_indices
-    if result[0][0] == 0:
+    # The sigmoid output is a probability in the range [0, 1].
+    # Use a threshold of 0.5 to convert the probability into a binary prediction.
+    if result[0][0] < 0.5:
         prediction = "Normal"
-    if result[0][0] == 1:
+    else:
         prediction = "Abnormality detected"


### PR DESCRIPTION
### Describe your change:

Hi! I'd like to work on this issue.

I noticed that the prediction logic compares the model's output to exact values (`0` and `1`), but since the final layer uses a sigmoid activation, `model.predict()` returns a probability between `0` and `1`, not an exact class label. Using a threshold (e.g., `0.5`) would make the prediction logic correct for binary classification.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
