### PR TITLE
fix(reddit): remove unreachable 429 check after raise_for_status()

### DIFF
--- a/web_programming/reddit.py
+++ b/web_programming/reddit.py
@@ -40,9 +40,9 @@ def get_subreddit_data(
         headers={"User-agent": "A random string"},
         timeout=10,
     )
+    # raise_for_status() already raises httpx.HTTPStatusError for any 4xx/5xx
+    # response (including 429), so no extra status check is needed here.
     response.raise_for_status()
-    if response.status_code == 429:
-        raise httpx.HTTPError(response=response)
 
     data = response.json()
     if not wanted_data:


### PR DESCRIPTION
Addresses the genuine bug @cclauss flagged in #15174 (`web_programming/reddit.py`).

```python
response.raise_for_status()
if response.status_code == 429:
    raise httpx.HTTPError(response=response)
```

Two problems with the removed lines:

1. **Unreachable.** `response.raise_for_status()` already raises `httpx.HTTPStatusError` for every 4xx/5xx response, including 429, so the following `if response.status_code == 429` can never be true — execution never reaches it.
2. **The dead call was itself invalid.** `httpx.HTTPError.__init__(self, message)` takes a message string and has no `response` parameter, so `httpx.HTTPError(response=response)` would raise `TypeError` if it ever ran. (This is exactly the `unknown-argument` / `missing-argument` diagnostic `ty` reports on this file.)

The fix keeps `raise_for_status()` — the intended rate-limit behaviour is preserved — and drops the dead branch, with a short comment explaining why no extra status check is needed. The `__main__` note about Error 429 still applies.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [ ] All functions have doctests that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword: e.g. "Fixes #ISSUE-NUMBER".