### PR TITLE
fix: NameError when importing matrix_exponentiation.py

### DIFF
--- a/maths/matrix_exponentiation.py
+++ b/maths/matrix_exponentiation.py
@@ -1,5 +1,7 @@
 """Matrix Exponentiation"""
 
+from __future__ import annotations
+
 import timeit
 
 """


### PR DESCRIPTION
## Problem

Importing `maths/matrix_exponentiation.py` raises `NameError: name 'Matrix' is not defined`. `Matrix.__mul__` uses `Matrix` in its own annotation, which is evaluated while the class body is still executing, before the name exists. The type hints were added in #14288.

## Solution

Add `from __future__ import annotations` to defer annotation evaluation. This is the same fix already used in 250+ files in this repo (e.g. `maths/prime_factors.py`). Two-line diff, no behavior change.

## Verification

- Before: `python3 -c 'import maths.matrix_exponentiation'` fails with the reported NameError.
- After: import succeeds and `python3 -m doctest maths/matrix_exponentiation.py` passes (10/10).
- `ruff check` passes.

Also scanned all of `maths/` for the same pattern (self-referential annotations without the future import); this is the only occurrence.

Closes #15075