### PR TITLE
Raise an error when simplex reaches max iterations

### DIFF
--- a/linear_programming/simplex.py
+++ b/linear_programming/simplex.py
@@ -302,7 +302,10 @@ class Tableau:
                 self.tableau = self.change_stage()
             else:
                 self.tableau = self.pivot(row_idx, col_idx)
-        return {}
+        raise ValueError(
+            f"Simplex did not converge within {Tableau.maxiter} iterations. "
+            "The problem may be cycling or unbounded."
+        )
 
     def interpret_tableau(self) -> dict[str, float]:
         """Given the final tableau, add the corresponding values of the basic

--- a/tests/test_simplex.py
+++ b/tests/test_simplex.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from linear_programming.simplex import Tableau
+
+
+def test_run_simplex_raises_when_max_iterations_are_exhausted(monkeypatch):
+    monkeypatch.setattr(Tableau, "maxiter", 0)
+    tableau = Tableau(
+        np.array([[-1.0, -1.0, 0.0, 0.0, 1.0], [1.0, 1.0, 1.0, 0.0, 2.0]]),
+        2,
+        0,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Simplex did not converge within 0 iterations\. "
+        r"The problem may be cycling or unbounded\.",
+    ):
+        tableau.run_simplex()


### PR DESCRIPTION
Fixes #14584.

`Tableau.run_simplex()` now raises:

`ValueError: Simplex did not converge within N iterations. The problem may be cycling or unbounded.`

when the configured iteration limit is exhausted, instead of silently returning an empty dictionary. A regression test forces `maxiter=0` and verifies the exact diagnostic.

Tests:
- `python -m pytest tests/test_simplex.py -q` (1 passed)
- `python -m doctest linear_programming/simplex.py`
- `git diff --check`