### PR TITLE
docs: update hacktober prep tracker after close_pull_requests_with_failing_tests.sh run

### DIFF
--- a/docs/hacktober_2026_prep.md
+++ b/docs/hacktober_2026_prep.md
@@ -16,7 +16,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 4. [ ] #15146 enhancement, awaiting reviews
 5. [ ] #15144 awaiting reviews
 6. [ ] #15142 enhancement, awaiting reviews
-7. [ ] #15128 awaiting reviews, tests are failing
+7. [x] #15128 closed by close_pull_requests_with_failing_tests.sh
 8. [ ] #15117 enhancement, awaiting reviews
 9. [ ] #15108 enhancement, awaiting reviews
 10. [ ] #15107 enhancement, awaiting reviews
@@ -33,7 +33,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 21. [ ] #15074 enhancement, awaiting reviews
 22. [ ] #15072 enhancement, awaiting reviews
 23. [ ] #15063 enhancement, awaiting reviews
-24. [ ] #15057 tests are failing
+24. [x] #15057 closed by close_pull_requests_with_failing_tests.sh
 25. [ ] #15056 awaiting reviews
 26. [ ] #15055 enhancement, awaiting reviews
 27. [ ] #15054 enhancement, awaiting reviews
@@ -53,10 +53,10 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 41. [ ] #15038 enhancement, awaiting reviews
 42. [ ] #15036 enhancement, awaiting reviews
 43. [ ] #15026 enhancement, awaiting reviews
-44. [ ] #15025 enhancement, awaiting reviews, tests are failing
+44. [x] #15025 closed by close_pull_requests_with_failing_tests.sh
 45. [ ] #15024 enhancement, awaiting reviews
 46. [ ] #15023 enhancement, awaiting reviews
-47. [ ] #15021 enhancement, awaiting reviews, tests are failing
+47. [x] #15021 closed by close_pull_requests_with_failing_tests.sh
 48. [ ] #15019 awaiting reviews
 49. [ ] #15014 enhancement, awaiting reviews
 50. [ ] #15012 awaiting reviews
@@ -74,13 +74,13 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 62. [ ] #14987 enhancement, awaiting reviews
 63. [ ] #14986 enhancement, awaiting reviews
 64. [ ] #14979 enhancement, awaiting reviews
-65. [ ] #14975 enhancement, awaiting reviews, tests are failing
-66. [ ] #14974 enhancement, awaiting reviews, tests are failing
+65. [x] #14975 closed by close_pull_requests_with_failing_tests.sh
+66. [x] #14974 closed by close_pull_requests_with_failing_tests.sh
 67. [x] #14973 closed by close_pull_requests_with_require_tests.sh
-68. [ ] #14972 enhancement, awaiting reviews, tests are failing
+68. [x] #14972 closed by close_pull_requests_with_failing_tests.sh
 69. [ ] #14967 enhancement, awaiting reviews
 70. [ ] #14939 enhancement, awaiting reviews
-71. [ ] #14938 enhancement, awaiting reviews, tests are failing
+71. [x] #14938 closed by close_pull_requests_with_failing_tests.sh
 72. [ ] #14925 enhancement, awaiting reviews
 73. [ ] #14923 enhancement, awaiting reviews
 74. [ ] #14920 enhancement, awaiting reviews
@@ -116,7 +116,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 104. [ ] #14845 enhancement, awaiting reviews
 105. [ ] #14843 enhancement, awaiting reviews
 106. [ ] #14838 enhancement, awaiting reviews
-107. [ ] #14835 enhancement, awaiting reviews, tests are failing
+107. [x] #14835 closed by close_pull_requests_with_failing_tests.sh
 108. [ ] #14833 enhancement, awaiting reviews
 109. [ ] #14832 enhancement, awaiting reviews
 110. [ ] #14829 enhancement, awaiting reviews
@@ -126,7 +126,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 114. [ ] #14823 enhancement, awaiting reviews
 115. [ ] #14821 no labels
 116. [ ] #14819 awaiting reviews
-117. [ ] #14818 enhancement, awaiting reviews, tests are failing
+117. [x] #14818 closed by close_pull_requests_with_failing_tests.sh
 118. [ ] #14814 enhancement, awaiting reviews
 119. [ ] #14812 awaiting reviews
 120. [x] #14810 closed by close_pull_requests_with_require_type_hints.sh
