### PR TITLE
fix(searches): jump_search returns -1 for empty list (was IndexError)

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -33,9 +33,14 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     10
     >>> jump_search(["aa", "bb", "cc", "dd", "ee", "ff"], "ee")
     4
+    >>> jump_search([], 5)
+    -1
     """
 
     arr_size = len(arr)
+    if arr_size == 0:
+        return -1
+
     block_size = int(math.sqrt(arr_size))
 
     prev = 0


### PR DESCRIPTION
Fixes #15085

`jump_search([], 5)` raised `IndexError` because `arr[min(step, arr_size) - 1]` evaluates `arr[-1]` on an empty collection.

**Change:** early return `-1` when the collection is empty (an empty sequence cannot contain the target), + doctest to lock the behavior.

**Verified:** doctest passes (6 tests incl. the new empty case); `jump_search([], 5) == -1`, normal cases unaffected.