### PR TITLE
fix: Remove defensive checks in bipartite graph functions

### DIFF
--- a/graphs/check_bipatrite.py
+++ b/graphs/check_bipatrite.py
@@ -67,8 +67,6 @@ def is_bipartite_dfs(graph: dict[int, list[int]]) -> bool:
         """
         if visited[node] == -1:
             visited[node] = color
-            if node not in graph:
-                return True
             for neighbor in graph[node]:
                 if not depth_first_search(neighbor, 1 - color):
                     return False
@@ -140,8 +138,6 @@ def is_bipartite_bfs(graph: dict[int, list[int]]) -> bool:
             visited[node] = 0
             while queue:
                 curr_node = queue.popleft()
-                if curr_node not in graph:
-                    continue
                 for neighbor in graph[curr_node]:
                     if visited[neighbor] == -1:
                         visited[neighbor] = 1 - visited[curr_node]


### PR DESCRIPTION
This commit removes defensive checks in is_bipartite_dfs and is_bipartite_bfs functions that were preventing natural KeyError and TypeError exceptions from occurring for invalid graph inputs.

The functions contained checks like 'if node not in graph: return True' and 'if curr_node not in graph: continue' which would return early or skip processing when encountering invalid graph structures, instead of allowing the natural exceptions to occur.

According to FIXME comments in the docstrings, the expected behavior is:
- KeyError should be raised when a graph contains neighbors that are not keys in the graph dictionary
- TypeError should be raised when non-integer keys are used where integers are expected

By removing these defensive checks, the functions now properly raise KeyError when accessing graph[node] for a node that is not a key in the graph, which aligns with the documented expected behavior.