### PR TITLE
ci: skip uv-lock on pre-commit.ci (no network access there)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 ci:
   autoupdate_schedule: monthly
+  # uv-lock resolves dependencies from PyPI, but pre-commit.ci runs hooks with no
+  # network access, so it fails there. Skip it on pre-commit.ci; it still runs locally.
+  skip: [uv-lock]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
### Describe your change:

The `uv-lock` hook added in #15111 is failing on **pre-commit.ci** for every PR:

```
uv-lock..................................................................Failed
- hook id: uv-lock
error: Request failed after 3 retries in 3.4s
  Caused by: Failed to fetch: `https://pypi.org/simple/matplotlib/`
  Caused by: dns error: failed to lookup address information: Temporary failure in name resolution
```

pre-commit.ci runs hooks in a sandbox **without network access**, but `uv-lock` resolves dependencies against PyPI, so it can never succeed there. This adds `skip: [uv-lock]` under the `ci` key so pre-commit.ci stops reporting a red check on unrelated PRs. The hook still runs locally and the `uv.lock` file is still kept in sync by the dedicated `uv-lock` GitHub Actions job / local runs.

This is a follow-up fixing a regression from my own #15111 — sorry for the noise.

* [x] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? — Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. — CI/config change only.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s).