### PR TITLE
docs(skill): make the PR checkbox rule a hard final gate

### DIFF
--- a/.github/skills/new-pull-request/SKILL.md
+++ b/.github/skills/new-pull-request/SKILL.md
@@ -19,7 +19,13 @@ hand. A hand-modified `uv.lock` makes the `algorithms-keeper` bot close the pull
 request as invalid, and even a repo maintainer cannot undo that.
 
 Always check at least one Markdown checkbox in the pull request description (the "Describe your change" section), or the
-`algorithms-keeper` bot will close the pull request as invalid — and it does this *before* a human reads the PR, so a genuinely good change gets closed for a formatting reason. This applies to **every** pull request, including CI, docs, and tooling changes that are not algorithms: tick the boxes that genuinely apply so the body is never submitted with all boxes empty. Any repo maintainer can undo this if you @mention them on the closed pull request, but re-opening is often unreliable, so it is far better to get it right the first time.
+`algorithms-keeper` bot will close the pull request as invalid — and it does
+this *before* a human reads the PR, so a genuinely good change gets closed for a
+formatting reason. This applies to **every** pull request, including CI, docs,
+and tooling changes that are not algorithms: tick the boxes that genuinely apply
+so the body is never submitted with all boxes empty. Any repo maintainer can
+undo this if you @mention them on the closed pull request, but re-opening is
+often unreliable, so it is far better to get it right the first time.
 
 ### 1. Before contributing / Is this an algorithm?
 

--- a/.github/skills/new-pull-request/SKILL.md
+++ b/.github/skills/new-pull-request/SKILL.md
@@ -19,7 +19,7 @@ hand. A hand-modified `uv.lock` makes the `algorithms-keeper` bot close the pull
 request as invalid, and even a repo maintainer cannot undo that.
 
 Always check at least one Markdown checkbox in the pull request description (the "Describe your change" section), or the
-`algorithms-keeper` bot will close the pull request as invalid. Any repo maintainer can undo this if you @mention them on the closed pull request.
+`algorithms-keeper` bot will close the pull request as invalid — and it does this *before* a human reads the PR, so a genuinely good change gets closed for a formatting reason. This applies to **every** pull request, including CI, docs, and tooling changes that are not algorithms: tick the boxes that genuinely apply so the body is never submitted with all boxes empty. Any repo maintainer can undo this if you @mention them on the closed pull request, but re-opening is often unreliable, so it is far better to get it right the first time.
 
 ### 1. Before contributing / Is this an algorithm?
 
@@ -55,3 +55,15 @@ Always check at least one Markdown checkbox in the pull request description (the
 - [ ] At least one **Wikipedia (or equivalent) URL** documenting the algorithm.
 - [ ] Docstring explains what the function does and its parameters/returns.
 - [ ] No unnecessary third-party dependencies.
+
+## Before you click "Create pull request"
+
+This is the final gate. Do not open the pull request until every item here is true:
+
+- [ ] At least one Markdown checkbox in the PR description is checked. **Verify
+      this by re-reading the rendered body** — if every box is still `- [ ]`, the
+      `algorithms-keeper` bot will auto-close the PR before any human sees it.
+      Check the boxes that genuinely apply to this change; never submit an
+      all-empty checklist, even for a CI, docs, or tooling PR.
+- [ ] The branch is not `master`, and `master` is synced with `upstream/master`.
+- [ ] `uv.lock` was not hand-edited.


### PR DESCRIPTION
### Describe your change:

As requested by @cclauss on #15233, this makes the "tick at least one checkbox" rule impossible to miss.

The requirement was previously buried in a prose paragraph in the middle of the skill, so PR bodies generated straight from the template kept being submitted with every box empty — and `algorithms-keeper` auto-closes those *before* a human reads them, so genuinely good changes get closed for a formatting reason (exactly what happened to #15233).

Changes:
- Strengthen the inline warning and spell out that it applies to **every** PR — including CI, docs, and tooling changes that aren't algorithms — tick the boxes that genuinely apply so the body is never all-empty.
- Add a `## Before you click "Create pull request"` **final gate** at the end of the skill with an explicit *re-read the rendered body* verify step.

Docs-only change to a skill file; no code, no dependencies.

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? — _Note: Please avoid changing both code and tests in a single pull request._
* [x] Documentation change?

### Checklist:

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
