### PR TITLE
fix(searches): jump_search returns -1 for empty list (was IndexError)

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -33,9 +33,14 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     10
     >>> jump_search(["aa", "bb", "cc", "dd", "ee", "ff"], "ee")
     4
+    >>> jump_search([], 5)
+    -1
     """
 
     arr_size = len(arr)
+    if arr_size == 0:
+        return -1
+
     block_size = int(math.sqrt(arr_size))
 
     prev = 0


### PR DESCRIPTION
### Describe your change:

Fix jump_search to return -1 for an empty collection instead of raising IndexError.

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints].
* [x] All functions have [doctests] that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword]: "Fixes #15085".

Fixes #15085. `jump_search([], 5)` raised `IndexError` because `arr[min(step, arr_size) - 1]` evaluates `arr[-1]` on an empty collection. Add an early `return -1` for an empty sequence (which cannot contain the target) + a doctest. Doctest verified: 6 tests pass, `jump_search([], 5) == -1`, normal cases unaffected.