### PR TITLE
scripts: de-duplicate and harden the close_pull_requests_with_*.sh backlog jobs

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -462,6 +462,7 @@
 
 ## Fuzzy Logic
   * [Fuzzy Operations](fuzzy_logic/fuzzy_operations.py)
+  * [Fuzzy Set Operations](fuzzy_logic/fuzzy_set_operations.py)
 
 ## Genetic Algorithm
   * [Basic String](genetic_algorithm/basic_string.py)

--- a/scripts/close_pull_requests_with_awaiting_changes.sh
+++ b/scripts/close_pull_requests_with_awaiting_changes.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "awaiting changes" label is present
-  awaiting_changes=$(echo "$pr_labels" | jq -r '.[] | select(.name == "awaiting changes")')
-  echo "Checking PR #$pr_number $pr_title ($awaiting_changes) ($pr_labels)"
-
-  # If awaiting_changes, close the pull request
-  if [[ -n "$awaiting_changes" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to awaiting_changes label"
-    gh pr close "$pr_number" --comment "Closing awaiting_changes PRs to prepare for Hacktoberfest"
-    sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "awaiting changes".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "awaiting changes" "$@"

--- a/scripts/close_pull_requests_with_failing_tests.sh
+++ b/scripts/close_pull_requests_with_failing_tests.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "tests are failing" label is present
-  tests_are_failing=$(echo "$pr_labels" | jq -r '.[] | select(.name == "tests are failing")')
-  echo "Checking PR #$pr_number $pr_title ($tests_are_failing) ($pr_labels)"
-
-  # If there are failing tests, close the pull request
-  if [[ -n "$tests_are_failing" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to tests_are_failing label"
-    gh pr close "$pr_number" --comment "Closing tests_are_failing PRs to prepare for Hacktoberfest"
-    sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "tests are failing".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "tests are failing" "$@"

--- a/scripts/close_pull_requests_with_label.sh
+++ b/scripts/close_pull_requests_with_label.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Close every open pull request that carries a given label, leaving an
+# explanatory comment. This is used to clear the backlog before Hacktoberfest.
+#
+# Usage:
+#   scripts/close_pull_requests_with_label.sh "<label>" ["<comment>"]
+#
+# Examples:
+#   scripts/close_pull_requests_with_label.sh "require type hints"
+#   DRY_RUN=1 scripts/close_pull_requests_with_label.sh "tests are failing"
+#
+# Environment variables:
+#   DRY_RUN=1   Print the PRs that would be closed without closing them.
+#   REPO        Target repository (default: TheAlgorithms/Python).
+#   SLEEP       Seconds to wait between closes (default: 2) to avoid tripping
+#               GitHub's secondary rate limits during bulk closes.
+#
+# On completion the script prints a machine-readable summary line:
+#   CLOSED_COUNT=<n> CLOSED_PRS=<comma-separated PR numbers>
+# so the Hacktoberfest tracker can be updated from the output.
+
+set -euo pipefail
+
+label="${1:-}"
+if [[ -z "$label" ]]; then
+  echo "error: missing label argument" >&2
+  echo "usage: $0 \"<label>\" [\"<comment>\"]" >&2
+  exit 2
+fi
+
+repo="${REPO:-TheAlgorithms/Python}"
+sleep_seconds="${SLEEP:-2}"
+comment="${2:-Closing \"${label}\" PRs to prepare for Hacktoberfest}"
+
+# Filter by label server-side so we never miss PRs beyond an arbitrary --limit
+# cap (the repo can have ~900 open PRs). --limit is set high purely as a ceiling.
+prs=$(gh pr list --repo "$repo" --state open --label "$label" \
+  --json number,title --limit 1000)
+
+count=$(echo "$prs" | jq 'length')
+echo "Found $count open PR(s) with label \"$label\" in $repo"
+
+closed=()
+while read -r pr; do
+  [[ -z "$pr" ]] && continue
+  pr_number=$(echo "$pr" | jq -r '.number')
+  pr_title=$(echo "$pr" | jq -r '.title')
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[dry-run] would close PR #$pr_number: $pr_title"
+    closed+=("$pr_number")
+    continue
+  fi
+
+  echo "Closing PR #$pr_number: $pr_title"
+  gh pr close "$pr_number" --repo "$repo" --comment "$comment"
+  closed+=("$pr_number")
+  sleep "$sleep_seconds"
+done < <(echo "$prs" | jq -c '.[]')
+
+# Machine-readable summary for the tracker.
+IFS=,; echo "CLOSED_COUNT=${#closed[@]} CLOSED_PRS=${closed[*]:-}"

--- a/scripts/close_pull_requests_with_require_descriptive_names.sh
+++ b/scripts/close_pull_requests_with_require_descriptive_names.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require descriptive names" label is present
-  require_descriptive_names=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require descriptive names")')
-  echo "Checking PR #$pr_number $pr_title ($require_descriptive_names) ($pr_labels)"
-
-  # If there are require_descriptive_names, close the pull request
-  if [[ -n "$require_descriptive_names" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_descriptive_names label"
-    gh pr close "$pr_number" --comment "Closing require_descriptive_names PRs to prepare for Hacktoberfest"
-  fi
-done
+#
+# Close every open pull request labelled "require descriptive names".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require descriptive names" "$@"

--- a/scripts/close_pull_requests_with_require_tests.sh
+++ b/scripts/close_pull_requests_with_require_tests.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require_tests" label is present
-  require_tests=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require tests")')
-  echo "Checking PR #$pr_number $pr_title ($require_tests) ($pr_labels)"
-
-  # If there require tests, close the pull request
-  if [[ -n "$require_tests" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_tests label"
-    gh pr close "$pr_number" --comment "Closing require_tests PRs to prepare for Hacktoberfest"
-    # sleep 2
-  fi
-done
+#
+# Close every open pull request labelled "require tests".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require tests" "$@"

--- a/scripts/close_pull_requests_with_require_type_hints.sh
+++ b/scripts/close_pull_requests_with_require_type_hints.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
-
-# List all open pull requests
-prs=$(gh pr list --state open --json number,title,labels --limit 500)
-
-# Loop through each pull request
-echo "$prs" | jq -c '.[]' | while read -r pr; do
-  pr_number=$(echo "$pr" | jq -r '.number')
-  pr_title=$(echo "$pr" | jq -r '.title')
-  pr_labels=$(echo "$pr" | jq -r '.labels')
-
-  # Check if the "require type hints" label is present
-  require_type_hints=$(echo "$pr_labels" | jq -r '.[] | select(.name == "require type hints")')
-  echo "Checking PR #$pr_number $pr_title ($require_type_hints) ($pr_labels)"
-
-  # If require_type_hints, close the pull request
-  if [[ -n "$require_type_hints" ]]; then
-    echo "Closing PR #$pr_number $pr_title due to require_type_hints label"
-    gh pr close "$pr_number" --comment "Closing require_type_hints PRs to prepare for Hacktoberfest"
-  fi
-done
+#
+# Close every open pull request labelled "require type hints".
+# Thin wrapper around close_pull_requests_with_label.sh so all five backlog
+# jobs share one implementation. Set DRY_RUN=1 to preview.
+set -euo pipefail
+exec "$(dirname "$0")/close_pull_requests_with_label.sh" "require type hints" "$@"


### PR DESCRIPTION
This is a replica of @priya-sundaram-dev pull request:
* #15169 

This is a follow-up to:
* #15081

Extract the five byte-for-byte-identical backlog-closing scripts into one parameterized close_pull_requests_with_label.sh and make each named script a thin wrapper. Addresses the recommendations from #15168:

- Correctness: filter by label server-side (gh pr list --label) instead of listing all ~900 open PRs and matching client-side, so no PR is skipped by an arbitrary --limit cap.
- De-duplication: one implementation removes the drift between copies (some had sleep 2, one had it commented out, two had none).
- Throttling: a single, deliberate SLEEP (default 2s) between closes.
- Safety rails: set -euo pipefail, explicit --repo, and a DRY_RUN=1 preview mode that prints what would close before a maintainer commits.
- Machine-readable summary (CLOSED_COUNT/CLOSED_PRS) so the Hacktoberfest tracker can be updated from script output.

### Describe your change:

* [x] Fix scripts
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is the work of @priya-sundaram-dev
* [ ] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
