### PR TITLE
docs: fix sumset docstring

### DIFF
--- a/maths/sumset.py
+++ b/maths/sumset.py
@@ -10,9 +10,9 @@ Source:
 
 def sumset(set_a: set, set_b: set) -> set:
     """
-    :param first set: a set of numbers
-    :param second set: a set of numbers
-    :return: the nth number in Sylvester's sequence
+    :param set_a: a set of numbers
+    :param set_b: a set of numbers
+    :return: the sumset of set_a and set_b (all pairwise sums a + b)
 
     >>> sumset({1, 2, 3}, {4, 5, 6})
     {5, 6, 7, 8, 9}


### PR DESCRIPTION
### Describe your change:

Fixed the incorrect docstring in `maths/sumset.py`.

* Corrected the parameter names from `first set` / `second set` to `set_a` / `set_b`.
* Corrected the return description from Sylvester's sequence to the sumset of the two input sets.
* No implementation or test code was changed.

Fixes #15013

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:

* [x] I have read https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md.
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".
