### PR TITLE
ci: slim apt-get system-lib lists to libhdf5-dev only (and use --yes)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
+      - run: sudo apt-get update && sudo apt-get install --yes libhdf5-dev
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/project_euler.yml
+++ b/.github/workflows/project_euler.yml
@@ -14,13 +14,7 @@ jobs:
   project-euler:
     runs-on: ubuntu-latest
     steps:
-      - run:
-          sudo apt-get update && sudo apt-get install -y libtiff5-dev libjpeg8-dev libopenjp2-7-dev
-          zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk
-          libharfbuzz-dev libfribidi-dev libxcb1-dev
-          libxml2-dev libxslt-dev
-          libhdf5-dev
-          libopenblas-dev
+      - run: sudo apt-get update && sudo apt-get install --yes libhdf5-dev
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
@@ -32,13 +26,7 @@ jobs:
   validate-solutions:
     runs-on: ubuntu-latest
     steps:
-      - run:
-          sudo apt-get update && sudo apt-get install -y libtiff5-dev libjpeg8-dev libopenjp2-7-dev
-          zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk
-          libharfbuzz-dev libfribidi-dev libxcb1-dev
-          libxml2-dev libxslt-dev
-          libhdf5-dev
-          libopenblas-dev
+      - run: sudo apt-get update && sudo apt-get install --yes libhdf5-dev
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -25,13 +25,7 @@ jobs:
   build_docs:
     runs-on: ubuntu-24.04-arm
     steps:
-      - run:
-          sudo apt-get update && sudo apt-get install -y libtiff5-dev libjpeg8-dev libopenjp2-7-dev
-          zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk
-          libharfbuzz-dev libfribidi-dev libxcb1-dev
-          libxml2-dev libxslt-dev
-          libhdf5-dev
-          libopenblas-dev
+      - run: sudo apt-get update && sudo apt-get install --yes libhdf5-dev
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7


### PR DESCRIPTION
Per @cclauss's suggestion to trim the `apt-get install` lists in our workflows.

### What
- `project_euler.yml` (both jobs) and `sphinx.yml` currently install a long list of `-dev` system libraries (libtiff/libjpeg/libopenjp2/zlib/freetype/lcms2/webp/tcl/tk/python3-tk/harfbuzz/fribidi/xcb/xml2/xslt/hdf5/openblas). This PR reduces each to **`libhdf5-dev` only**.
- Switches the deprecated `-y` flag to `--yes` in all three workflows (`build.yml` included).

### Why it's safe
Those `-dev` packages existed to *build* dependencies from source. The project's deps now all ship self-contained manylinux/musllinux wheels:
- **pillow ≥ 11.3**, **lxml**, **matplotlib**, **numpy/scipy** — wheels bundle their own image/xml/BLAS libs.
- **h5py 3.16** wheels bundle HDF5.

Nothing in the tree `import`s `h5py` directly (only a commented `cnn.h5` line), so `libhdf5-dev` is very likely droppable too — but I kept it for this first step exactly as suggested ("drop all packages except libhdf5-dev and see if tests pass"). If CI is green here, I'll open a tiny follow-up removing `libhdf5-dev` as well.

Letting CI be the empirical test.