### PR TITLE
Fix word_occurrence return type and typo

### DIFF
--- a/strings/word_occurrence.py
+++ b/strings/word_occurrence.py
@@ -3,12 +3,12 @@
 from collections import defaultdict
 
 
-def word_occurrence(sentence: str) -> dict:
+def word_occurrence(sentence: str) -> defaultdict[str, int]:
     """
     >>> from collections import Counter
     >>> SENTENCE = "a b A b c b d b d e f e g e h e i e j e 0"
-    >>> occurence_dict = word_occurrence(SENTENCE)
-    >>> all(occurence_dict[word] == count for word, count
+    >>> occurrence_dict = word_occurrence(SENTENCE)
+    >>> all(occurrence_dict[word] == count for word, count
     ...     in Counter(SENTENCE.split()).items())
     True
     >>> dict(word_occurrence("Two  spaces"))


### PR DESCRIPTION
### Describe your change:

Fix the return type annotation and a typo in the existing word_occurrence() doctest.

This change:

- Updates the return type from dict to defaultdict[str, int] to match the actual returned object.
- Fixes the misspelled occurence_dict variable name in the doctest.
- Keeps the existing defaultdict implementation unchanged.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
