### PR TITLE
fix: sub-interval midpoint formula in ternary search

### DIFF
--- a/searches/ternary_search.py
+++ b/searches/ternary_search.py
@@ -82,6 +82,11 @@ def ite_ternary_search(array: list[int], target: int) -> int:
     -1
     >>> ite_ternary_search([.1, .4 , -.1], .1)
     0
+    >>> test_list_large = list(range(100))
+    >>> ite_ternary_search(test_list_large, 65)
+    65
+    >>> ite_ternary_search(test_list_large, 105)
+    -1
     """
 
     left = 0
@@ -90,8 +95,8 @@ def ite_ternary_search(array: list[int], target: int) -> int:
         if right - left < precision:
             return lin_search(left, right, array, target)
 
-        one_third = (left + right) // 3 + 1
-        two_third = 2 * (left + right) // 3 + 1
+        one_third = left + (right - left) // 3
+        two_third = right - (right - left) // 3
 
         if array[one_third] == target:
             return one_third
@@ -99,13 +104,13 @@ def ite_ternary_search(array: list[int], target: int) -> int:
             return two_third
 
         elif target < array[one_third]:
-            right = one_third - 1
+            right = one_third
         elif array[two_third] < target:
             left = two_third + 1
 
         else:
             left = one_third + 1
-            right = two_third - 1
+            right = two_third
     return -1
 
 
@@ -133,12 +138,19 @@ def rec_ternary_search(left: int, right: int, array: list[int], target: int) -> 
     -1
     >>> rec_ternary_search(0, 3, [.1, .4 , -.1], .1)
     0
+    >>> test_list_large = list(range(100))
+    >>> rec_ternary_search(0, len(test_list_large), test_list_large, 65)
+    65
+    >>> rec_ternary_search(20, 80, test_list_large, 65)
+    65
+    >>> rec_ternary_search(20, 80, test_list_large, 15)
+    -1
     """
     if left < right:
         if right - left < precision:
             return lin_search(left, right, array, target)
-        one_third = (left + right) // 3 + 1
-        two_third = 2 * (left + right) // 3 + 1
+        one_third = left + (right - left) // 3
+        two_third = right - (right - left) // 3
 
         if array[one_third] == target:
             return one_third
@@ -146,11 +158,11 @@ def rec_ternary_search(left: int, right: int, array: list[int], target: int) -> 
             return two_third
 
         elif target < array[one_third]:
-            return rec_ternary_search(left, one_third - 1, array, target)
+            return rec_ternary_search(left, one_third, array, target)
         elif array[two_third] < target:
             return rec_ternary_search(two_third + 1, right, array, target)
         else:
-            return rec_ternary_search(one_third + 1, two_third - 1, array, target)
+            return rec_ternary_search(one_third + 1, two_third, array, target)
     else:
         return -1
 
@@ -165,9 +177,10 @@ if __name__ == "__main__":
     assert collection == sorted(collection), f"List must be ordered.\n{collection}."
     target = int(input("Enter the number to be found in the list:\n").strip())
     result1 = ite_ternary_search(collection, target)
-    result2 = rec_ternary_search(0, len(collection) - 1, collection, target)
+    result2 = rec_ternary_search(0, len(collection), collection, target)
     if result2 != -1:
         print(f"Iterative search: {target} found at positions: {result1}")
         print(f"Recursive search: {target} found at positions: {result2}")
     else:
         print("Not found")
+

--- a/searches/ternary_search.py
+++ b/searches/ternary_search.py
@@ -183,4 +183,3 @@ if __name__ == "__main__":
         print(f"Recursive search: {target} found at positions: {result2}")
     else:
         print("Not found")
-


### PR DESCRIPTION
### Describe your change:

Fixes #15069

- Fixed the sub-interval split point calculation formulas in `searches/ternary_search.py` for both `ite_ternary_search` and `rec_ternary_search`.
- Corrected the midpoint calculations when the search interval starts at an index greater than `0`.
- Adjusted the search boundary updates to correctly handle the exclusive `right` index.
- Added doctests covering non-zero `left` boundaries and larger input arrays to prevent regressions.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".