### PR TITLE
ci: reduce pytest --ignore list in build.yml (re-enable local_weighted_learning)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
           --ignore=computer_vision/cnn_classification.py
           --ignore=docs/conf.py
           --ignore=dynamic_programming/k_means_clustering_tensorflow.py
-          --ignore=machine_learning/local_weighted_learning/local_weighted_learning.py
           --ignore=machine_learning/lstm/lstm_prediction.py
           --ignore=neural_network/input_data.py
           --ignore=project_euler/

--- a/machine_learning/local_weighted_learning/local_weighted_learning.py
+++ b/machine_learning/local_weighted_learning/local_weighted_learning.py
@@ -50,13 +50,13 @@ def weight_matrix(point: np.ndarray, x_train: np.ndarray, tau: float) -> np.ndar
         m x m weight matrix around the prediction point, where m is the size of
         the training set
     >>> weight_matrix(
-    ...     np.array([1., 1.]),
-    ...     np.array([[16.99, 10.34], [21.01,23.68], [24.59,25.69]]),
-    ...     0.6
-    ... )
-    array([[1.43807972e-207, 0.00000000e+000, 0.00000000e+000],
-           [0.00000000e+000, 0.00000000e+000, 0.00000000e+000],
-           [0.00000000e+000, 0.00000000e+000, 0.00000000e+000]])
+    ...     np.array([16.99, 10.34]),
+    ...     np.array([[16.99, 10.34], [21.01, 23.68], [24.59, 25.69]]),
+    ...     5,
+    ... ).round(4)
+    array([[1.    , 0.    , 0.    ],
+           [0.    , 0.0206, 0.    ],
+           [0.    , 0.    , 0.0028]])
     """
     m = len(x_train)  # Number of training samples
     weights = np.eye(m)  # Initialize weights as identity matrix
@@ -83,13 +83,13 @@ def local_weight(
     Returns:
         ndarray of local weights
     >>> local_weight(
-    ...     np.array([1., 1.]),
-    ...     np.array([[16.99, 10.34], [21.01,23.68], [24.59,25.69]]),
+    ...     np.array([16.99, 10.34]),
+    ...     np.array([[16.99, 10.34], [21.01, 23.68], [24.59, 25.69]]),
     ...     np.array([[1.01, 1.66, 3.5]]),
-    ...     0.6
-    ... )
-    array([[0.00873174],
-           [0.08272556]])
+    ...     5,
+    ... ).round(5)
+    array([[0.02572],
+           [0.05552]])
     """
     weight_mat = weight_matrix(point, x_train, tau)
     weight = np.linalg.inv(x_train.T @ weight_mat @ x_train) @ (
@@ -116,9 +116,9 @@ def local_weight_regression(
     >>> local_weight_regression(
     ...     np.array([[16.99, 10.34], [21.01, 23.68], [24.59, 25.69]]),
     ...     np.array([[1.01, 1.66, 3.5]]),
-    ...     0.6
-    ... )
-    array([1.07173261, 1.65970737, 3.50160179])
+    ...     5,
+    ... ).round(5)
+    array([1.01094, 1.98589, 3.42233])
     """
     y_pred = np.zeros(len(x_train))  # Initialize array of predictions
     for i, item in enumerate(x_train):


### PR DESCRIPTION
Per @cclauss's request in #15081, this trims the `pytest --ignore` list in `build.yml`. I investigated every ignored path to see which could be re-enabled. Removing `docs/conf.py` and `project_euler/` was explicitly out of scope (config file / dedicated workflow), so this focuses on the rest.

### Re-enabled ✅
- **`machine_learning/local_weighted_learning/local_weighted_learning.py`** — imports only `numpy` and `matplotlib` (both already in `[project.dependencies]`), and all plotting lives under `if __name__ == "__main__"`, so `--doctest-modules` just imports it cleanly.

  The reason it was *actually* ignored surfaced once CI ran it: its doctests used `tau=0.6` on data with feature values ~17–25, so the Gaussian weights underflowed to ≈0 (e.g. `8e-118`, `1e-177`). That made `XᵀWX` numerically singular (**cond ≈ 5.6e18**), so `inv(...)` — and the predictions — were **nondeterministic across numpy/BLAS builds**: on the CI numpy the first prediction came out `0.0` instead of the documented `1.07`. Second commit fixes this by switching the doctests to **`tau=5`** (cond ≈ 2e2) — the same bandwidth the module's own `main()` already uses — and rounding the outputs so they're stable across platforms. Deterministic now; the 5 doctests pass under `--doctest-modules`.

### Investigated, needs to stay ignored — with the specific blocker
- **`computer_vision/cnn_classification.py`**, **`dynamic_programming/k_means_clustering_tensorflow.py`**, **`neural_network/input_data.py`** — all import **`tensorflow`**, which is not (and, given its size/Python-version cadence, deliberately isn't) in `[project.dependencies]`. Collection fails at import. Same reason tracked historically in #11318.
- **`machine_learning/lstm/lstm_prediction.py`** — imports `keras`, but Keras 3 needs a backend (TensorFlow/JAX/PyTorch) and none is in the dependency set, so `from keras.layers import LSTM` can't resolve a backend in CI.
- **`quantum/q_fourier_transform.py`** — imports `qiskit` (not a dependency) and uses the removed `qiskit.Aer` / `execute` API. Already tracked by the `# TODO: #8818 Re-enable quantum tests` comment right above this block.
- **`web_programming/current_stock_price.py`**, **`web_programming/fetch_anime_and_play.py`** — their doctests make live HTTP requests to third-party sites and assert on scraped HTML; re-enabling them would make `build` flaky/dependent on external services.
- **`scripts/validate_solutions.py`** — validates Project Euler answers against a network manifest and is meant to run in its own dedicated flow, not the general `build` matrix.

### Net effect
One line removed from the ignore list, with `local_weighted_learning` now genuinely green in CI. I kept the change deliberately small and evidence-based — happy to revisit any of the above if a maintainer wants to add the corresponding heavy/optional dependency (e.g. a TensorFlow or Qiskit job).

Ref #15081.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] All functions and variable names follow Python naming conventions.
- [x] All function parameters and return values are annotated with Python type hints.
- [x] All functions have doctests that pass the automated testing.
- [x] This is a CI/tooling change (`build.yml`) plus the doctest fix needed to make the re-enabled module pass; it does not add a new algorithm.

🤖 Written and tested by Priya Sundaram, an autonomous AI agent. #ABotWroteThis
