### PR TITLE
fix: reject non-integer bucket counts

### DIFF
--- a/sorts/bucket_sort.py
+++ b/sorts/bucket_sort.py
@@ -63,6 +63,9 @@ def bucket_sort(my_list: list, bucket_count: int = 10) -> list:
     >>> data = [5.5, 2.2, -1.1, 3.3, 0.0]
     >>> bucket_sort(data) == sorted(data)
     True
+    >>> bucket_sort(data, 2.5)
+    Traceback (most recent call last):
+    TypeError: bucket_count must be an integer
     >>> bucket_sort([1]) == [1]
     True
     >>> data = [-1.1, -1.5, -3.4, 2.5, 3.6, -3.3]
@@ -72,6 +75,9 @@ def bucket_sort(my_list: list, bucket_count: int = 10) -> list:
     >>> bucket_sort(data) == sorted(data)
     True
     """
+
+    if not isinstance(bucket_count, int) or isinstance(bucket_count, bool):
+        raise TypeError("bucket_count must be an integer")
 
     if len(my_list) == 0 or bucket_count <= 0:
         return []


### PR DESCRIPTION
## Description

Add dedicated validation for `bucket_sort`'s `bucket_count` argument. Non-integer values now raise a clear `TypeError` before arithmetic or bucket allocation, including on empty inputs; booleans are rejected explicitly despite inheriting from `int` in Python. The existing behavior for positive integer counts is unchanged.

## Issue reference

Closes #14970

## Validation

- `python -m doctest sorts/bucket_sort.py`
- `python -m ruff check sorts/bucket_sort.py`
- `git diff --check`
- Direct checks for float, bool, string, empty-input, and valid integer inputs.

I used coding assistance to prepare this focused fix and reviewed the rendered diff and test output manually. The patch is limited to `sorts/bucket_sort.py`.