@@ -159,27 +159,27 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 147. [ ] #14736 awaiting reviews
 148. [ ] #14733 awaiting reviews
 149. [x] #14732 closed by close_pull_requests_with_require_tests.sh
-150. [ ] #14731 awaiting reviews, tests are failing
+150. [x] #14731 closed by close_pull_requests_with_failing_tests.sh
 151. [ ] #14729 enhancement, awaiting reviews
 152. [ ] #14728 awaiting reviews
-153. [ ] #14727 awaiting reviews, tests are failing
+153. [x] #14727 closed by close_pull_requests_with_failing_tests.sh
 154. [x] #14726 closed by close_pull_requests_with_require_type_hints.sh
 155. [ ] #14724 awaiting reviews
-156. [ ] #14723 awaiting reviews, tests are failing
+156. [x] #14723 closed by close_pull_requests_with_failing_tests.sh
 157. [ ] #14721 enhancement, awaiting reviews
 158. [ ] #14718 enhancement, awaiting reviews
-159. [ ] #14717 awaiting reviews, tests are failing
+159. [x] #14717 closed by close_pull_requests_with_failing_tests.sh
 160. [ ] #14714 enhancement, awaiting reviews
 161. [ ] #14713 awaiting reviews
 162. [ ] #14712 awaiting reviews
 163. [ ] #14708 enhancement, awaiting reviews
 164. [ ] #14702 enhancement, awaiting reviews
 165. [ ] #14701 enhancement, awaiting reviews
-166. [ ] #14700 tests are failing
+166. [x] #14700 closed by close_pull_requests_with_failing_tests.sh
 167. [ ] #14694 enhancement, awaiting reviews
-168. [ ] #14690 awaiting reviews, tests are failing, documentation
+168. [x] #14690 closed by close_pull_requests_with_failing_tests.sh
 169. [ ] #14685 enhancement, awaiting reviews
-170. [ ] #14680 enhancement, awaiting reviews, tests are failing
+170. [x] #14680 closed by close_pull_requests_with_failing_tests.sh
 171. [x] #14677 closed by close_pull_requests_with_require_descriptive_names.sh
 172. [ ] #14673 enhancement, awaiting reviews
 173. [ ] #14668 awaiting reviews
@@ -199,12 +199,12 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 187. [ ] #14630 no labels
 188. [ ] #14627 enhancement, awaiting reviews
 189. [ ] #14626 enhancement, awaiting reviews
-190. [ ] #14625 enhancement, awaiting reviews, tests are failing
+190. [x] #14625 closed by close_pull_requests_with_failing_tests.sh
 191. [ ] #14623 awaiting reviews
 192. [ ] #14622 enhancement, awaiting reviews
-193. [ ] #14618 enhancement, awaiting reviews, tests are failing
-194. [ ] #14617 enhancement, awaiting reviews, tests are failing
-195. [ ] #14616 enhancement, awaiting reviews, tests are failing
+193. [x] #14618 closed by close_pull_requests_with_failing_tests.sh
+194. [x] #14617 closed by close_pull_requests_with_failing_tests.sh
+195. [x] #14616 closed by close_pull_requests_with_failing_tests.sh
 196. [ ] #14613 enhancement, awaiting reviews
 197. [ ] #14611 awaiting reviews
 198. [ ] #14610 enhancement, awaiting reviews
@@ -212,7 +212,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 200. [ ] #14608 enhancement, awaiting reviews
 201. [ ] #14607 enhancement, awaiting reviews
 202. [ ] #14602 awaiting reviews
-203. [ ] #14594 awaiting reviews, tests are failing, documentation
+203. [x] #14594 closed by close_pull_requests_with_failing_tests.sh
 204. [x] #14582 closed by close_pull_requests_with_require_tests.sh
 205. [ ] #14581 enhancement, awaiting reviews
 206. [ ] #14579 enhancement, awaiting reviews
@@ -229,26 +229,26 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 217. [ ] #14527 awaiting reviews
 218. [ ] #14526 awaiting reviews
 219. [ ] #14525 awaiting reviews
-220. [ ] #14524 awaiting reviews, tests are failing
+220. [x] #14524 closed by close_pull_requests_with_failing_tests.sh
 221. [ ] #14523 enhancement, awaiting reviews
