### PR TITLE
Fix word occurrence doctest variable typo

### DIFF
--- a/strings/word_occurrence.py
+++ b/strings/word_occurrence.py
@@ -7,8 +7,8 @@ def word_occurrence(sentence: str) -> dict:
     """
     >>> from collections import Counter
     >>> SENTENCE = "a b A b c b d b d e f e g e h e i e j e 0"
-    >>> occurence_dict = word_occurrence(SENTENCE)
-    >>> all(occurence_dict[word] == count for word, count
+    >>> occurrence_dict = word_occurrence(SENTENCE)
+    >>> all(occurrence_dict[word] == count for word, count
     ...     in Counter(SENTENCE.split()).items())
     True
     >>> dict(word_occurrence("Two  spaces"))


### PR DESCRIPTION
## Summary

- fix the misspelled `occurrence_dict` variable in the `word_occurrence` doctest
- keep the example aligned with the function's `occurrence` naming

## Validation

- `python3 -m doctest strings/word_occurrence.py`
- `git diff --check`
