### PR TITLE
ci: single-source the Python version via pyproject.toml + add uv-lock pre-commit hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           cache-dependency-glob: uv.lock
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version-file: pyproject.toml
           allow-prereleases: true
       - run: uv sync --group=test
       - name: Run tests

--- a/.github/workflows/directory_writer.yml
+++ b/.github/workflows/directory_writer.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version-file: pyproject.toml
           allow-prereleases: true
       - name: Write DIRECTORY.md
         run: |

--- a/.github/workflows/project_euler.yml
+++ b/.github/workflows/project_euler.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version-file: pyproject.toml
           allow-prereleases: true
       - run: uv sync --group=euler-validate --group=test
       - run: uv run pytest --doctest-modules --cov-report=term-missing:skip-covered --cov=project_euler/ project_euler/
@@ -43,7 +43,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version-file: pyproject.toml
           allow-prereleases: true
       - run: uv sync --group=euler-validate --group=test
       - run: uv run pytest scripts/validate_solutions.py

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version-file: pyproject.toml
           allow-prereleases: true
       - run: uv sync --group=docs
       - uses: actions/configure-pages@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
     hooks:
       - id: auto-walrus
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.12.7
+    hooks:
+      - id: uv-lock
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:


### PR DESCRIPTION
As discussed in #15081 and https://github.com/TheAlgorithms/Python/pull/15104#issuecomment-5450998944, this does the two follow-ups:

### 1. Add `astral-sh/uv-pre-commit` (`uv-lock` hook)
Keeps `uv.lock` automatically in sync with `pyproject.toml`. Right now the lockfile only gets refreshed by hand, so it can silently drift (e.g. after a dependency bump). With this hook, pre-commit.ci relocks and auto-commits whenever `pyproject.toml` changes, so `uv sync` in CI always sees a consistent lock.

```yaml
- repo: https://github.com/astral-sh/uv-pre-commit
  rev: 0.12.7
  hooks:
    - id: uv-lock
```

### 2. `python-version-file: pyproject.toml` on every `actions/setup-python`
Replaces the hard-coded `python-version: 3.14` in `build.yml`, `project_euler.yml` (both jobs), `sphinx.yml`, and `directory_writer.yml` with `python-version-file: pyproject.toml`. `actions/setup-python@v7` reads `project.requires-python` (`>=3.14`), so the interpreter version now has a **single source of truth** — bumping `requires-python` moves all of CI at once and there's no chance of a workflow being left behind.

No behavioural change today (still resolves to 3.14); this is a maintainability cleanup. Happy to adjust the pin style if you'd prefer a `.python-version` file instead.