-222. [ ] #14518 awaiting reviews, tests are failing
-223. [ ] #14511 enhancement, awaiting reviews, tests are failing
-224. [ ] #14510 enhancement, awaiting reviews, tests are failing
-225. [ ] #14507 awaiting reviews, tests are failing
+222. [x] #14518 closed by close_pull_requests_with_failing_tests.sh
+223. [x] #14511 closed by close_pull_requests_with_failing_tests.sh
+224. [x] #14510 closed by close_pull_requests_with_failing_tests.sh
+225. [x] #14507 closed by close_pull_requests_with_failing_tests.sh
 226. [ ] #14506 awaiting reviews
 227. [ ] #14504 awaiting reviews
 228. [ ] #14495 enhancement, awaiting reviews
 229. [ ] #14492 awaiting reviews
-230. [ ] #14486 awaiting reviews, tests are failing
+230. [x] #14486 closed by close_pull_requests_with_failing_tests.sh
 231. [ ] #14482 awaiting reviews
-232. [ ] #14480 enhancement, awaiting reviews, tests are failing
+232. [x] #14480 closed by close_pull_requests_with_failing_tests.sh
 233. [x] #14478 closed by close_pull_requests_with_require_tests.sh
 234. [ ] #14477 enhancement, awaiting reviews
 235. [ ] #14472 enhancement, awaiting reviews
-236. [ ] #14468 enhancement, awaiting reviews, tests are failing
+236. [x] #14468 closed by close_pull_requests_with_failing_tests.sh
 237. [ ] #14460 enhancement, awaiting reviews
 238. [ ] #14456 enhancement, awaiting reviews
-239. [ ] #14455 enhancement, awaiting reviews, tests are failing
+239. [x] #14455 closed by close_pull_requests_with_failing_tests.sh
 240. [ ] #14440 awaiting reviews
 241. [ ] #14437 awaiting reviews
 242. [ ] #14436 no labels
@@ -267,40 +267,40 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 255. [ ] #14351 enhancement, awaiting reviews
 256. [ ] #14346 no labels
 257. [x] #14342 closed by close_pull_requests_with_require_tests.sh
-258. [ ] #14336 awaiting reviews, tests are failing
-259. [ ] #14332 awaiting reviews, tests are failing
-260. [ ] #14331 awaiting reviews, tests are failing
+258. [x] #14336 closed by close_pull_requests_with_failing_tests.sh
+259. [x] #14332 closed by close_pull_requests_with_failing_tests.sh
+260. [x] #14331 closed by close_pull_requests_with_failing_tests.sh
 261. [x] #14321 closed by close_pull_requests_with_require_descriptive_names.sh
 262. [x] #14316 closed by close_pull_requests_with_require_type_hints.sh
 263. [x] #14314 closed by close_pull_requests_with_require_tests.sh
 264. [ ] #14307 enhancement, awaiting reviews
-265. [ ] #14304 awaiting reviews, tests are failing
+265. [x] #14304 closed by close_pull_requests_with_failing_tests.sh
 266. [x] #14303 closed by close_pull_requests_with_require_tests.sh
-267. [ ] #14300 enhancement, awaiting reviews, tests are failing
-268. [ ] #14297 awaiting reviews, tests are failing
+267. [x] #14300 closed by close_pull_requests_with_failing_tests.sh
+268. [x] #14297 closed by close_pull_requests_with_failing_tests.sh
 269. [ ] #14291 enhancement, awaiting reviews
-270. [ ] #14290 tests are failing
-271. [ ] #14286 enhancement, awaiting reviews, tests are failing
-272. [ ] #14285 tests are failing
+270. [x] #14290 closed by close_pull_requests_with_failing_tests.sh
+271. [x] #14286 closed by close_pull_requests_with_failing_tests.sh
+272. [x] #14285 closed by close_pull_requests_with_failing_tests.sh
 273. [ ] #14284 no labels
-274. [ ] #14283 tests are failing
+274. [x] #14283 closed by close_pull_requests_with_failing_tests.sh
 275. [ ] #14278 enhancement, awaiting reviews
 276. [ ] #14277 enhancement, awaiting reviews
 277. [ ] #14275 enhancement, awaiting reviews
-278. [ ] #14272 enhancement, awaiting reviews, tests are failing
-279. [ ] #14270 enhancement, awaiting reviews, tests are failing
-280. [ ] #14269 enhancement, awaiting reviews, tests are failing
+278. [x] #14272 closed by close_pull_requests_with_failing_tests.sh
+279. [x] #14270 closed by close_pull_requests_with_failing_tests.sh
+280. [x] #14269 closed by close_pull_requests_with_failing_tests.sh
 281. [ ] #14264 no labels
 282. [ ] #14262 enhancement, awaiting reviews
