### PR TITLE
perf: keep Euler 135 arithmetic integral

### DIFF
--- a/project_euler/problem_135/sol1.py
+++ b/project_euler/problem_135/sol1.py
@@ -35,11 +35,13 @@ def solution(limit: int = 1000000) -> int:
     frequency = [0] * limit
     for first_term in range(1, limit):
         for n in range(first_term, limit, first_term):
-            common_difference = first_term + n / first_term
+            # n is generated as a multiple of first_term, so keep this path
+            # entirely integral instead of creating a float for every pair.
+            common_difference = first_term + n // first_term
             if common_difference % 4:  # d must be divisible by 4
                 continue
             else:
-                common_difference /= 4
+                common_difference //= 4
                 if (
                     first_term > common_difference
                     and first_term < 4 * common_difference


### PR DESCRIPTION
`project_euler/problem_135/sol1.py` already generates `n` as a multiple of `first_term`, but the inner loop converted that exact relationship to floating point on every iteration. This patch keeps the calculation integral with `//` for both the quotient and the division by four.

The solution and its existing doctests are unchanged in behavior. The full default calculation still returns `4989`.

Checks:

- `python -m doctest -v project_euler/problem_135/sol1.py`
- `python -m ruff check project_euler/problem_135/sol1.py`
- `python -c "... solution() ..."` -> `4989`
- `git diff --check`

Fixes #8594
