### PR TITLE
fix: raise ValueError for multi-char separator in split()

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,21 +17,19 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+    ...
+    ValueError: separator must be a single character
     """
-
-    split_words = []
-
-    last_index = 0
-    for index, char in enumerate(string):
-        if char == separator:
-            split_words.append(string[last_index:index])
-            last_index = index + 1
-        if index + 1 == len(string):
-            split_words.append(string[last_index : index + 1])
-    return split_words
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
+    return string.split(separator)
 
 
 if __name__ == "__main__":
     from doctest import testmod
 
     testmod()
+

--- a/strings/split.py
+++ b/strings/split.py
@@ -32,4 +32,3 @@ if __name__ == "__main__":
     from doctest import testmod
 
     testmod()
-


### PR DESCRIPTION
## Summary
Fixes #14649 - split() silently returns wrong result for multi-character separators

## Problem
The custom split() function compares each character in the input string with the separator. Because of that, a multi-character separator such as "--" is never matched.

## Solution
Added validation to raise ValueError when separator length != 1, and simplified the implementation to use Python's built-in str.split().

## Testing
- All existing doctests pass
- New doctest added for multi-char separator validation

Fixes #14649