### PR TITLE
docs: add AGENTS.md with contribution rules for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and their humans) contributing to
+**TheAlgorithms/Python**. This complements — and never overrides —
+[`CONTRIBUTING.md`](CONTRIBUTING.md). Read that first.
+
+This repository is educational: implementations should be clear and correct
+rather than maximally optimized. Every change goes through CI and the
+`algorithms-keeper` bot, both of which reject non-conforming PRs automatically.
+
+## Before opening a pull request
+
+- **Check at least one box in the PR description.** The `algorithms-keeper`
+  bot **closes any PR whose "Describe your change" section has no checked
+  box** (`* [x]`). Fill in the template that ships in
+  `.github/pull_request_template.md` and tick every item that applies before
+  you submit — this is the single most common reason automated PRs get closed.
+- **One algorithm file per PR.** Split unrelated changes into separate PRs to
+  keep review focused.
+- **Don't change code and its doctests in the same PR.** If you're only
+  updating tests, say so and touch nothing else.
+
+## Code conventions (enforced by CI)
+
+- **Formatting & linting:** `ruff` (`ruff check .` and `ruff format .`).
+  Run `pre-commit run --all-files` locally to catch everything CI will.
+- **Type hints:** annotate every function parameter and return value with
+  [type hints](https://docs.python.org/3/library/typing.html).
+- **Doctests:** every function needs at least one
+  [doctest](https://docs.python.org/3/library/doctest.html) that passes under
+  `python -m doctest -v your_file.py` (and `pytest`).
+- **Naming:** filenames are all-lowercase with underscores (no spaces or
+  dashes); functions and variables follow standard Python naming.
+- **Placement:** new files go inside an existing directory.
+- **References:** new algorithms include a URL to Wikipedia or a comparable
+  explanation.
+
+## Running the suite locally
+
+```bash
+python -m pip install -r requirements.txt
+pre-commit run --all-files          # ruff, formatting, hooks
+python -m pytest your_module/your_file.py --doctest-modules
+```
+
+Some directories are intentionally skipped in CI (`--ignore` entries in
+`.github/workflows/build.yml`), usually because a heavy dependency lacks a
+wheel for the CPython version the repo currently targets. Check that list
+before assuming a file is untested.
+
+## Good agent behavior
+
+- Keep diffs minimal and scoped to the stated change.
+- Preserve existing style and structure; prefer clarity over cleverness.
+- Never fabricate doctest output — run it and paste the real result.
+- If CI is red, read the log and fix the cause rather than re-running blindly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ rather than maximally optimized. Every change goes through CI and the
 
 ## Code conventions (enforced by CI)
 
-- **Formatting & linting:** `ruff` (`ruff check .` and `ruff format .`).
-  Run `pre-commit run --all-files` locally to catch everything CI will.
+- **Formatting & linting:** `ruff` (`uvx ruff check .` and `uvx ruff format .`).
+  Run `uvx pre-commit run --all-files` locally to catch everything CI will.
 - **Type hints:** annotate every function parameter and return value with
   [type hints](https://docs.python.org/3/library/typing.html).
 - **Doctests:** every function needs at least one
@@ -37,11 +37,17 @@ rather than maximally optimized. Every change goes through CI and the
 
 ## Running the suite locally
 
+This project is managed with [`uv`](https://docs.astral.sh/uv/) — there is no
+`requirements.txt`. Dependencies live in `pyproject.toml`/`uv.lock`, and `uvx`
+runs a tool in a throwaway environment without polluting yours:
+
 ```bash
-python -m pip install -r requirements.txt
-pre-commit run --all-files          # ruff, formatting, hooks
-python -m pytest your_module/your_file.py --doctest-modules
+uvx pre-commit run --all-files                       # ruff, formatting, hooks
+uvx pytest your_module/your_file.py --doctest-modules
 ```
+
+(`uv run pytest ...` works too if you'd rather use the project's locked
+environment.)
 
 Some directories are intentionally skipped in CI (`--ignore` entries in
 `.github/workflows/build.yml`), usually because a heavy dependency lacks a


### PR DESCRIPTION
### Describe your change:

Adds a model-neutral `AGENTS.md` at the repo root, as suggested by @cclauss in #15119, so AI coding agents (and their humans) have a single place that records the conventions that most often trip up automated PRs.

The headline rule is the one that keeps closing bot PRs: **`algorithms-keeper` closes any PR whose "Describe your change" section has no checked box**, so the file tells agents to tick the template before submitting. It also summarizes the ruff / type-hint / doctest / naming / placement requirements and points at `CONTRIBUTING.md` as the source of truth (it never overrides it).

I used the vendor-neutral `AGENTS.md` filename (the emerging cross-tool convention) rather than a tool-specific one so every agent picks it up.

* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.