### PR TITLE
Fix in_static_equilibrium for NumPy 2.x (2-D cross product removed)

### DIFF
--- a/physics/in_static_equilibrium.py
+++ b/physics/in_static_equilibrium.py
@@ -4,7 +4,7 @@ Checks if a system of forces is in static equilibrium.
 
 from __future__ import annotations
 
-from numpy import array, cos, cross, float64, radians, sin
+from numpy import array, cos, float64, radians, sin
 from numpy.typing import NDArray
 
 
@@ -51,7 +51,11 @@ def in_static_equilibrium(
     False
     """
     # summation of moments is zero
-    moments: NDArray[float64] = cross(location, forces)
+    # NumPy 2.x removed the 2-D cross product, so compute the scalar
+    # (z-axis) moment for each row directly: x_i * Fy_i - y_i * Fx_i.
+    moments: NDArray[float64] = (
+        location[:, 0] * forces[:, 1] - location[:, 1] * forces[:, 0]
+    )
     sum_moments: float = sum(moments)
     return bool(abs(sum_moments) < eps)
 


### PR DESCRIPTION
### Describe your change:

`physics/in_static_equilibrium.py` calls `numpy.cross()` on **2-D** input vectors. NumPy deprecated 2-D cross products in 2.0 and **removed** them in newer releases, so on recent NumPy the doctest now raises:

```
ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
```

Current `master` CI still passes only because its lockfile pins `numpy==2.2.5`; the failure surfaces on newer NumPy (e.g. the free-threaded `3.14t` job resolves `numpy==2.5.2`). This is a latent break that will hit `master` on the next NumPy bump.

The 2-D "cross product" is just the scalar z-component `x·Fy − y·Fx` per row, so I compute it directly. Behaviour is identical to the old `cross()` and works across all NumPy versions. Doctests and the `__main__` self-checks pass unchanged.

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? — _no, existing doctests unchanged_

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one issue, please mention the issue number.