### PR TITLE
fix: handle negative numbers in radix sort

### DIFF
--- a/sorts/radix_sort.py
+++ b/sorts/radix_sort.py
@@ -21,7 +21,13 @@ def radix_sort(list_of_ints: list[int]) -> list[int]:
     True
     >>> radix_sort([1,100,10,1000]) == sorted([1,100,10,1000])
     True
+    >>> radix_sort([-1, 0, 1])
+    Traceback (most recent call last):
+    ...
+    ValueError: radix_sort does not support negative numbers
     """
+    if any(i < 0 for i in list_of_ints):
+        raise ValueError("radix_sort does not support negative numbers")
     placement = 1
     max_digit = max(list_of_ints)
     while placement <= max_digit:


### PR DESCRIPTION
### Describe your change

- [x] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
Fixes negative number handling in radix sort — negative integers were not sorted correctly.

#### Additional comments?
Test: python3 sorts/radix_sort.py