### PR TITLE
Fix docstring copy-paste error in maths/sumset.py

### DIFF
--- a/maths/sumset.py
+++ b/maths/sumset.py
@@ -10,9 +10,9 @@ Source:
 
 def sumset(set_a: set, set_b: set) -> set:
     """
-    :param first set: a set of numbers
-    :param second set: a set of numbers
-    :return: the nth number in Sylvester's sequence
+    :param set_a: a set of numbers
+    :param set_b: a set of numbers
+    :return: the sumset of set_a and set_b (all pairwise sums a + b)
 
     >>> sumset({1, 2, 3}, {4, 5, 6})
     {5, 6, 7, 8, 9}


### PR DESCRIPTION
### Describe your change:

The docstring of `sumset()` in `maths/sumset.py` contained a copy-paste error from `maths/sylvester_sequence.py`:

* The `return` description said *"the nth number in Sylvester's sequence"* — but the function computes a sumset, a completely different mathematical concept.
* The `param` names (`first set`, `second set`) did not match the actual parameter names (`set_a`, `set_b`).

Fixed both so the docstring now accurately describes the parameters and the return value:

```
:param set_a: a set of numbers
:param set_b: a set of numbers
:return: the sumset of set_a and set_b (all pairwise sums a + b)
```

No code logic changed — documentation fix only. All existing doctests pass.

Fixes #15013

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/TheAlgorithms/Python/pulls) for the same update/change?
* [ ] Does your submission pass tests? &nbsp; (documentation only change; doctests pass locally)

