### PR TITLE
fix: initialize PageRank to 1/n instead of 1

### DIFF
--- a/graphs/page_rank.py
+++ b/graphs/page_rank.py
@@ -34,7 +34,7 @@ class Node:
 def page_rank(nodes, limit=3, d=0.85):
     ranks = {}
     for node in nodes:
-        ranks[node.name] = 1
+        ranks[node.name] = 1 / len(nodes)
 
     outbounds = {}
     for node in nodes:


### PR DESCRIPTION
### Describe your change

- [x] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
Initializes PageRank values to 1/n (uniform distribution) instead of 1, matching the standard PageRank algorithm and improving convergence.

#### Additional comments?
None.