-283. [ ] #14261 tests are failing
+283. [x] #14261 closed by close_pull_requests_with_failing_tests.sh
 284. [ ] #14260 enhancement, awaiting reviews
-285. [ ] #14256 enhancement, awaiting reviews, tests are failing
+285. [x] #14256 closed by close_pull_requests_with_failing_tests.sh
 286. [ ] #14239 no labels
 287. [ ] #14237 awaiting reviews
-288. [ ] #14234 awaiting reviews, tests are failing
+288. [x] #14234 closed by close_pull_requests_with_failing_tests.sh
 289. [ ] #14233 awaiting reviews
 290. [ ] #14229 awaiting reviews
-291. [ ] #14227 enhancement, awaiting reviews, tests are failing
+291. [x] #14227 closed by close_pull_requests_with_failing_tests.sh
 292. [ ] #14224 enhancement, awaiting reviews
 293. [ ] #14221 awaiting reviews, documentation
 294. [ ] #14219 awaiting reviews
@@ -321,34 +321,34 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 309. [x] #14138 closed by close_pull_requests_with_require_type_hints.sh
 310. [ ] #14134 no labels
 311. [ ] #14099 no labels
-312. [ ] #14098 tests are failing
-313. [ ] #14096 awaiting reviews, tests are failing
+312. [x] #14098 closed by close_pull_requests_with_failing_tests.sh
+313. [x] #14096 closed by close_pull_requests_with_failing_tests.sh
 314. [ ] #14095 no labels
 315. [x] #14090 closed by close_pull_requests_with_require_type_hints.sh
 316. [ ] #14089 no labels
-317. [ ] #14088 tests are failing
+317. [x] #14088 closed by close_pull_requests_with_failing_tests.sh
 318. [x] #14086 closed by close_pull_requests_with_require_tests.sh
-319. [ ] #14085 awaiting reviews, tests are failing
+319. [x] #14085 closed by close_pull_requests_with_failing_tests.sh
 320. [x] #14082 closed by close_pull_requests_with_require_descriptive_names.sh
-321. [ ] #14080 awaiting reviews, tests are failing
+321. [x] #14080 closed by close_pull_requests_with_failing_tests.sh
 322. [ ] #14079 no labels
 323. [ ] #14065 awaiting reviews
 324. [x] #14061 closed by close_pull_requests_with_require_descriptive_names.sh
 325. [ ] #14059 no labels
 326. [ ] #14058 enhancement, awaiting reviews
-327. [ ] #14057 tests are failing
+327. [x] #14057 closed by close_pull_requests_with_failing_tests.sh
 328. [ ] #14056 awaiting reviews
 329. [ ] #14052 awaiting reviews
 330. [ ] #14051 no labels
 331. [ ] #14048 awaiting reviews
 332. [x] #14045 closed by close_pull_requests_with_require_tests.sh
 333. [ ] #14041 awaiting reviews
-334. [ ] #14040 awaiting reviews, tests are failing
+334. [x] #14040 closed by close_pull_requests_with_failing_tests.sh
 335. [ ] #14038 awaiting reviews
 336. [ ] #14037 awaiting reviews
 337. [ ] #14036 awaiting reviews
 338. [ ] #14035 awaiting reviews
-339. [ ] #14034 tests are failing
+339. [x] #14034 closed by close_pull_requests_with_failing_tests.sh
 340. [ ] #14032 no labels
 341. [ ] #14031 no labels
 342. [ ] #14030 awaiting reviews
@@ -367,7 +367,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 355. [ ] #14008 awaiting reviews
 356. [x] #14004 closed by close_pull_requests_with_require_tests.sh
 357. [ ] #14001 awaiting reviews
-358. [ ] #14000 awaiting reviews, tests are failing
+358. [x] #14000 closed by close_pull_requests_with_failing_tests.sh
 359. [ ] #13994 no labels
 360. [ ] #13993 no labels
 361. [ ] #13991 no labels
@@ -375,30 +375,30 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 363. [x] #13989 closed by close_pull_requests_with_require_descriptive_names.sh
 364. [ ] #13987 enhancement, awaiting reviews
 365. [ ] #13984 no labels
