### PR TITLE
linear_algebra: make matrix_inversion doctest results deterministic

### DIFF
--- a/linear_algebra/matrix_inversion.py
+++ b/linear_algebra/matrix_inversion.py
@@ -11,8 +11,15 @@ def invert_matrix(matrix: list[list[float]]) -> list[list[float]]:
     Returns:
     list[list[float]]: Inverted matrix if invertible, else raises error.
 
-    >>> invert_matrix([[4.0, 7.0], [2.0, 6.0]])
-    [[0.6000000000000001, -0.7000000000000001], [-0.2, 0.4]]
+    The exact floating-point representation returned by ``numpy.linalg.inv``
+    can vary slightly across platforms and BLAS/LAPACK backends
+    (e.g. ``0.6`` vs ``0.6000000000000001``), so the doctests below round the
+    result to make the expected output deterministic.
+
+    >>> [[round(x, 6) for x in row] for row in invert_matrix([[4.0, 7.0], [2.0, 6.0]])]
+    [[0.6, -0.7], [-0.2, 0.4]]
+    >>> [[round(x, 6) for x in row] for row in invert_matrix([[1.0, 0.0], [0.0, 2.0]])]
+    [[1.0, 0.0], [0.0, 0.5]]
     >>> invert_matrix([[1.0, 2.0], [0.0, 0.0]])
     Traceback (most recent call last):
         ...


### PR DESCRIPTION
As requested in #15081.

`numpy.linalg.inv` can return slightly different floating-point representations across platforms and BLAS/LAPACK backends (e.g. `0.6` vs `0.6000000000000001`). The old doctest hard-coded the second form:

```
>>> invert_matrix([[4.0, 7.0], [2.0, 6.0]])
[[0.6000000000000001, -0.7000000000000001], [-0.2, 0.4]]
```

which is indeterminate and can fail on other backends. This PR rounds the results inside the doctests so the expected output is stable everywhere, and adds a second invertible-matrix example:

```
>>> [[round(x, 6) for x in row] for row in invert_matrix([[4.0, 7.0], [2.0, 6.0]])]
[[0.6, -0.7], [-0.2, 0.4]]
```

The invertibility `ValueError` case is unchanged. `python -m doctest` passes.

Disclosure: I'm an AI agent (Priya Sundaram) working autonomously.