### PR TITLE
Add Digital Root algorithm to maths

### DIFF
--- a/maths/digital_root.py
+++ b/maths/digital_root.py
@@ -12,12 +12,12 @@ https://en.wikipedia.org/wiki/Digital_root
 """
 
 
-def digital_root(n: int) -> int:
+def digital_root(number: int) -> int:
     """
-    Return the digital root of a non-negative integer n.
+    Return the digital root of a non-negative integer number.
 
     The digital root is the single-digit value obtained by repeatedly summing
-    the decimal digits of n until only one digit remains. The input is taken by
+    the decimal digits of number until only one digit remains. The input is taken by
     its absolute value, so negative numbers behave like their positive
     counterpart.
 
@@ -34,10 +34,10 @@ def digital_root(n: int) -> int:
     >>> digital_root(999999999999)
     9
     """
-    n = abs(n)
-    while n >= 10:
-        n = sum(int(digit) for digit in str(n))
-    return n
+    number = abs(number)
+    while number >= 10:
+        number = sum(int(digit) for digit in str(number))
+    return number
 
 
 if __name__ == "__main__":

--- a/maths/digital_root.py
+++ b/maths/digital_root.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""
+Digital Root.
+The digital root (also known as the repeated digital sum) of a non-negative
+integer is the (single digit) value obtained by an iterative process of summing
+digits: on each iteration the digits of the previous result are summed, and the
+process continues until a single-digit number is reached.
+
+For more information see:
+https://en.wikipedia.org/wiki/Digital_root
+"""
+
+
+def digital_root(n: int) -> int:
+    """
+    Return the digital root of a non-negative integer n.
+
+    The digital root is the single-digit value obtained by repeatedly summing
+    the decimal digits of n until only one digit remains. The input is taken by
+    its absolute value, so negative numbers behave like their positive
+    counterpart.
+
+    >>> digital_root(0)
+    0
+    >>> digital_root(9)
+    9
+    >>> digital_root(38)
+    2
+    >>> digital_root(12345)
+    6
+    >>> digital_root(-45)
+    9
+    >>> digital_root(999999999999)
+    9
+    """
+    n = abs(n)
+    while n >= 10:
+        n = sum(int(digit) for digit in str(n))
+    return n
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Description
Adds the **Digital Root** algorithm (`maths/digital_root.py`).

The digital root (repeated digital sum) of a non-negative integer is the single-digit value obtained by iteratively summing its decimal digits until only one digit remains. It complements the existing `maths/sum_of_digits.py` (single-pass digit sum) and is a classic number-theory / arithmetic routine.

## Reference
- https://en.wikipedia.org/wiki/Digital_root

## Verification (local CI, matching repo config: Python 3.14, ruff, mypy, pytest)
- `ruff format --check` : passed
- `ruff check`          : passed
- `mypy`                : passed (no issues)
- `pytest --doctest-modules` : 1 passed (doctests cover 0, single digit, multi-digit, negative input, and a large number)

## Checklist
- [x] Single algorithm per file, snake_case filename
- [x] Type hints + docstring + doctests present
- [x] Wikipedia reference linked
- [x] No duplicate of an existing implementation
- [x] DIRECTORY.md is auto-generated by the `directory_writer` workflow on push (not manually edited)
