### PR TITLE
Add baby-step giant-step discrete logarithm algorithm

### DIFF
--- a/maths/baby_step_giant_step.py
+++ b/maths/baby_step_giant_step.py
@@ -80,9 +80,7 @@ def baby_step_giant_step(base: int, target: int, modulus: int) -> int:
             return giant_index * step_count + baby_steps[gamma]
         gamma = (gamma * giant_factor) % modulus
 
-    raise ValueError(
-        f"no discrete logarithm for {target} base {base} modulo {modulus}"
-    )
+    raise ValueError(f"no discrete logarithm for {target} base {base} modulo {modulus}")
 
 
 if __name__ == "__main__":

--- a/maths/baby_step_giant_step.py
+++ b/maths/baby_step_giant_step.py
@@ -61,8 +61,8 @@ def baby_step_giant_step(base: int, target: int, modulus: int) -> int:
     if base == 0:
         if target == 0:
             return 1
-        raise ValueError(f"no discrete logarithm for {target} base 0 modulo {modulus}")
-
+        message = f"no discrete logarithm for {target} base 0 modulo {modulus}"
+        raise ValueError(message)
     # Baby steps: store base^j for j = 0 .. m-1
     step_count = ceil(isqrt(modulus - 1))
     baby_steps: dict[int, int] = {}

--- a/maths/baby_step_giant_step.py
+++ b/maths/baby_step_giant_step.py
@@ -80,7 +80,8 @@ def baby_step_giant_step(base: int, target: int, modulus: int) -> int:
             return giant_index * step_count + baby_steps[gamma]
         gamma = (gamma * giant_factor) % modulus
 
-    raise ValueError(f"no discrete logarithm for {target} base {base} modulo {modulus}")
+    message = f"no discrete logarithm for {target} base {base} modulo {modulus}"
+    raise ValueError(message)
 
 
 if __name__ == "__main__":

--- a/maths/baby_step_giant_step.py
+++ b/maths/baby_step_giant_step.py
@@ -1,0 +1,91 @@
+"""
+Baby-step giant-step algorithm for discrete logarithms.
+
+Solve for the smallest non-negative integer ``exponent`` such that
+``base ** exponent ≡ target (mod modulus)``, assuming ``modulus`` is prime
+and ``base`` is a primitive root (or at least generates ``target``).
+
+Time and space complexity are O(sqrt(modulus)).
+
+https://en.wikipedia.org/wiki/Baby-step_giant-step
+"""
+
+from __future__ import annotations
+
+from math import ceil, isqrt
+
+
+def baby_step_giant_step(base: int, target: int, modulus: int) -> int:
+    """
+    Return the discrete logarithm of ``target`` to ``base`` modulo ``modulus``.
+
+    Finds the smallest non-negative ``exponent`` satisfying
+    ``pow(base, exponent, modulus) == target % modulus``.
+
+    Raises ValueError when no solution exists in ``0 .. modulus - 1``, or when
+    the modulus is not a positive integer greater than 1.
+
+    >>> baby_step_giant_step(2, 1, 5)
+    0
+    >>> baby_step_giant_step(2, 2, 5)
+    1
+    >>> baby_step_giant_step(2, 3, 5)
+    3
+    >>> pow(2, 3, 5)
+    3
+    >>> baby_step_giant_step(5, 8, 13)
+    3
+    >>> pow(5, 3, 13)
+    8
+    >>> baby_step_giant_step(7, 1, 11)
+    0
+    >>> baby_step_giant_step(3, 13, 17)
+    4
+    >>> baby_step_giant_step(2, 3, 1)
+    Traceback (most recent call last):
+        ...
+    ValueError: modulus must be an integer greater than 1
+    >>> baby_step_giant_step(2, 0, 7)
+    Traceback (most recent call last):
+        ...
+    ValueError: no discrete logarithm for 0 base 2 modulo 7
+    """
+    if modulus <= 1:
+        raise ValueError("modulus must be an integer greater than 1")
+
+    base %= modulus
+    target %= modulus
+
+    if target == 1:
+        return 0
+    if base == 0:
+        if target == 0:
+            return 1
+        raise ValueError(f"no discrete logarithm for {target} base 0 modulo {modulus}")
+
+    # Baby steps: store base^j for j = 0 .. m-1
+    step_count = ceil(isqrt(modulus - 1))
+    baby_steps: dict[int, int] = {}
+    value = 1
+    for baby_index in range(step_count):
+        if value not in baby_steps:
+            baby_steps[value] = baby_index
+        value = (value * base) % modulus
+
+    # Giant step factor: base^{-m} mod modulus
+    giant_factor = pow(base, -step_count, modulus)
+    gamma = target
+    for giant_index in range(step_count):
+        if gamma in baby_steps:
+            return giant_index * step_count + baby_steps[gamma]
+        gamma = (gamma * giant_factor) % modulus
+
+    raise ValueError(
+        f"no discrete logarithm for {target} base {base} modulo {modulus}"
+    )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
## Describe your change:
- [x] Add an algorithm?
- [ ] Fix a bug or typo in an existing algorithm?
- [x] Add or change doctests?
- [ ] Documentation change?

## Checklist:
- [x] I have read CONTRIBUTING.md.
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file.
- [x] All new Python files are placed inside an existing directory.
- [x] All filenames are in all lowercase characters with no spaces or dashes.
- [x] All functions and variable names follow Python naming conventions.
- [x] All function parameters and return values are annotated with Python type hints.
- [x] All functions have doctests that pass the automated testing.
- [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
- [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword.

## Summary
Adds `maths/baby_step_giant_step.py` implementing the classic baby-step giant-step method for discrete logarithms modulo a prime (or any modulus where `base` is invertible).

- Builds a baby-step table of size `⌈√(modulus-1)⌉`
- Uses modular inverse giant steps via `pow(base, -m, modulus)`
- Returns the smallest non-negative exponent; raises `ValueError` when no solution exists
- Doctests verified locally with `python -m doctest`

Reference: https://en.wikipedia.org/wiki/Baby-step_giant-step

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/