### PR TITLE
fix(sorts): raise ValueError on negative inputs in radix_sort (#14950)

### DIFF
--- a/sorts/radix_sort.py
+++ b/sorts/radix_sort.py
@@ -11,17 +11,27 @@ RADIX = 10
 
 def radix_sort(list_of_ints: list[int]) -> list[int]:
     """
-    Examples:
+    Sort a list of non-negative integers using radix sort.
+
+    This implementation works only with non-negative values because it
+    iterates over the decimal digits of each number.
+
     >>> radix_sort([0, 5, 3, 2, 2])
     [0, 2, 2, 3, 5]
-
     >>> radix_sort(list(range(15))) == sorted(range(15))
     True
-    >>> radix_sort(list(range(14,-1,-1))) == sorted(range(15))
+    >>> radix_sort(list(range(14, -1, -1))) == sorted(range(15))
     True
-    >>> radix_sort([1,100,10,1000]) == sorted([1,100,10,1000])
+    >>> radix_sort([1, 100, 10, 1000]) == sorted([1, 100, 10, 1000])
     True
+    >>> radix_sort([3, 1, -1, 2])
+    Traceback (most recent call last):
+    ...
+    ValueError: All numbers in list_of_ints must be non-negative
     """
+    if any(item < 0 for item in list_of_ints):
+        raise ValueError("All numbers in list_of_ints must be non-negative")
+
     placement = 1
     max_digit = max(list_of_ints)
     while placement <= max_digit:


### PR DESCRIPTION
Fixes #14950

### Describe your change:
Added input validation to `sorts/radix_sort.py` to raise a `ValueError` when negative integers are passed in `list_of_ints`. Included `doctest` examples verifying both normal execution and the expected `ValueError`.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".