### PR TITLE
scripts: de-duplicate and harden the close_pull_requests_with_*.sh backlog jobs

### DIFF
--- a/scripts/close_pull_requests_with_awaiting_changes.sh
+++ b/scripts/close_pull_requests_with_awaiting_changes.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "awaiting changes" label is present
-  awaiting_changes=$(echo "$pr_labels" | jq -r '.[] | select(.name == "awaiting changes")')
-  echo "Checking PR #$pr_number $pr_title ($awaiting_changes) ($pr_labels)"
-
-  # If awaiting_changes, close the pull request
-  if [[ -n "$awaiting_changes" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to awaiting_changes label"
-    gh pr close "$pr_number" --comment "Closing awaiting_changes PRs to prepare for Hacktoberfest"
-    sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "awaiting changes".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "awaiting changes" "$@"

--- a/scripts/close_pull_requests_with_failing_tests.sh
+++ b/scripts/close_pull_requests_with_failing_tests.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "tests are failing" label is present
-  tests_are_failing=$(echo "$pr_labels" | jq -r '.[] | select(.name == "tests are failing")')
-  echo "Checking PR #$pr_number $pr_title ($tests_are_failing) ($pr_labels)"
-
-  # If there are failing tests, close the pull request
-  if [[ -n "$tests_are_failing" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to tests_are_failing label"
-    gh pr close "$pr_number" --comment "Closing tests_are_failing PRs to prepare for Hacktoberfest"
-    sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "tests are failing".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "tests are failing" "$@"

--- a/scripts/close_pull_requests_with_label.sh
+++ b/scripts/close_pull_requests_with_label.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Close every open pull request that carries a given label, leaving an
+# explanatory comment. This is used to clear the backlog before Hacktoberfest.
+#
+# Usage:
+#   scripts/close_pull_requests_with_label.sh "<label>" ["<comment>"]
+#
+# Examples:
+#   scripts/close_pull_requests_with_label.sh "require type hints"
+#   DRY_RUN=1 scripts/close_pull_requests_with_label.sh "tests are failing"
+#
+# Environment variables:
+#   DRY_RUN=1   Print the PRs that would be closed without closing them.
+#   REPO        Target repository (default: TheAlgorithms/Python).
+#   SLEEP       Seconds to wait between closes (default: 2) to avoid tripping
+#               GitHub's secondary rate limits during bulk closes.
+#
+# On completion the script prints a machine-readable summary line:
+#   CLOSED_COUNT=<n> CLOSED_PRS=<comma-separated PR numbers>
+# so the Hacktoberfest tracker can be updated from the output.
+
+set -euo pipefail
+
+label="${1:-}"
+if [[ -z "$label" ]]; then
+  echo "error: missing label argument" >&2
+  echo "usage: $0 \"<label>\" [\"<comment>\"]" >&2
+  exit 2
+fi
+
+repo="${REPO:-TheAlgorithms/Python}"
+sleep_seconds="${SLEEP:-2}"
+comment="${2:-Closing \"${label}\" PRs to prepare for Hacktoberfest}"
+
+# Filter by label server-side so we never miss PRs beyond an arbitrary --limit
+# cap (the repo can have ~900 open PRs). --limit is set high purely as a ceiling.
+prs=$(gh pr list --repo "$repo" --state open --label "$label" \
+  --json number,title --limit 1000)
+
+count=$(echo "$prs" | jq 'length')
+echo "Found $count open PR(s) with label \"$label\" in $repo"
+
+closed=()
+while read -r pr; do
+  [[ -z "$pr" ]] && continue
+  pr_number=$(echo "$pr" | jq -r '.number')
+  pr_title=$(echo "$pr" | jq -r '.title')
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[dry-run] would close PR #$pr_number: $pr_title"
+    closed+=("$pr_number")
+    continue
+  fi
+
+  echo "Closing PR #$pr_number: $pr_title"
+  gh pr close "$pr_number" --repo "$repo" --comment "$comment"
+  closed+=("$pr_number")
+  sleep "$sleep_seconds"
+done < <(echo "$prs" | jq -c '.[]')
+
+# Machine-readable summary for the tracker.
+IFS=,; echo "CLOSED_COUNT=${#closed[@]} CLOSED_PRS=${closed[*]:-}"

--- a/scripts/close_pull_requests_with_require_descriptive_names.sh
+++ b/scripts/close_pull_requests_with_require_descriptive_names.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require descriptive names" label is present
-  require_descriptive_names=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require descriptive names")')
-  echo "Checking PR #$pr_number $pr_title ($require_descriptive_names) ($pr_labels)"
-
-  # If there are require_descriptive_names, close the pull request
-  if [[ -n "$require_descriptive_names" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_descriptive_names label"
-    gh pr close "$pr_number" --comment "Closing require_descriptive_names PRs to prepare for Hacktoberfest"
-  fi
-done
+#
+# Close every open pull request labelled "require descriptive names".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require descriptive names" "$@"

--- a/scripts/close_pull_requests_with_require_tests.sh
+++ b/scripts/close_pull_requests_with_require_tests.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require_tests" label is present
-  require_tests=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require tests")')
-  echo "Checking PR #$pr_number $pr_title ($require_tests) ($pr_labels)"
-
-  # If there require tests, close the pull request
-  if [[ -n "$require_tests" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_tests label"
-    gh pr close "$pr_number" --comment "Closing require_tests PRs to prepare for Hacktoberfest"
-    # sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "require tests".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require tests" "$@"

--- a/scripts/close_pull_requests_with_require_type_hints.sh
+++ b/scripts/close_pull_requests_with_require_type_hints.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require type hints" label is present
-  require_type_hints=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require type hints")')
-  echo "Checking PR #$pr_number $pr_title ($require_type_hints) ($pr_labels)"
-
-  # If require_type_hints, close the pull request
-  if [[ -n "$require_type_hints" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_type_hints label"
-    gh pr close "$pr_number" --comment "Closing require_type_hints PRs to prepare for Hacktoberfest"
-  fi
-done
+#
+# Close every open pull request labelled "require type hints".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require type hints" "$@"


### PR DESCRIPTION
As requested by @cclauss in https://github.com/TheAlgorithms/Python/issues/15081#issuecomment-5520... — the follow-up PR applying the script recommendations I made in #15168.

### What changed
The five `scripts/close_pull_requests_with_*.sh` jobs were byte-for-byte identical apart from one label name and one comment string. This PR extracts the shared logic into one parameterized `close_pull_requests_with_label.sh` and turns each named script into a one-line wrapper, so the existing entry points (referenced in `docs/hacktober_2026_prep.md`) keep working.

Each recommendation from #15168, applied:

1. **Correctness — no more silently skipped PRs.** The old scripts ran `gh pr list --state open --limit 500` and matched labels in `jq`. With ~900 open PRs, any matching PR past the 500th was never closed. The new script filters **server-side** with `gh pr list --label "<label>"`, so the cap can't hide PRs (and it's much faster — it fetches only the matching PRs).
2. **De-duplication.** One implementation removes the drift between the copies: `awaiting_changes`/`failing_tests` had `sleep 2`, `require_tests` had it commented out, and the other two had none.
3. **Consistent throttling.** A single deliberate `SLEEP` (default 2s) between closes to avoid tripping GitHub's secondary rate limits during bulk closes.
4. **Safety rails.** `set -euo pipefail`, an explicit `--repo` (overridable via `REPO=`), and a `DRY_RUN=1` mode that prints exactly what *would* close before a maintainer commits.
5. **Machine-readable summary.** Ends with `CLOSED_COUNT=<n> CLOSED_PRS=<...>` so `docs/hacktober_2026_prep.md` can be updated from the output instead of by hand.

### Verification
- `bash -n` passes on all six files.
- Read-only dry run against this repo works end-to-end:
  ```
  $ DRY_RUN=1 scripts/close_pull_requests_with_require_tests.sh
  Found 24 open PR(s) with label "require tests" in TheAlgorithms/Python
  [dry-run] would close PR #14973: feat: add MinHash Jaccard similarity estimator
  ...
  CLOSED_COUNT=24 CLOSED_PRS=14973,14732,...,13523
  ```

Behaviour of the named scripts is unchanged for a maintainer running them; they just share one hardened implementation now.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only touches shell scripts under `scripts/`; no algorithm added.
- [x] All filenames are in all lowercase characters with no spaces or dashes.
- [x] Related to #15081.