### PR TITLE
fix(searches): handle empty list in jump_search

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -33,7 +33,12 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     10
     >>> jump_search(["aa", "bb", "cc", "dd", "ee", "ff"], "ee")
     4
+    >>> jump_search([], 5)
+    -1
     """
+
+    if not arr:
+        return -1
 
     arr_size = len(arr)
     block_size = int(math.sqrt(arr_size))


### PR DESCRIPTION
### Describe your change:

Fixes #15085

Added an early return guard `if not arr: return -1` in `jump_search()` (`searches/jump_search.py`) to handle empty list inputs gracefully instead of raising an `IndexError`.

Also added a corresponding doctest, `>>> jump_search([], 5)`, to verify that searching an empty list correctly returns `-1`.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all of my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".