### PR TITLE
fix(cyclic_sort): validate input to prevent infinite loop

### DIFF
--- a/sorts/cyclic_sort.py
+++ b/sorts/cyclic_sort.py
@@ -29,6 +29,11 @@ def cyclic_sort(nums: list[int]) -> list[int]:
     [1, 2, 3, 4, 5]
     """
 
+    if len(nums) != len(set(nums)):
+        raise ValueError(f"All numbers must be unique, got {nums}")
+    if nums and (min(nums) < 1 or max(nums) > len(nums)):
+        raise ValueError(f"All numbers must be in range 1 to {len(nums)}, got {nums}")
+
     # Perform cyclic sort
     index = 0
     while index < len(nums):


### PR DESCRIPTION
### Description
Fixes #14898 — `cyclic_sort` entered an infinite loop on inputs with duplicates or out-of-range values (e.g. `[7,3,2,3,54,5,4]`). Added upfront validation: raises `ValueError` if numbers are not unique or not in `1..n`.

### Checklist
- [x] I have read the contribution guidelines
- [x] Doctests pass (`python -m doctest sorts/cyclic_sort.py`)
