### PR TITLE
fix: validate Butterworth filter inputs

### DIFF
--- a/audio_filters/butterworth_filter.py
+++ b/audio_filters/butterworth_filter.py
@@ -10,6 +10,38 @@ Alternatively you can use scipy.signal.butter, which should yield the same resul
 """
 
 
+def _validate_frequency(frequency: int, samplerate: int, q_factor: float) -> None:
+    """
+    Validate arguments shared by the Butterworth filter factories.
+
+    >>> _validate_frequency(1000, 48000, 1 / sqrt(2))
+    >>> _validate_frequency(0, 48000, 1 / sqrt(2))
+    Traceback (most recent call last):
+        ...
+    ValueError: frequency must be a positive integer
+    >>> _validate_frequency(24000, 48000, 1 / sqrt(2))
+    Traceback (most recent call last):
+        ...
+    ValueError: frequency must be less than half the samplerate
+    >>> _validate_frequency(1000, 0, 1 / sqrt(2))
+    Traceback (most recent call last):
+        ...
+    ValueError: samplerate must be a positive integer
+    >>> _validate_frequency(1000, 48000, 0)
+    Traceback (most recent call last):
+        ...
+    ValueError: q_factor must be positive
+    """
+    if not isinstance(frequency, int) or frequency <= 0:
+        raise ValueError("frequency must be a positive integer")
+    if not isinstance(samplerate, int) or samplerate <= 0:
+        raise ValueError("samplerate must be a positive integer")
+    if frequency >= samplerate / 2:
+        raise ValueError("frequency must be less than half the samplerate")
+    if q_factor <= 0:
+        raise ValueError("q_factor must be positive")
+
+
 def make_lowpass(
     frequency: int,
     samplerate: int,
@@ -23,6 +55,7 @@ def make_lowpass(
     [1.0922959556412573, -1.9828897227476208, 0.9077040443587427, 0.004277569313094809,
      0.008555138626189618, 0.004277569313094809]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -53,6 +86,7 @@ def make_highpass(
     [1.0922959556412573, -1.9828897227476208, 0.9077040443587427, 0.9957224306869052,
      -1.9914448613738105, 0.9957224306869052]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -83,6 +117,7 @@ def make_bandpass(
     [1.0922959556412573, -1.9828897227476208, 0.9077040443587427, 0.06526309611002579,
      0, -0.06526309611002579]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -114,6 +149,7 @@ def make_allpass(
     [1.0922959556412573, -1.9828897227476208, 0.9077040443587427, 0.9077040443587427,
      -1.9828897227476208, 1.0922959556412573]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -142,6 +178,7 @@ def make_peak(
     [1.0653405327119334, -1.9828897227476208, 0.9346594672880666, 1.1303715025601122,
      -1.9828897227476208, 0.8696284974398878]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -174,6 +211,7 @@ def make_lowshelf(
     [3.0409336710888786, -5.608870992220748, 2.602157875636628, 3.139954022810743,
      -5.591841778072785, 2.5201667380627257]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)
@@ -211,6 +249,7 @@ def make_highshelf(
     [2.2229172136088806, -3.9587208137297303, 1.7841414181566304, 4.295432981120543,
      -7.922740859457287, 3.6756456963725253]
     """
+    _validate_frequency(frequency, samplerate, q_factor)
     w0 = tau * frequency / samplerate
     _sin = sin(w0)
     _cos = cos(w0)


### PR DESCRIPTION
### Describe your change:

Fixes #12379

Adds shared validation for Butterworth filter factory inputs before coefficients are calculated. The change rejects non-positive frequencies, samplerates, and Q factors with `ValueError`, and rejects cutoff frequencies at or above the Nyquist limit. This prevents invalid high-pass/low-pass/etc. calls from returning unusable coefficients or falling through to `ZeroDivisionError`. The new doctests cover valid input and the expected error cases.

Validation:
- `python3 -m doctest -v audio_filters/butterworth_filter.py` - passed, 19 doctests passed.
- `python3 -m pytest audio_filters/butterworth_filter.py` - passed, 8 tests passed.
- `uvx ruff check audio_filters/butterworth_filter.py` - passed.
- `python3 -m compileall -q audio_filters/butterworth_filter.py` - passed.
- `git diff --check` - passed.

Blockers:
- `uv run --with=pytest pytest audio_filters/butterworth_filter.py` could not start locally because no Python >=3.14 interpreter is available on this machine, and `uv python install 3.14` reported no macOS/aarch64 download for that request.
- `python3 -m pytest audio_filters` collected the touched file successfully, but the broader package run is blocked locally by missing optional dependencies in unrelated files: `audio_filters/show_response.py` requires `matplotlib`, and after ignoring it, `audio_filters/iir_filter.py` requires `scipy` for its doctest.
- `uvx ruff check .` with local `ruff 0.16.0` reports three unrelated existing findings outside this PR's file; the touched file passes the same ruff command.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md#coding-style).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
