### PR TITLE
fix(maths): add future annotations to fix self-referential Matrix type

### DIFF
--- a/maths/matrix_exponentiation.py
+++ b/maths/matrix_exponentiation.py
@@ -1,5 +1,7 @@
 """Matrix Exponentiation"""
 
+from __future__ import annotations
+
 import timeit
 
 """


### PR DESCRIPTION
Fixes #15075. Add from __future__ import annotations to handle self-referential Matrix type hints in __mul__ and modular_exponentiation.