### PR TITLE
docs(skill): recommend ruff --fix workflow for PRs failing ruff check

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -33,6 +33,23 @@ suggest the fix — never just "rejected".
 - [ ] Descriptive variable and function names (no single letters where a word helps).
 - [ ] Code is formatted and lint-clean (`ruff`, `pre-commit`).
 
+#### When a PR fails `ruff check`
+
+Don't just report the failure — try the mechanical fixes and recommend the one
+that works, in this order:
+
+1. Run `ruff check --fix file_path.py`. If that makes the file pass, recommend
+   that solution — these are the fixes `ruff` considers **safe**.
+2. If it still fails, run `ruff check --fix --unsafe-fixes file_path.py`. If that
+   makes the file pass **and** the resulting diff is genuinely safe (it preserves
+   behavior — review it, don't trust it blindly), recommend that solution and note
+   that it required `--unsafe-fixes`.
+3. If neither passes, or the unsafe fix would change behavior, describe the
+   remaining rule violations and the manual change the author needs to make.
+
+Always quote the exact rule code(s) `ruff` reports (e.g. `UP047`, `RUF100`) so the
+author knows what is being flagged, and paste the concrete command you ran.
+
 ### 3. Other Requirements for Submissions
 
 - [ ] At least one **Wikipedia (or equivalent) URL** documenting the algorithm.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -47,8 +47,9 @@ that works, in this order:
 3. If neither passes, or the unsafe fix would change behavior, describe the
    remaining rule violations and the manual change the author needs to make.
 
-Always quote the exact rule code(s) `ruff` reports (e.g. `UP047`, `RUF100`) so the
-author knows what is being flagged, and paste the concrete command you ran.
+Always quote the exact rule code(s) `ruff` reports (e.g., `ruff rule UP047`,
+`ruff rule RUF100`) so the author can run those commands to read the rules being
+flagged. Also, paste the concrete command you ran.
 
 ### 3. Other Requirements for Submissions
 


### PR DESCRIPTION
Per @cclauss's request in #15081, this adds a *When a PR fails `ruff check`* subsection to `.github/skills/code-review/SKILL.md`.

It gives reviewers a fixed, repeatable procedure:

1. Try `ruff check --fix file_path.py` (safe fixes) — if the file passes, recommend that.
2. Otherwise try `ruff check --fix --unsafe-fixes file_path.py` — if it passes **and** the diff genuinely preserves behavior, recommend that and note it needed `--unsafe-fixes`.
3. If neither works (or the unsafe fix changes behavior), describe the remaining violations and the manual fix.

It also reminds the reviewer to quote the exact rule codes (e.g. `UP047`, `RUF100`) and paste the command they ran, so the author knows exactly what to do.

Refs #15081.

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one file (`.github/skills/code-review/SKILL.md`); it is a documentation-only change, not a new algorithm.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.