### PR TITLE
fix(gcd): fix invalid Python 3 except clause syntax

### DIFF
--- a/maths/greatest_common_divisor.py
+++ b/maths/greatest_common_divisor.py
@@ -73,7 +73,7 @@ def main():
             f"{greatest_common_divisor(num_1, num_2)}"
         )
         print(f"By iterative gcd({num_1}, {num_2}) = {gcd_by_iterative(num_1, num_2)}")
-    except IndexError, UnboundLocalError, ValueError:
+    except (IndexError, UnboundLocalError, ValueError):
         print("Wrong input")
 
 


### PR DESCRIPTION
### Describe your change

- [x] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
Fixes the obsolete comma-style except clause, which is a syntax error in Python 3.

#### Additional comments?
None.