-366. [ ] #13983 awaiting reviews, tests are failing
+366. [x] #13983 closed by close_pull_requests_with_failing_tests.sh
 367. [ ] #13977 no labels
 368. [ ] #13973 awaiting reviews
 369. [ ] #13972 no labels
 370. [ ] #13969 no labels
-371. [ ] #13967 tests are failing
+371. [x] #13967 closed by close_pull_requests_with_failing_tests.sh
 372. [ ] #13966 no labels
 373. [ ] #13964 no labels
 374. [ ] #13963 no labels
 375. [ ] #13962 enhancement, awaiting reviews
 376. [ ] #13960 no labels
-377. [ ] #13958 tests are failing
+377. [x] #13958 closed by close_pull_requests_with_failing_tests.sh
 378. [ ] #13955 awaiting reviews
 379. [ ] #13954 enhancement, awaiting reviews
 380. [ ] #13950 enhancement, awaiting reviews
 381. [ ] #13947 awaiting reviews
-382. [ ] #13943 tests are failing
-383. [ ] #13942 tests are failing
+382. [x] #13943 closed by close_pull_requests_with_failing_tests.sh
+383. [x] #13942 closed by close_pull_requests_with_failing_tests.sh
 384. [ ] #13941 awaiting reviews
 385. [ ] #13938 no labels
-386. [ ] #13935 tests are failing
+386. [x] #13935 closed by close_pull_requests_with_failing_tests.sh
 387. [ ] #13934 no labels
 388. [ ] #13924 awaiting reviews
-389. [ ] #13916 awaiting reviews, tests are failing
+389. [x] #13916 closed by close_pull_requests_with_failing_tests.sh
 390. [ ] #13915 enhancement, awaiting reviews
 391. [x] #13912 closed by close_pull_requests_with_require_descriptive_names.sh
 392. [ ] #13911 no labels
@@ -408,8 +408,8 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 396. [ ] #13903 no labels
 397. [ ] #13901 no labels
 398. [ ] #13900 enhancement, awaiting reviews
-399. [ ] #13899 awaiting reviews, tests are failing
-400. [ ] #13897 tests are failing
+399. [x] #13899 closed by close_pull_requests_with_failing_tests.sh
+400. [x] #13897 closed by close_pull_requests_with_failing_tests.sh
 401. [ ] #13896 awaiting reviews
 402. [ ] #13894 awaiting reviews
 403. [ ] #13892 awaiting reviews
@@ -419,8 +419,8 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 407. [x] #13883 closed by close_pull_requests_with_require_tests.sh
 408. [ ] #13882 awaiting reviews
 409. [ ] #13880 no labels
-410. [ ] #13879 enhancement, awaiting reviews, tests are failing
-411. [ ] #13878 tests are failing
+410. [x] #13879 closed by close_pull_requests_with_failing_tests.sh
+411. [x] #13878 closed by close_pull_requests_with_failing_tests.sh
 412. [ ] #13873 awaiting reviews
 413. [ ] #13869 enhancement, awaiting reviews
 414. [ ] #13862 no labels
@@ -428,7 +428,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 416. [ ] #13847 awaiting reviews, documentation
 417. [ ] #13843 no labels
 418. [ ] #13841 no labels
-419. [ ] #13839 awaiting reviews, tests are failing
+419. [x] #13839 closed by close_pull_requests_with_failing_tests.sh
 420. [ ] #13836 no labels
 421. [ ] #13835 awaiting reviews
 422. [ ] #13831 awaiting reviews
@@ -440,19 +440,19 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 428. [x] #13823 closed by close_pull_requests_with_require_tests.sh
 429. [x] #13822 closed by close_pull_requests_with_require_tests.sh
 430. [ ] #13818 no labels
-431. [ ] #13816 tests are failing
+431. [x] #13816 closed by close_pull_requests_with_failing_tests.sh
 432. [ ] #13815 awaiting reviews
 433. [ ] #13814 no labels
-434. [ ] #13810 awaiting reviews, tests are failing
+434. [x] #13810 closed by close_pull_requests_with_failing_tests.sh
 435. [ ] #13808 awaiting reviews
 436. [ ] #13807 no labels
 437. [ ] #13806 no labels
 438. [ ] #13802 awaiting reviews
