### PR TITLE
fix: raise documented ValueError for negative input in largest_of_very_large_numbers

### DIFF
--- a/maths/largest_of_very_large_numbers.py
+++ b/maths/largest_of_very_large_numbers.py
@@ -17,6 +17,8 @@ def res(x, y):
     ...
     ValueError: expected a positive input
     """
+    if x < 0:
+        raise ValueError("expected a positive input")
     if 0 not in (x, y):
         # We use the relation x^y = y*log10(x), where 10 is the base.
         return y * math.log10(x)


### PR DESCRIPTION
### Describe your change:

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

---

Fixes #14930

The docstring of `maths/largest_of_very_large_numbers.res` documents `ValueError: expected a positive input` for `res(-1, 5)`, but no validation existed — `math.log10(x)` raised `ValueError: math domain error` instead, failing the doctest.

Added the documented validation (`if x < 0: raise ValueError("expected a positive input")`).

Verified: `python3 -m doctest maths/largest_of_very_large_numbers.py -v` — all 4 doctests pass. `ruff check` passes.