### PR TITLE
fix(maths): raise documented ValueError for negative inputs in res()

### DIFF
--- a/maths/largest_of_very_large_numbers.py
+++ b/maths/largest_of_very_large_numbers.py
@@ -3,7 +3,7 @@
 import math
 
 
-def res(x, y):
+def res(x: int | float, y: int | float) -> float | int:
     """
     Reduces large number to a more manageable number
     >>> res(5, 7)
@@ -17,6 +17,8 @@ def res(x, y):
     ...
     ValueError: expected a positive input
     """
+    if x < 0:
+        raise ValueError("expected a positive input")
     if 0 not in (x, y):
         # We use the relation x^y = y*log10(x), where 10 is the base.
         return y * math.log10(x)


### PR DESCRIPTION
## Description
This PR resolves issue #14930 by adding the documented `x < 0` validation check in `res()` in `maths/largest_of_very_large_numbers.py`.

## Details
- Raises `ValueError("expected a positive input")` when `x < 0`, aligning the code with the existing doctest contract.