-439. [ ] #13799 awaiting reviews, tests are failing
+439. [x] #13799 closed by close_pull_requests_with_failing_tests.sh
 440. [ ] #13797 no labels
 441. [ ] #13791 no labels
-442. [ ] #13790 tests are failing
-443. [ ] #13789 tests are failing
+442. [x] #13790 closed by close_pull_requests_with_failing_tests.sh
+443. [x] #13789 closed by close_pull_requests_with_failing_tests.sh
 444. [x] #13781 closed by close_pull_requests_with_require_tests.sh
 445. [x] #13774 closed by close_pull_requests_with_require_tests.sh
 446. [x] #13773 closed by close_pull_requests_with_require_type_hints.sh
@@ -464,8 +464,8 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 452. [ ] #13751 awaiting reviews
 453. [ ] #13750 no labels
 454. [ ] #13749 awaiting reviews
-455. [ ] #13746 tests are failing
-456. [ ] #13745 tests are failing
+455. [x] #13746 closed by close_pull_requests_with_failing_tests.sh
+456. [x] #13745 closed by close_pull_requests_with_failing_tests.sh
 457. [ ] #13744 awaiting reviews
 458. [x] #13742 closed by close_pull_requests_with_require_tests.sh
 459. [ ] #13738 no labels
@@ -490,14 +490,14 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 478. [x] #13679 closed by close_pull_requests_with_require_descriptive_names.sh
 479. [x] #13676 closed by close_pull_requests_with_require_descriptive_names.sh
 480. [x] #13675 closed by close_pull_requests_with_require_descriptive_names.sh
-481. [ ] #13671 awaiting reviews, tests are failing
+481. [x] #13671 closed by close_pull_requests_with_failing_tests.sh
 482. [ ] #13661 awaiting reviews
 483. [x] #13658 closed by close_pull_requests_with_require_type_hints.sh
 484. [x] #13655 closed by close_pull_requests_with_require_tests.sh
-485. [ ] #13653 enhancement, awaiting reviews, tests are failing
+485. [x] #13653 closed by close_pull_requests_with_failing_tests.sh
 486. [ ] #13648 no labels
 487. [ ] #13647 no labels
-488. [ ] #13646 awaiting reviews, tests are failing
+488. [x] #13646 closed by close_pull_requests_with_failing_tests.sh
 489. [ ] #13645 awaiting reviews
 490. [x] #13644 closed by close_pull_requests_with_require_type_hints.sh
 491. [ ] #13641 awaiting reviews
@@ -513,45 +513,45 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 501. [ ] #13615 awaiting reviews
 502. [ ] #13609 awaiting reviews
 503. [ ] #13606 no labels
-504. [ ] #13605 awaiting reviews, tests are failing
+504. [x] #13605 closed by close_pull_requests_with_failing_tests.sh
 505. [ ] #13604 awaiting reviews, documentation
 506. [ ] #13603 awaiting reviews
 507. [ ] #13601 enhancement, awaiting reviews
 508. [x] #13600 closed by close_pull_requests_with_require_tests.sh
 509. [ ] #13597 enhancement, awaiting reviews
-510. [ ] #13595 awaiting reviews, tests are failing
+510. [x] #13595 closed by close_pull_requests_with_failing_tests.sh
 511. [ ] #13593 awaiting reviews
 512. [ ] #13589 awaiting reviews
 513. [ ] #13588 awaiting reviews
 514. [ ] #13586 awaiting reviews
-515. [ ] #13585 awaiting reviews, tests are failing
-516. [ ] #13558 tests are failing
+515. [x] #13585 closed by close_pull_requests_with_failing_tests.sh
+516. [x] #13558 closed by close_pull_requests_with_failing_tests.sh
 517. [ ] #13555 no labels
 518. [ ] #13554 awaiting reviews
-519. [ ] #13552 tests are failing
+519. [x] #13552 closed by close_pull_requests_with_failing_tests.sh
 520. [ ] #13551 no labels
 521. [ ] #13550 awaiting reviews
-522. [ ] #13544 awaiting reviews, tests are failing
-523. [ ] #13541 tests are failing
+522. [x] #13544 closed by close_pull_requests_with_failing_tests.sh
+523. [x] #13541 closed by close_pull_requests_with_failing_tests.sh
 524. [ ] #13538 awaiting reviews
