### PR TITLE
fix: add negative input validation to largest_of_very_large_numbers

### DIFF
--- a/maths/largest_of_very_large_numbers.py
+++ b/maths/largest_of_very_large_numbers.py
@@ -17,6 +17,8 @@ def res(x, y):
     ...
     ValueError: expected a positive input
     """
+    if x < 0 or y < 0:
+        raise ValueError("expected a positive input")
     if 0 not in (x, y):
         # We use the relation x^y = y*log10(x), where 10 is the base.
         return y * math.log10(x)


### PR DESCRIPTION
### Describe your change

- [x] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
Rejects negative numbers in largest_of_very_large_numbers, which only supports non-negative inputs.

#### Additional comments?
None.