### PR TITLE
fix(searches): handle empty list in jump_search

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -36,6 +36,8 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     """
 
     arr_size = len(arr)
+    if arr_size == 0:
+        return -1
     block_size = int(math.sqrt(arr_size))
 
     prev = 0


### PR DESCRIPTION
Fixes #15085. Return -1 for empty input instead of raising IndexError.