### PR TITLE
ci: add informational ty type-check job (config-only replacement for #15174)

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -1,0 +1,25 @@
+# https://docs.astral.sh/ty/
+name: ty
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ty:
+    runs-on: ubuntu-latest
+    # Informational only: ty is not yet a required gate. This job surfaces
+    # type-check findings in the logs so they can be triaged into gradual
+    # [tool.ty] rules without blocking merges. Flip `continue-on-error` to
+    # false once the baseline is clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      # Type-check on a regular (GIL) 3.14 interpreter so third-party stubs
+      # resolve. The free-threaded 3.14t venv used by the test matrix does not
+      # resolve several typed dependencies, which made ty skip its own config.
+      - run: uv sync --python 3.14 --group=test
+      - run: uv run --python 3.14 --with=ty==0.0.78 ty check --output-format=github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,12 @@ skip = """\
 [tool.mypy]
 python_version = "3.14"
 
+[tool.ty.environment]
+# Type-check against a regular (GIL) 3.14 interpreter. Pinning this keeps ty's
+# assumptions consistent with the CI job in .github/workflows/ty.yml, where the
+# free-threaded 3.14t test venv would otherwise leave several stubs unresolved.
+python-version = "3.14"
+
 [tool.pytest]
 ini_options.addopts = [
   "--durations=10",
@@ -200,3 +206,4 @@ report.omit = [
   "project_euler/*",
 ]
 report.sort = "Cover"
+


### PR DESCRIPTION
Config-only replacement for #15174, per @cclauss's request there. It wires `ty` into CI **without** the ~280-file `from __future__` churn or any source edits, so the type-checker can start reporting findings immediately and get tightened gradually.

**What this changes (2 files, config only):**

- **`.github/workflows/ty.yml`** — a new, standalone `ty` job. It is deliberately **`continue-on-error: true`** (informational), so it can never turn a required check red while the baseline is still noisy. It runs the type check on a regular (GIL) **3.14** interpreter (`uv sync --python 3.14`), which is the key fix for #15174: that PR's `ty` step ran inside the free-threaded **3.14t** test venv, where several third-party stubs don't resolve — so `ty` fell back to defaults and reported ~45 errors, 42 of them on rules that a project config would have ignored. `ty` is also pinned (`--with=ty==0.0.78`, matching the `ty-pre-commit` rev in #15174) for reproducibility.
- **`pyproject.toml`** — a minimal `[tool.ty.environment]` with `python-version = "3.14"`, so `ty`'s assumptions match that CI job. No rule ignores are invented here; the informational run surfaces the real findings first, and those get triaged into `[tool.ty.rules]` from actual output rather than guesses.

**Why not touch the existing `ruff` workflow / rename it:** keeping `ruff` untouched means no change to the required-check name (branch protection), and the new job stays cleanly separable.

**Suggested path to a gate:** land this informational; triage the reported diagnostics into `[tool.ty.rules]` a family at a time (the same gradual-un-ignore model I use on my own project); flip `continue-on-error` to `false` once the baseline is clean. The `from __future__` cleanup from #15174, if still wanted, is orthogonal and can be its own PR so config lands fast and doesn't force a 280-file re-review.

I don't have `ty` + free-threaded CI locally to run the full check, so I've kept this to the safe, verifiable wiring; this repo's CI will show the actual `ty` output on the (non-blocking) job. Happy to iterate on flags or the config in review.


---

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes configuration/CI files (no algorithm files).
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.

_The type-hint / doctest / Wikipedia-URL items don't apply: this is a config-only CI change (`.github/workflows/ty.yml` + `[tool.ty]` in `pyproject.toml`), not an algorithm._
