### PR TITLE
fix: make bad character shift effective in boyer_moore_search

### DIFF
--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -86,15 +86,15 @@ class BoyerMooreSearch:
         """
 
         positions = []
-        for i in range(self.textLen - self.patLen + 1):
+        i = 0
+        while i <= self.textLen - self.patLen:
             mismatch_index = self.mismatch_in_text(i)
             if mismatch_index == -1:
                 positions.append(i)
+                i += 1
             else:
                 match_index = self.match_in_pattern(self.text[mismatch_index])
-                i = (
-                    mismatch_index - match_index
-                )  # shifting index lgtm [py/multiple-definition]
+                i = max(i + 1, mismatch_index - match_index)
         return positions
 
 


### PR DESCRIPTION
### Describe your change

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
The bad-character shift was dead code: reassigning the or-loop variable i has no effect, so the algorithm degraded to brute-force O(nm). Rewrite as a while loop so the shift actually skips positions.

#### Additional comments?
None.

Fixes #14844