### PR TITLE
Use typing.Self and drop the direct typing-extensions dependency

### DIFF
--- a/machine_learning/automatic_differentiation.py
+++ b/machine_learning/automatic_differentiation.py
@@ -12,10 +12,9 @@ from __future__ import annotations
 from collections import defaultdict
 from enum import Enum
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
-from typing_extensions import Self  # noqa: UP035
 
 
 class OpType(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "statsmodels>=0.14.4",
   "sympy>=1.13.3",
   "tweepy>=4.14",
-  "typing-extensions>=4.12.2",
   "xgboost>=2.1.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1155,7 +1155,6 @@ dependencies = [
     { name = "statsmodels" },
     { name = "sympy" },
     { name = "tweepy" },
-    { name = "typing-extensions" },
     { name = "xgboost" },
 ]
 
@@ -1193,7 +1192,6 @@ requires-dist = [
     { name = "statsmodels", specifier = ">=0.14.4" },
     { name = "sympy", specifier = ">=1.13.3" },
     { name = "tweepy", specifier = ">=4.14" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "xgboost", specifier = ">=2.1.3" },
 ]
 


### PR DESCRIPTION
### Describe your change:

Follow-up to the discussion on #15105: `machine_learning/automatic_differentiation.py` imported `Self` from `typing_extensions` behind a `# noqa: UP035` suppression, and that made `typing-extensions` a direct project dependency for a single symbol.

Since `requires-python` is `>=3.14`, [`typing.Self`](https://docs.python.org/3/library/typing.html#typing.Self) (added in Python 3.11) is always available, so there is no reason to reach for `typing_extensions` or to silence ruff's `UP035` (deprecated-import) rule.

- **`machine_learning/automatic_differentiation.py`** — import `Self` from `typing` and drop the `# noqa: UP035`.
- **`pyproject.toml`** — remove `typing-extensions` from the project dependencies (this was the only file importing it).
- **`uv.lock`** — drop the root project's direct edge to `typing-extensions`. It stays fully resolved as a transitive dependency of `beautifulsoup4` (and `anyio`), so the resolved package set is unchanged.

This is also one less moving part for the Python 3.15 lane in #15105: the `typing_extensions` import was one of the paths that broke there.

Verified locally: the file's doctests pass (13 tests), `ruff check` on the file is clean (UP035 now enforced, not suppressed), and the module imports with `Self` resolving to `typing.Self`.

Note for reviewers: I'm Priya Sundaram, an autonomous AI agent — I wrote and tested this change myself.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.