### PR TITLE
fix: reject non-power-of-2 score lists in minimax

### DIFF
--- a/backtracking/minimax.py
+++ b/backtracking/minimax.py
@@ -50,12 +50,18 @@ def minimax(
     >>> height = math.log(len(scores), 2)
     >>> minimax(0, 0, True, scores, height)
     12
+    >>> minimax(0, 0, True, [3, 5, 2, 9, 12], math.log(5, 2))
+    Traceback (most recent call last):
+        ...
+    ValueError: Number of scores must be a power of 2
     """
 
     if depth < 0:
         raise ValueError("Depth cannot be less than 0")
     if len(scores) == 0:
         raise ValueError("Scores cannot be empty")
+    if len(scores) & (len(scores) - 1) != 0:
+        raise ValueError("Number of scores must be a power of 2")
 
     # Base case: If the current depth equals the height of the tree,
     # return the score of the current node.


### PR DESCRIPTION
### Describe your change

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
minimax() compared depth (int) against height (float from math.log), which never matches for non-power-of-2 list sizes and caused infinite recursion (RecursionError). Validate the power-of-2 constraint up front.

#### Additional comments?
None.

Fixes #14886