### PR TITLE
quantum: modernize QFT to Qiskit 2.x and re-enable its test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
           allow-prereleases: true
       - run: uv sync --group=test
       - name: Run tests
-        # TODO: #8818 Re-enable quantum tests
         run: uv run --with=pytest-run-parallel pytest
           --iterations=8 --parallel-threads=auto
           --ignore=computer_vision/cnn_classification.py
@@ -30,7 +29,6 @@ jobs:
           --ignore=machine_learning/lstm/lstm_prediction.py
           --ignore=neural_network/input_data.py
           --ignore=project_euler/
-          --ignore=quantum/q_fourier_transform.py
           --ignore=scripts/validate_solutions.py
           --ignore=web_programming/current_stock_price.py
           --ignore=web_programming/fetch_anime_and_play.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "opencv-python>=4.10.0.84",
   "pandas>=2.2.3",
   "pillow>=11.3",
+  "qiskit>=2",
   "rich>=13.9.4",
   "scikit-learn>=1.5.2",
   "scipy>=1.16.2",

--- a/quantum/q_fourier_transform.py
+++ b/quantum/q_fourier_transform.py
@@ -43,7 +43,7 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
         number_of_qubits : number of qubits
 
     Returns:
-        qiskit.result.counts.Counts: measurement counts over 10000 shots.
+        qiskit.result.counts.Counts: measurement counts over 10,000 shots.
 
     The simulation is seeded, so the set of observed outcomes is reproducible:
 

--- a/quantum/q_fourier_transform.py
+++ b/quantum/q_fourier_transform.py
@@ -101,7 +101,7 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
     # so the observed outcomes are reproducible for the doctest above.
     backend = BasicSimulator()
     transpiled_circuit = transpile(quantum_circuit, backend)
-    job = backend.run(transpiled_circuit, shots=10000, seed_simulator=42)
+    job = backend.run(transpiled_circuit, shots=10_000, seed_simulator=42)
 
     return job.result().get_counts(quantum_circuit)
 

--- a/quantum/q_fourier_transform.py
+++ b/quantum/q_fourier_transform.py
@@ -1,27 +1,34 @@
 """
-Build the quantum fourier transform (qft) for a desire
-number of quantum bits using Qiskit framework. This
-experiment run in IBM Q simulator with 10000 shots.
-This circuit can be use as a building block to design
-the Shor's algorithm in quantum computing. As well as,
-quantum phase estimation among others.
-.
+Build the quantum Fourier transform (QFT) for a desired
+number of qubits using the Qiskit framework.
+
+This circuit can be used as a building block to design
+Shor's algorithm in quantum computing, as well as
+quantum phase estimation, among others.
+
+The circuit is simulated with Qiskit's built-in, pure-Python
+``BasicSimulator`` (no compiled ``qiskit-aer`` backend required),
+so it runs anywhere Qiskit itself installs.
+
 References:
 https://en.wikipedia.org/wiki/Quantum_Fourier_transform
-https://qiskit.org/textbook/ch-algorithms/quantum-fourier-transform.html
+https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.QFT
 """
 
 import math
 
 import numpy as np
 import qiskit
-from qiskit import Aer, ClassicalRegister, QuantumCircuit, QuantumRegister, execute
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
+from qiskit.providers.basic_provider import BasicSimulator
 
 
 def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts.Counts:
     """
-    # >>> quantum_fourier_transform(2)
-    # {'00': 2500, '01': 2500, '11': 2500, '10': 2500}
+    Build and simulate the quantum Fourier transform applied to the all-zero
+    state ``|0...0>``.  The QFT maps ``|0...0>`` to a uniform superposition, so
+    every computational-basis outcome is (up to shot noise) equally likely.
+
     # quantum circuit for number_of_qubits = 3:
                                                ┌───┐
     qr_0: ──────■──────────────────────■───────┤ H ├─X─
@@ -31,13 +38,20 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
     qr_2: ┤ H ├─■────────■───────────────────────────X─
           └───┘
     cr: 3/═════════════════════════════════════════════
-    Args:
-        n : number of qubits
-    Returns:
-        qiskit.result.counts.Counts: distribute counts.
 
-    >>> quantum_fourier_transform(2)
-    {'00': 2500, '01': 2500, '10': 2500, '11': 2500}
+    Args:
+        number_of_qubits : number of qubits
+
+    Returns:
+        qiskit.result.counts.Counts: measurement counts over 10000 shots.
+
+    The simulation is seeded, so the set of observed outcomes is reproducible:
+
+    >>> counts = quantum_fourier_transform(2)
+    >>> sorted(counts)
+    ['00', '01', '10', '11']
+    >>> sum(counts.values())
+    10000
     >>> quantum_fourier_transform(-1)
     Traceback (most recent call last):
         ...
@@ -82,9 +96,12 @@ def quantum_fourier_transform(number_of_qubits: int = 3) -> qiskit.result.counts
 
     # measure all the qubits
     quantum_circuit.measure(qr, cr)
-    # simulate with 10000 shots
-    backend = Aer.get_backend("qasm_simulator")
-    job = execute(quantum_circuit, backend, shots=10000)
+
+    # simulate with 10000 shots on the pure-Python BasicSimulator; seed the run
+    # so the observed outcomes are reproducible for the doctest above.
+    backend = BasicSimulator()
+    transpiled_circuit = transpile(quantum_circuit, backend)
+    job = backend.run(transpiled_circuit, shots=10000, seed_simulator=42)
 
     return job.result().get_counts(quantum_circuit)
 


### PR DESCRIPTION
### Describe your change:

Follow-up to #15118 and the ask in #15081. Re-opens #15119 (auto-closed by the keeper bot for the draft's unchecked template — CI has since gone fully green, so there's no reason to keep it a draft).

`quantum/q_fourier_transform.py` imported `Aer` and `execute` from `qiskit` — both **removed in the Qiskit 1.0 API break** — so the file could never import, which is why it sat on the `--ignore` list and its doctest was never validated. This ports it to the current API:

- Simulate with the **pure-Python `BasicSimulator`** (`transpile()` + `backend.run()`) instead of `Aer.get_backend("qasm_simulator")` + `execute()`. `BasicSimulator` ships inside `qiskit` core, so **no compiled `qiskit-aer` backend is required** — relevant because `qiskit-aer` has no Python 3.14 wheels yet (Qiskit/qiskit-aer#2378), while this repo requires Python ≥ 3.14.
- Seed the run (`seed_simulator=42`) and rewrite the doctest to check the **reproducible, shot-noise-independent** facts (all four outcomes appear; counts sum to the shot total) rather than exact per-state counts — the old `{'00': 2500, ...}` doctest was statistically impossible and only "passed" because it was ignored.
- Add `qiskit>=2` to `dependencies`; drop `--ignore=quantum/q_fourier_transform.py` and the stale `# TODO: #8818` comment from `build.yml`.

**CI is green:** `build` and `build_docs` both pass on the repo's Python 3.14 interpreter, confirming `qiskit` core installs/imports and the new doctest runs and passes. Closes the quantum half of #8818.

The remaining TensorFlow `--ignore` entries are hard-blocked by the Python 3.14 floor (TensorFlow tops out at 3.13); full matrix is in #15081 / the earlier #15119 thread.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
