### PR TITLE
quantum: modernize QFT to Qiskit 2.x and re-enable its test (DRAFT)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
           allow-prereleases: true
       - run: uv sync --group=test
       - name: Run tests
-        # TODO: #8818 Re-enable quantum tests
         run: uv run --with=pytest-run-parallel pytest
           --iterations=8 --parallel-threads=auto
           --ignore=computer_vision/cnn_classification.py
@@ -30,7 +29,6 @@ jobs:
           --ignore=machine_learning/lstm/lstm_prediction.py
           --ignore=neural_network/input_data.py
           --ignore=project_euler/
-          --ignore=quantum/q_fourier_transform.py
           --ignore=scripts/validate_solutions.py
           --ignore=web_programming/current_stock_price.py
           --ignore=web_programming/fetch_anime_and_play.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "opencv-python>=4.10.0.84",
   "pandas>=2.2.3",
   "pillow>=11.3",
+  "qiskit>=2",
   "rich>=13.9.4",
   "scikit-learn>=1.5.2",
   "scipy>=1.16.2",

--- a/quantum/q_fourier_transform.py
+++ b/quantum/q_fourier_transform.py
@@ -1,27 +1,34 @@
 """
-Build the quantum fourier transform (qft) for a desire
-number of quantum bits using Qiskit framework. This
-experiment run in IBM Q simulator with 10000 shots.
-This circuit can be use as a building block to design
-the Shor's algorithm in quantum computing. As well as,
-quantum phase estimation among others.
-.
+Build the quantum Fourier transform (QFT) for a desired
+number of qubits using the Qiskit framework.
+
+This circuit can be used as a building block to design
+Shor's algorithm in quantum computing, as well as
+quantum phase estimation, among others.
+
+The circuit is simulated with Qiskit's built-in, pure-Python
+``BasicSimulator`` (no compiled ``qiskit-aer`` backend required),
+so it runs anywhere Qiskit itself installs.
+
 References:
 https://en.wikipedia.org/wiki/Quantum_Fourier_transform
-https://qiskit.org/textbook/ch-algorithms/quantum-fourier-transform.html
+https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.QFT
 """
 
 import math
 
 import numpy as np
 import qiskit
-from qiskit import Aer, ClassicalRegister, QuantumCircuit, QuantumRegister, execute
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
+from qiskit.providers.basic_provider import BasicSimulator
 
 
 def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts.Counts:
     """
-    # >>> quantum_fourier_transform(2)
-    # {'00': 2500, '01': 2500, '11': 2500, '10': 2500}
+    Build and simulate the quantum Fourier transform applied to the all-zero
+    state ``|0...0>``.  The QFT maps ``|0...0>`` to a uniform superposition, so
+    every computational-basis outcome is (up to shot noise) equally likely.
+
     # quantum circuit for number_of_qubits = 3:
                                                ┌───┐
     qr_0: ──────■──────────────────────■───────┤ H ├─X─
@@ -31,13 +38,20 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
     qr_2: ┤ H ├─■────────■───────────────────────────X─
           └───┘
     cr: 3/═════════════════════════════════════════════
-    Args:
-        n : number of qubits
-    Returns:
-        qiskit.result.counts.Counts: distribute counts.
 
-    >>> quantum_fourier_transform(2)
-    {'00': 2500, '01': 2500, '10': 2500, '11': 2500}
+    Args:
+        number_of_qubits : number of qubits
+
+    Returns:
+        qiskit.result.counts.Counts: measurement counts over 10000 shots.
+
+    The simulation is seeded, so the set of observed outcomes is reproducible:
+
+    >>> counts = quantum_fourier_transform(2)
+    >>> sorted(counts)
+    ['00', '01', '10', '11']
+    >>> sum(counts.values())
+    10000
     >>> quantum_fourier_transform(-1)
     Traceback (most recent call last):
         ...
@@ -82,9 +96,12 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
 
     # measure all the qubits
     quantum_circuit.measure(qr, cr)
-    # simulate with 10000 shots
-    backend = Aer.get_backend("qasm_simulator")
-    job = execute(quantum_circuit, backend, shots=10000)
+
+    # simulate with 10000 shots on the pure-Python BasicSimulator; seed the run
+    # so the observed outcomes are reproducible for the doctest above.
+    backend = BasicSimulator()
+    transpiled_circuit = transpile(quantum_circuit, backend)
+    job = backend.run(transpiled_circuit, shots=10000, seed_simulator=42)
 
     return job.result().get_counts(quantum_circuit)
 


### PR DESCRIPTION
Follow-up to #15118 and the ask in #15081: try to get the remaining ignored tests working, starting with the quantum one.

### What this does
`quantum/q_fourier_transform.py` imported `Aer` and `execute` from `qiskit` — both **removed in the Qiskit 1.0 API break** — so the file could never import, which is why it sat on the `--ignore` list and its doctest was never validated. This ports it to the current API:

- Simulate with the **pure-Python `BasicSimulator`** (`transpile()` + `backend.run()`) instead of `Aer.get_backend("qasm_simulator")` + `execute()`. `BasicSimulator` ships inside `qiskit` core, so **no compiled `qiskit-aer` backend is required** — relevant because `qiskit-aer` doesn't publish Python 3.14 wheels yet (Qiskit/qiskit-aer#2378), while this repo requires Python ≥ 3.14.
- Seed the run (`seed_simulator=42`) and rewrite the doctest to check the **reproducible, shot-noise-independent** facts (all four outcomes appear; counts sum to the shot total) rather than exact per-state counts, which random sampling can never hit — the old `{'00': 2500, ...}` doctest was statistically impossible and only "passed" because it was ignored.
- Add `qiskit>=2` to `dependencies`; drop `--ignore=quantum/q_fourier_transform.py` and the stale `# TODO: #8818 Re-enable quantum tests` comment from `build.yml`.

### Why draft
I can't install Qiskit on Python 3.14 locally to fully verify, so I'm opening this as a **draft to let CI confirm** `qiskit` core installs and imports on the repo's interpreter (the same document-the-failures approach as #15104/#15105). If it's green, happy to mark ready. Closes the quantum half of #8818 once it lands.

### The other ignored files (TensorFlow) — separate story
The remaining `--ignore` entries are TensorFlow-based and are **hard-blocked by the Python floor**, not by stale code:

| File | Blocker |
|---|---|
| `dynamic_programming/k_means_clustering_tensorflow.py`, `neural_network/input_data.py`, `computer_vision/cnn_classification.py` | `import tensorflow` — TensorFlow's latest release tops out at **Python 3.13**; there are no 3.14 wheels, so adding it would break `uv sync` for the whole repo. `k_means_clustering_tensorflow.py` also still uses the TF1.x graph API (`tf.placeholder`, sessions). |
| `machine_learning/lstm/lstm_prediction.py` | Keras-only, but Keras 3 needs a backend and the only backend that fits the Python floor would be JAX; it also trains an LSTM per run (slow/heavy for `build`). |
| `web_programming/current_stock_price.py`, `web_programming/fetch_anime_and_play.py`, `scripts/validate_solutions.py` | live network / third-party HTML → flaky, should stay out of `build`. |

So TF re-enablement realistically waits on TensorFlow shipping 3.14 wheels (or a JAX-backend rewrite of the Keras files). Happy to take on the JAX-backend `lstm_prediction` path as a separate PR if you'd like.
