### PR TITLE
fix(searches): empty jump_search input; validate cyclic_sort

### DIFF
--- a/searches/jump_search.py
+++ b/searches/jump_search.py
@@ -33,9 +33,14 @@ def jump_search[T: Comparable](arr: Sequence[T], item: T) -> int:
     10
     >>> jump_search(["aa", "bb", "cc", "dd", "ee", "ff"], "ee")
     4
+    >>> jump_search([], 5)
+    -1
     """
 
     arr_size = len(arr)
+    if arr_size == 0:
+        return -1
+
     block_size = int(math.sqrt(arr_size))
 
     prev = 0

--- a/sorts/cyclic_sort.py
+++ b/sorts/cyclic_sort.py
@@ -27,7 +27,29 @@ def cyclic_sort(nums: list[int]) -> list[int]:
     []
     >>> cyclic_sort([3, 5, 2, 1, 4])
     [1, 2, 3, 4, 5]
+    >>> cyclic_sort([7, 3, 2, 3, 54, 5, 4])  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    ValueError: All numbers must be unique, got [7, 3, 2, 3, 54, 5, 4]
+    >>> cyclic_sort([1, 2, 5])  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    ValueError: All numbers must be in range 1 to 3, got 5
     """
+
+    length = len(nums)
+    if length == 0:
+        return nums
+
+    seen: set[int] = set()
+    for num in nums:
+        if num < 1 or num > length:
+            raise ValueError(
+                f"All numbers must be in range 1 to {length}, got {num}"
+            )
+        if num in seen:
+            raise ValueError(f"All numbers must be unique, got {nums}")
+        seen.add(num)
 
     # Perform cyclic sort
     index = 0

--- a/sorts/cyclic_sort.py
+++ b/sorts/cyclic_sort.py
@@ -44,11 +44,11 @@ def cyclic_sort(nums: list[int]) -> list[int]:
     seen: set[int] = set()
     for num in nums:
         if num < 1 or num > length:
-            raise ValueError(
-                f"All numbers must be in range 1 to {length}, got {num}"
-            )
+            msg = f"All numbers must be in range 1 to {length}, got {num}"
+            raise ValueError(msg)
         if num in seen:
-            raise ValueError(f"All numbers must be unique, got {nums}")
+            msg = f"All numbers must be unique, got {nums}"
+            raise ValueError(msg)
         seen.add(num)
 
     # Perform cyclic sort


### PR DESCRIPTION
## Summary

- **jump_search**: return `-1` for empty sequences instead of raising `IndexError` (Fixes #15085).
- **cyclic_sort**: validate that input is a permutation of `1..n` before sorting; raise `ValueError` on duplicates or out-of-range values to prevent infinite loops (Fixes #14898).

## Test plan

- [x] `python -m doctest searches/jump_search.py sorts/cyclic_sort.py`
- [x] `uvx ruff check sorts/cyclic_sort.py searches/jump_search.py`
- [x] Manual check: `jump_search([], 5)` returns `-1`
- [x] Manual check: `cyclic_sort([1, 1, 2])` raises `ValueError`