### PR TITLE
Skill review edits: uv.lock wording + DIRECTORY.md/README.md auto-gen note

### DIFF
--- a/.github/skills/new-pull-request/SKILL.md
+++ b/.github/skills/new-pull-request/SKILL.md
@@ -13,8 +13,10 @@ creating a new pull request.
 Create a new clearly named branch for the pull request.  Pull request changes must
 not be made or submitted on the `master` branch.
 
-Never modify the `uv.lock` file because the `algorithms-keeper` bot will close
-the pull request as invalid.  Even a repo maintainer cannot undo this.
+Never hand-edit or revert the `uv.lock` file. If you add a legitimate
+dependency, let the `uv-lock` pre-commit hook regenerate it — do not touch it by
+hand. A hand-modified `uv.lock` makes the `algorithms-keeper` bot close the pull
+request as invalid, and even a repo maintainer cannot undo that.
 
 Always check at least one Markdown checkbox in the pull request description (the "Describe your change" section), or the
 `algorithms-keeper` bot will close the pull request as invalid.  Any repo maintainer can undo this if you @mention them on the closed pull request.
@@ -40,6 +42,8 @@ Always check at least one Markdown checkbox in the pull request description (the
 - [ ] Public functions have **doctests that actually pass**.
 - [ ] Descriptive variable and function names (no single letters where a word helps).
 - [ ] Code is formatted and lint-clean (`ruff`, `pre-commit`).
+- [ ] `DIRECTORY.md` and `README.md` are **not hand-edited** — the
+      `algorithms-keeper` bot regenerates them automatically after merge.
 
 ### 3. Other Requirements for Submissions
 


### PR DESCRIPTION
Follow-up to my review on #15212. @cclauss asked me to push my recommended changes into the branch — I don't have push access to `TheAlgorithms/Python`, so here they are as a small PR targeting `skill-new-pull-request` (merge this to fold them in).

(Re-opening my earlier #15215, which the keeper auto-closed for an unchecked checklist — fittingly, since this PR *is* about documenting the keeper's checklist behavior. Checklist now filled below.)

Two edits, both to `.github/skills/new-pull-request/SKILL.md`:

1. **uv.lock wording.** The current text ("never modify uv.lock … even a maintainer cannot undo") reads as "never let uv.lock change," but a *legitimate dependency add* makes the `uv-lock` pre-commit hook regenerate it (CONTRIBUTING.md). Rephrased to: never **hand-edit or revert** it; let the hook manage it — a *hand-modified* lock is what the keeper closes on.
2. **New checklist item** under *Coding Style*: `DIRECTORY.md` and `README.md` are regenerated by `algorithms-keeper` after merge, so don't hand-edit them (CONTRIBUTING.md L189).

### Describe your change:

Documentation-only edit to the `new-pull-request` skill added in #15212.

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests?
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one file.

Reviewed and authored by Priya Sundaram, an AI agent.
