### PR TITLE
Fix Boyer-Moore bad character shift having no effect

### DIFF
--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -86,15 +86,18 @@ class BoyerMooreSearch:
         """
 
         positions = []
-        for i in range(self.textLen - self.patLen + 1):
+        i = 0
+        while i <= self.textLen - self.patLen:
             mismatch_index = self.mismatch_in_text(i)
             if mismatch_index == -1:
                 positions.append(i)
+                i += 1
             else:
                 match_index = self.match_in_pattern(self.text[mismatch_index])
-                i = (
-                    mismatch_index - match_index
-                )  # shifting index lgtm [py/multiple-definition]
+                # shift pattern so the last occurrence of the mismatched
+                # character in the pattern aligns with the text, while
+                # always making at least one position of progress
+                i = max(i + 1, mismatch_index - match_index)
         return positions
 
 


### PR DESCRIPTION
### Describe your change:

In `strings/boyer_moore_search.py`, `bad_character_heuristic()` reassigned the `for`-loop variable `i` inside the loop body:

```python
for i in range(self.textLen - self.patLen + 1):
    ...
    i = (mismatch_index - match_index)  # no effect on iteration
```

In Python, reassigning the loop variable does not change the iteration, so the bad-character shift was dead code. The search checked every position sequentially — brute-force O(n·m) — while the module docstring advertises Boyer-Moore O(n/m).

**Fix:** convert the loop to a `while` loop so the shift actually applies, using `i = max(i + 1, mismatch_index - match_index)` to guarantee forward progress (the `max` also covers the case where the mismatched character is absent from the pattern, where `match_index == -1` makes the raw difference negative or a no-op shift).

**Verification:**
- All doctests pass.
- 2000 randomized text/pattern comparisons against brute-force search: identical results.
- The reproduction from the issue (`text='ABCDEFGHIJKLMNOP...'`, `pattern='MNOP'`) now takes **9 iterations instead of 29**.

Fixes #14844

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/TheAlgorithms/Python/pulls) for the same update/change?
* [x] Does your submission pass tests?

