### PR TITLE
Raise ValueError for negative inputs in radix_sort

### DIFF
--- a/sorts/radix_sort.py
+++ b/sorts/radix_sort.py
@@ -21,7 +21,14 @@ def radix_sort(list_of_ints: list[int]) -> list[int]:
     True
     >>> radix_sort([1,100,10,1000]) == sorted([1,100,10,1000])
     True
+    >>> radix_sort([1, 3, -2, 4])
+    Traceback (most recent call last):
+        ...
+    ValueError: negative integers are not supported
     """
+    if any(i < 0 for i in list_of_ints):
+        raise ValueError("negative integers are not supported")
+
     placement = 1
     max_digit = max(list_of_ints)
     while placement <= max_digit:


### PR DESCRIPTION
Fixes #14950

radix_sort() previously returned an incorrect result when given
negative integers instead of raising an error. This adds an input
check that raises ValueError for negative values, plus a doctest
example covering the new behavior.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #14950".
