### PR TITLE
fix: reject multi-character separators in split

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,7 +17,15 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+        ...
+    ValueError: separator must be a single character
     """
+
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
 
     split_words = []
 


### PR DESCRIPTION
### Describe your change

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
split() compares character-by-character, so a multi-character separator was never matched and the string was returned unsplit. Raise ValueError for separators longer than one character.

#### Additional comments?
None.

Fixes #14649