### PR TITLE
fix: raise ValueError on negative inputs in radix_sort

### DIFF
--- a/sorts/radix_sort.py
+++ b/sorts/radix_sort.py
@@ -22,8 +22,11 @@ def radix_sort(list_of_ints: list[int]) -> list[int]:
     >>> radix_sort([1,100,10,1000]) == sorted([1,100,10,1000])
     True
     """
+    if any(x < 0 for x in list_of_ints):
+        raise ValueError("radix_sort only supports non-negative integers")
+
     placement = 1
-    max_digit = max(list_of_ints)
+    max_digit = max(list_of_ints) if list_of_ints else 0
     while placement <= max_digit:
         # declare and initialize empty buckets
         buckets: list[list] = [[] for _ in range(RADIX)]


### PR DESCRIPTION
### Describe your change

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
adix_sort() silently produced wrong output for negative numbers (digit extraction via int(i / placement) % RADIX). Raise a clear ValueError instead.

#### Additional comments?
None.

Fixes #14950