### PR TITLE
Reject multi-character split separators

### DIFF
--- a/strings/split.py
+++ b/strings/split.py
@@ -17,7 +17,15 @@ def split(string: str, separator: str = " ") -> list:
 
     >>> split(";abbb;;c;", separator=';')
     ['', 'abbb', '', 'c', '']
+
+    >>> split("a--b--c", separator="--")
+    Traceback (most recent call last):
+        ...
+    ValueError: separator must be a single character
     """
+
+    if len(separator) != 1:
+        raise ValueError("separator must be a single character")
 
     split_words = []
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,12 @@
+import pytest
+
+from strings.split import split
+
+
+def test_split_rejects_multi_character_separator():
+    with pytest.raises(ValueError, match="separator must be a single character"):
+        split("a--b--c", separator="--")
+
+
+def test_split_supports_single_character_separator():
+    assert split("a--b--c", separator="-") == ["a", "", "b", "", "c"]


### PR DESCRIPTION
Fixes #14649.

The custom `strings.split.split` implementation compares one input character at a time, so a multi-character separator is silently ignored and returns incorrect output. This PR:

- raises `ValueError("separator must be a single character")` for invalid separators
- preserves existing single-character separator behaviour
- adds a doctest and pytest regression coverage

Tests:
- `python -m pytest tests/test_split.py -q` (2 passed)
- `python -m doctest strings/split.py`
- `git diff --check`