-525. [ ] #13536 awaiting reviews, tests are failing
+525. [x] #13536 closed by close_pull_requests_with_failing_tests.sh
 526. [ ] #13535 awaiting reviews
 527. [ ] #13534 awaiting reviews
 528. [ ] #13531 no labels
 529. [ ] #13529 awaiting reviews
 530. [ ] #13528 awaiting reviews
 531. [ ] #13527 awaiting reviews
-532. [ ] #13526 awaiting reviews, tests are failing
+532. [x] #13526 closed by close_pull_requests_with_failing_tests.sh
 533. [x] #13523 closed by close_pull_requests_with_require_tests.sh
 534. [ ] #13522 awaiting reviews
-535. [ ] #13520 awaiting reviews, tests are failing
+535. [x] #13520 closed by close_pull_requests_with_failing_tests.sh
 536. [ ] #13519 awaiting reviews, documentation
 537. [ ] #13514 awaiting reviews
 538. [ ] #13510 awaiting reviews
-539. [ ] #13506 enhancement, awaiting reviews, tests are failing
+539. [x] #13506 closed by close_pull_requests_with_failing_tests.sh
 540. [ ] #13502 no labels
 541. [ ] #13487 awaiting reviews
-542. [ ] #13485 awaiting reviews, tests are failing
+542. [x] #13485 closed by close_pull_requests_with_failing_tests.sh
 543. [ ] #13484 awaiting reviews
 544. [ ] #13483 awaiting reviews
 545. [ ] #13482 awaiting reviews
@@ -561,7 +561,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 549. [ ] #13469 enhancement, awaiting reviews
 550. [ ] #13468 enhancement, awaiting reviews
 551. [ ] #13462 awaiting reviews
-552. [ ] #13457 awaiting reviews, tests are failing
+552. [x] #13457 closed by close_pull_requests_with_failing_tests.sh
 553. [ ] #13452 awaiting reviews
 554. [ ] #13447 awaiting reviews
 555. [ ] #13426 awaiting reviews
@@ -676,7 +676,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 664. [ ] #13014 no labels
 665. [ ] #13013 awaiting reviews
 666. [ ] #13012 enhancement, awaiting reviews
-667. [ ] #13009 awaiting reviews, tests are failing
+667. [x] #13009 closed by close_pull_requests_with_failing_tests.sh
 668. [ ] #13007 awaiting reviews
 669. [ ] #13002 no labels
 670. [ ] #13000 awaiting reviews
@@ -686,7 +686,7 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 674. [ ] #12980 awaiting reviews
 675. [ ] #12976 no labels
 676. [ ] #12974 awaiting reviews
-677. [ ] #12956 enhancement, awaiting reviews, tests are failing
+677. [x] #12956 closed by close_pull_requests_with_failing_tests.sh
 678. [ ] #12942 no labels
 679. [ ] #12940 awaiting reviews
 680. [ ] #12896 no labels
@@ -934,8 +934,9 @@ Notation: `<index>. [ ] #<pr_id> <labels>`
 | Script | PRs closed |
 | --- | ---: |
 | `close_pull_requests_with_awaiting_changes.sh` | 0 |
-| `close_pull_requests_with_failing_tests.sh` | 0 |
+| `close_pull_requests_with_failing_tests.sh` | 94 |
 | `close_pull_requests_with_require_descriptive_names.sh` | 14 |
 | `close_pull_requests_with_require_tests.sh` | 24 |
 | `close_pull_requests_with_require_type_hints.sh` | 15 |
-| **Total** | **53** |
+| **Total** | **147** |
+


### PR DESCRIPTION
Updates `docs/hacktober_2026_prep.md` for the `scripts/close_pull_requests_with_failing_tests.sh` run reported in https://github.com/TheAlgorithms/Python/pull/15175#issuecomment-5536771522 (`CLOSED_COUNT=95`), as requested by @cclauss on #15081.

- Marked **94** listed PRs `[x]` and relabeled them "closed by close_pull_requests_with_failing_tests.sh".
- **Closed totals** table: `close_pull_requests_with_failing_tests.sh` 0 → 94, **Total** 53 → 147.

Note on the 95 vs 94: the script output lists `#15174`, but that PR is not one of the 918 lines in this tracker (the snapshot was taken **2026-09-02**, before #15174; it's the `ty` pre-commit rollout PR that was itself closed in this batch). Every other one of the 95 IDs mapped to an open `[ ]` line and was checked off. Nothing else is touched.
