### PR TITLE
test: add connected components empty graph test

### DIFF
--- a/graphs/tests/test_connected_components.py
+++ b/graphs/tests/test_connected_components.py
@@ -1,0 +1,5 @@
+from graphs.connected_components import connected_components
+
+
+def test_connected_components_empty_graph():
+    assert connected_components({}) == []


### PR DESCRIPTION
Added a pytest test for connected_components with an empty graph.

The test verifies that an empty graph returns an empty list.