### PR TITLE
docs(skill): suggest NamedTuple/dataclass for simple field-bundle classes

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -33,6 +33,14 @@ suggest the fix — never just "rejected".
 - [ ] Descriptive variable and function names (no single letters where a word helps).
 - [ ] Code is formatted and lint-clean (`ruff`, `pre-commit`).
 
+> **Optional hint:** When a PR hand-writes a simple class that is mostly a
+> bundle of fields (a manual `__init__` plus `__repr__`/`__eq__`), it is worth
+> **suggesting** `from typing import NamedTuple` or
+> `from dataclasses import dataclass` where they would simplify the code. These
+> are underutilized tools that our contributors would benefit from using where
+> they make sense. Offer it as an optional improvement, not a blocker — do not
+> request changes solely because a class was written the longhand way.
+
 #### When a PR fails `ruff check`
 
 Don't just report the failure — try the mechanical fixes and recommend the one

--- a/.github/skills/new-pull-request/SKILL.md
+++ b/.github/skills/new-pull-request/SKILL.md
@@ -41,6 +41,11 @@ Always check at least one Markdown checkbox in the pull request description (the
 - [ ] Public functions/classes have **type hints**.
 - [ ] Public functions have **doctests that actually pass**.
 - [ ] Descriptive variable and function names (no single letters where a word helps).
+- [ ] For a simple class that is mostly a bundle of fields, **consider**
+      `from typing import NamedTuple` or `from dataclasses import dataclass`
+      instead of a hand-written `__init__`/`__repr__`/`__eq__`. These are
+      underutilized tools that make simple classes shorter and clearer — use
+      them where they genuinely simplify the code, not everywhere.
 - [ ] Code is formatted and lint-clean (`ruff`, `pre-commit`).
 - [ ] `DIRECTORY.md` and `README.md` are **not hand-edited** — the
       `algorithms-keeper` bot regenerates them automatically after merge.


### PR DESCRIPTION
As discussed on #15081.

### Describe your change:

Adds a small, **optional** guideline to both agent skill files:

- **`new-pull-request/SKILL.md`** (coder): a checklist item to *consider* `from typing import NamedTuple` or `from dataclasses import dataclass` for a simple class that is mostly a bundle of fields, instead of a hand-written `__init__`/`__repr__`/`__eq__`.
- **`code-review/SKILL.md`** (reviewer): an *optional* reviewer hint to suggest those tools where they would simplify the code — explicitly **not** a blocker / not grounds to request changes on their own.

These are underutilized tools that make simple classes shorter and clearer, and this nudges contributors (human or AI) toward them where they make sense.

* [x] Fix a bug or typo in an existing file.
* [x] Documentation change.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] This PR only changes one algorithm file (docs-only).