### PR TITLE
fix: raise ValueError for zero input in binary_count_trailing_zeros

### DIFF
--- a/bit_manipulation/binary_count_trailing_zeros.py
+++ b/bit_manipulation/binary_count_trailing_zeros.py
@@ -17,7 +17,9 @@ def binary_count_trailing_zeros(a: int) -> int:
     >>> binary_count_trailing_zeros(4294967296)
     32
     >>> binary_count_trailing_zeros(0)
-    0
+    Traceback (most recent call last):
+        ...
+    ValueError: Input value must be a positive integer
     >>> binary_count_trailing_zeros(-10)
     Traceback (most recent call last):
         ...
@@ -31,11 +33,11 @@ def binary_count_trailing_zeros(a: int) -> int:
         ...
     TypeError: '<' not supported between instances of 'str' and 'int'
     """
-    if a < 0:
-        raise ValueError("Input value must be a positive integer")
-    elif isinstance(a, float):
+    if isinstance(a, float):
         raise TypeError("Input value must be a 'int' type")
-    return 0 if (a == 0) else int(log2(a & -a))
+    if a < 0 or a == 0:
+        raise ValueError("Input value must be a positive integer")
+    return int(log2(a & -a))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your change:

Fixes #14479. Raises a ValueError for zero inputs since trailing zeros for zero are mathematically undefined. Previously returned 0.

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms have at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #14479".

Fixes #14479
