### PR TITLE
fix: add input validation to a1z26 encode for non-lowercase chars

### DIFF
--- a/ciphers/a1z26.py
+++ b/ciphers/a1z26.py
@@ -13,7 +13,13 @@ def encode(plain: str) -> list[int]:
     """
     >>> encode("myname")
     [13, 25, 14, 1, 13, 5]
+    >>> encode("MyName")
+    Traceback (most recent call last):
+    ...
+    ValueError: only lowercase letters are allowed
     """
+    if plain and not plain.islower():
+        raise ValueError("only lowercase letters are allowed")
     return [ord(elem) - 96 for elem in plain]
 
 


### PR DESCRIPTION
### Describe your change

- [x] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
Raises a clear error when a1z26 encoding receives characters outside a-z.

#### Additional comments?
None.