### PR TITLE
fix: raise ValueError when simplex hits max iterations

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,7 +302,11 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+        raise ValueError(
+            "Simplex did not converge within "
+            f"{Tableau.maxiter} iterations. The problem may be cycling or "
+            "unbounded."
+        )
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic


### PR DESCRIPTION
### Describe your change

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Add, change, or clarify documentation?

#### What does this implement/fix?
un_simplex() silently returned {} when the iteration limit was exhausted, hiding cycling/unbounded problems. Raise an informative ValueError instead.

#### Additional comments?
None.

Fixes #14584