### PR TITLE
fix(ciphers): add input validation and doctests to a1z26 encode and decode

### DIFF
--- a/ciphers/a1z26.py
+++ b/ciphers/a1z26.py
@@ -13,7 +13,13 @@ def encode(plain: str) -> list[int]:
     """
     >>> encode("myname")
     [13, 25, 14, 1, 13, 5]
+    >>> encode("HELLO")
+    Traceback (most recent call last):
+        ...
+    ValueError: plain text must contain only lowercase letters 'a'-'z'
     """
+    if not plain or any(not ("a" <= elem <= "z") for elem in plain):
+        raise ValueError("plain text must contain only lowercase letters 'a'-'z'")
     return [ord(elem) - 96 for elem in plain]
 
 
@@ -21,7 +27,13 @@ def decode(encoded: list[int]) -> str:
     """
     >>> decode([13, 25, 14, 1, 13, 5])
     'myname'
+    >>> decode([0, 27])
+    Traceback (most recent call last):
+        ...
+    ValueError: encoded values must be integers between 1 and 26
     """
+    if not encoded or any(not (1 <= elem <= 26) for elem in encoded):
+        raise ValueError("encoded values must be integers between 1 and 26")
     return "".join(chr(elem + 96) for elem in encoded)
 
 


### PR DESCRIPTION
## Description
This PR resolves issue #14931 by adding input validation to `encode()` and `decode()` in `ciphers/a1z26.py`.

## Details
- Raises `ValueError` when `encode()` receives non-lowercase inputs or `decode()` receives integers out of the 1–26 alphabet index range.
- Includes doctests verifying exception behavior.