### PR TITLE
fix(sorts): add testmod() call to gnome_sort __main__ block

### DIFF
--- a/.oss-upstream
+++ b/.oss-upstream
@@ -1,0 +1,1 @@
+﻿TheAlgorithms/Python

--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -51,6 +51,10 @@ def gnome_sort(lst: list) -> list:
 
 
 if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+
     user_input = input("Enter numbers separated by a comma:\n").strip()
     unsorted = [int(item) for item in user_input.split(",")]
     print(gnome_sort(unsorted))


### PR DESCRIPTION
### Describe your change:

`sorts/gnome_sort.py` was not calling `testmod()` in its `__main__` block, so running the file directly with `python3 gnome_sort.py` silently skipped doctest verification. Every other sort in this directory that has doctests (e.g. `insertion_sort.py`, `shell_sort.py`, `comb_sort.py`) already calls `testmod()` before prompting for user input.

This PR adds the two-line pattern used across the rest of the directory:

```python
from doctest import testmod
testmod()
```

Fixes #14881

* [x] Fix a bug or typo in an existing algorithm?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
