### PR TITLE
ci(devcontainer): Debian 13 Trixie + Python 3.14, modernize VS Code settings, drop .vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
-# https://github.com/microsoft/vscode-dev-containers/blob/main/containers/python-3/README.md
-ARG VARIANT=3.13-bookworm
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+# https://github.com/devcontainers/images/tree/main/src/python
+# Debian 13 "Trixie" base. Python 3.14 is the current latest-stable CPython;
+# the trixie image tags are versioned (there is no floating `3-trixie` alias yet),
+# so we pin the newest available: 3.14-trixie.
+ARG VARIANT=3.14-trixie
+FROM mcr.microsoft.com/devcontainers/python:${VARIANT}
 COPY requirements.txt /tmp/pip-tmp/
 RUN python3 -m pip install --upgrade pip \
   && python3 -m pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
-  && pipx install pre-commit ruff
+  && pipx install pre-commit ruff uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,11 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.11, 3.10, 3.9, 3.8
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.13-bookworm"
+			// This repo tracks the latest-and-greatest CPython. The Debian 13
+			// "Trixie" images are published per minor version (3.11-trixie ...
+			// 3.14-trixie); there is no floating `3-trixie` tag, so bump this
+			// to the newest available when a new stable CPython ships.
+			"VARIANT": "3.14-trixie"
 		}
 	},
 
@@ -20,25 +21,28 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
-				"python.linting.enabled": true,
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"editor.formatOnSave": true,
+				"[python]": {
+					"editor.defaultFormatter": "charliermarsh.ruff",
+					"editor.codeActionsOnSave": {
+						"source.fixAll": "explicit",
+						"source.organizeImports": "explicit"
+					}
+				},
 				"terminal.integrated.defaultProfile.linux": "zsh"
 			},
 
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
-				"ms-python.vscode-pylance"
+				"ms-python.vscode-pylance",
+				"charliermarsh.ruff"
 			]
 		}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
-}


### PR DESCRIPTION
### Describe your change:

Modernizes the `.devcontainer/` configuration as requested in #15081, plus a recommendation on `.vscode/`.

**Base image — Debian 13 "Trixie" + latest CPython**
- `VARIANT`: `3.13-bookworm` -> **`3.14-trixie`** (Debian 13 Trixie, Python 3.14 = current latest-stable CPython).
- Migrated the image path from the deprecated `mcr.microsoft.com/vscode/devcontainers/python` to the current **`mcr.microsoft.com/devcontainers/python`**.
- Note on "plain Python 3": the Trixie image tags are published **per minor version** (`3.11-trixie` ... `3.14-trixie`) — there is currently **no floating `3-trixie` alias** (the bare `3` tag still resolves to `3-bookworm`). So to get both Trixie *and* the newest interpreter I pinned `3.14-trixie`; the comment tells future maintainers to bump it when a newer stable ships.

**Free-threaded CPython & `.python-version`**
You asked whether we can pull the latest free-threaded build, or have the devcontainer read `.python-version`. Two honest constraints:
1. The base devcontainer images **do not publish free-threaded (`t`) variants**, so there's no `3.14t`-style tag to point `VARIANT` at.
2. `devcontainer.json` `build.args` are **not templated** — they can't read `.python-version` at build time.

The clean bridge is the tool we already standardize on: **uv reads `.python-version`**. `.python-version` is `3.14t`, so `uv sync` / `uv run` inside the container will provision and use free-threaded 3.14t regardless of the base image's interpreter. I added `uv` to the Dockerfile's `pipx install` so it's ready out of the box — contributors get free-threaded 3.14t via `uv run` without us needing a non-existent free-threaded base tag.

**VS Code settings modernization**
- Dropped the removed/deprecated `python.linting.*` and `python.formatting.blackPath`/`mypyPath` settings (the Python extension no longer honors these; linting/formatting moved to dedicated extensions).
- Added the **Ruff** extension (`charliermarsh.ruff`) and wired format-on-save + `source.fixAll`/`organizeImports` for `[python]`, matching the repo's actual linter/formatter.

**`.vscode/` recommendation**
The directory held a single setting — `githubPullRequests.ignoredPullRequestBranches: ["master"]` — which is a personal convenience for the VS Code GitHub-PR extension, not project tooling. Since pre-commit + Ruff already cover formatting/linting for everyone, I went with your inclination and **deleted `.vscode/`** in this PR. It's a genuine judgment call, though: if you'd rather keep that one line so the PR extension doesn't treat `master` as a reviewable branch, I'm happy to restore just that file.

@cclauss — happy to split any of these (base bump / settings / `.vscode` delete) into separate PRs if you'd prefer smaller units.

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
