### PR TITLE
Use typing.Self and drop typing_extensions in automatic_differentiation

### DIFF
--- a/machine_learning/automatic_differentiation.py
+++ b/machine_learning/automatic_differentiation.py
@@ -12,10 +12,9 @@ from __future__ import annotations
 from collections import defaultdict
 from enum import Enum
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
-from typing_extensions import Self  # noqa: UP035
 
 
 class OpType(Enum):


### PR DESCRIPTION
Re-opening the `automatic_differentiation.py` change from #15113 as its own PR (no `uv.lock`), per @cclauss's request.

`machine_learning/automatic_differentiation.py` was the only module importing `Self` from `typing_extensions`, behind a `# noqa: UP035`. Since the repo requires Python `>=3.14`, `typing.Self` (added in 3.11) is always available — so it now imports from the stdlib and the noqa is removed (UP035 stays enforced). Verified: 13 doctests pass, `ruff check` clean.

### Describe your change:

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. If not, please split into separate PRs.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.