### PR TITLE
ci(devcontainer): Debian 13 Trixie + Python 3.14, Ruff settings, drop .vscode (keeper-safe .json-only)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,14 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.11, 3.10, 3.9, 3.8
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.13-bookworm"
+			// This repo tracks the latest-and-greatest CPython on the newest
+			// stable Debian. The devcontainer base images are published per
+			// CPython minor version on Debian 13 "Trixie" (3.11-trixie ...
+			// 3.14-trixie); there is no floating `3-trixie` tag, so bump this
+			// to the newest available when a new stable CPython ships.
+			// NOTE: these images do not publish free-threaded (`t`) variants,
+			// so 3.14t cannot be selected via the tag alone.
+			"VARIANT": "3.14-trixie"
 		}
 	},
 
@@ -20,25 +24,29 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
-				"python.linting.enabled": true,
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				// Formatting/linting is handled by Ruff (matches pre-commit and CI).
+				"editor.formatOnSave": true,
+				"[python]": {
+					"editor.defaultFormatter": "charliermarsh.ruff",
+					"editor.codeActionsOnSave": {
+						"source.fixAll": "explicit",
+						"source.organizeImports": "explicit"
+					}
+				},
 				"terminal.integrated.defaultProfile.linux": "zsh"
 			},
 
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
-				"ms-python.vscode-pylance"
+				"ms-python.vscode-pylance",
+				"charliermarsh.ruff"
 			]
 		}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
-}


### PR DESCRIPTION
Replaces #15160, which `algorithms-keeper` kept auto-closing because it edited the extension-less `.devcontainer/Dockerfile` (the keeper's `ACCEPTED_EXTENSIONS` allow-list has no entry for `Dockerfile`, so reopening re-triggers the close — that's why the reopen at 10:50 didn't stick).

This version touches **`.json` files only**, so the keeper accepts it, while delivering the same outcome:

- **Debian 13 "Trixie" + Python 3.14**: bump `build.args.VARIANT` `3.13-bookworm` -> `3.14-trixie`. The base image is selected entirely from `devcontainer.json` — the Dockerfile's `ARG VARIANT` reads it — so the Dockerfile is left untouched and keeps installing `requirements.txt` + pipx `pre-commit`/`ruff`.
- **VS Code settings modernized**: the old `python.linting.*` / `python.formatting.blackPath` keys were removed by the Python extension long ago. Replaced with Ruff `formatOnSave` + `source.fixAll`/`source.organizeImports`, matching pre-commit and CI. Added the `charliermarsh.ruff` extension.
- **`.vscode/` deleted** (per your preference on #15081): the sole file only muted a PR-branch notification; pre-commit/Ruff cover the rest.

Notes for the open questions on #15081:
- *Latest-and-greatest CPython*: there is no floating `3-trixie` tag on the `mcr.microsoft.com/vscode/devcontainers/python` path, so `VARIANT` must name the minor version; bump it when a new stable ships. (I added a comment saying so.)
- *Free-threading (3.14t)*: these images don't publish `t` variants, and devcontainer build args can't read `.python-version`, so 3.14t can't be selected via the tag alone — it would need a Dockerfile/uv change, which the keeper blocks from me. Happy to do that as a maintainer-merged follow-up.

Supersedes #15160.