### PR TITLE
Add time and space complexity analysis to insertion_sort docstring

### DIFF
--- a/sorts/insertion_sort.py
+++ b/sorts/insertion_sort.py
@@ -31,6 +31,12 @@ def insertion_sort[T: Comparable](collection: MutableSequence[T]) -> MutableSequ
     comparable items inside
     :return: the same collection ordered by ascending
 
+    Time Complexity:
+        - O(n^2) in the worst and average cases
+        - O(n) in the best case, when the collection is already sorted
+    Space Complexity:
+        - O(1), since the collection is sorted in place
+
     Examples:
     >>> insertion_sort([0, 5, 3, 2, 2])
     [0, 2, 2, 3, 5]


### PR DESCRIPTION
### Describe your change:

Adds the performance characteristics of insertion sort to the `insertion_sort()` docstring in `sorts/insertion_sort.py`, as requested in the issue:

* **Time Complexity:** O(n^2) worst and average case; O(n) best case when the input is already sorted
* **Space Complexity:** O(1) — the collection is sorted in place

Documentation-only change; no code logic modified. All existing doctests pass.

Fixes #14866

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/TheAlgorithms/Python/pulls) for the same update/change?
* [x] Does your submission pass tests?

