### PR TITLE
fix(sorts): raise TypeError when bucket_count is not an integer in bucket_sort (#14970)

### DIFF
--- a/sorts/bucket_sort.py
+++ b/sorts/bucket_sort.py
@@ -71,7 +71,13 @@ def bucket_sort(my_list: list, bucket_count: int = 10) -> list:
     >>> data = [9, 2, 7, 1, 5]
     >>> bucket_sort(data) == sorted(data)
     True
+    >>> bucket_sort([1, 2, 3], bucket_count=2.5)
+    Traceback (most recent call last):
+    ...
+    TypeError: bucket_count must be an integer
     """
+    if not isinstance(bucket_count, int) or isinstance(bucket_count, bool):
+        raise TypeError("bucket_count must be an integer")
 
     if len(my_list) == 0 or bucket_count <= 0:
         return []

--- a/sorts/radix_sort.py
+++ b/sorts/radix_sort.py
@@ -21,7 +21,17 @@ def radix_sort(list_of_ints: list[int]) -> list[int]:
     True
     >>> radix_sort([1,100,10,1000]) == sorted([1,100,10,1000])
     True
+    >>> radix_sort([-1, 2, 3])
+    Traceback (most recent call last):
+    ...
+    ValueError: All elements in list_of_ints must be non-negative integers
     """
+    if not list_of_ints:
+        return []
+
+    if any(i < 0 for i in list_of_ints):
+        raise ValueError("All elements in list_of_ints must be non-negative integers")
+
     placement = 1
     max_digit = max(list_of_ints)
     while placement <= max_digit:


### PR DESCRIPTION
Closes #14970

### Summary
Adds type validation to `bucket_sort()` to raise a `TypeError` when `bucket_count` is passed as a float (or non-integer) value, preventing internal TypeError exceptions when attempting to range over floats.