### PR TITLE
sorts: support comparable items in circle_sort

### DIFF
--- a/sorts/circle_sort.py
+++ b/sorts/circle_sort.py
@@ -8,8 +8,20 @@ For manual testing run:
 python3 circle_sort.py
 """
 
+from collections.abc import MutableSequence
+from typing import Any, Protocol, TypeVar
 
-def circle_sort(collection: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: Any, /) -> bool: ...
+
+
+T = TypeVar("T", bound=Comparable)
+
+
+def circle_sort[T: Comparable](
+    collection: MutableSequence[T],
+) -> MutableSequence[T]:
     """A pure Python implementation of circle sort algorithm
 
     :param collection: a mutable collection of comparable items in any order
@@ -22,6 +34,14 @@ def circle_sort(collection: list) -> list:
     []
     >>> circle_sort([-2, 5, 0, -45])
     [-45, -2, 0, 5]
+    >>> circle_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> circle_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+    >>> circle_sort([1, "a"])
+    Traceback (most recent call last):
+        ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
     >>> collections = ([], [0, 5, 3, 2, 2], [-2, 5, 0, -45])
     >>> all(sorted(collection) == circle_sort(collection) for collection in collections)
     True
@@ -30,10 +50,12 @@ def circle_sort(collection: list) -> list:
     if len(collection) < 2:
         return collection
 
-    def circle_sort_util(collection: list, low: int, high: int) -> bool:
+    def circle_sort_util(
+        collection: MutableSequence[T], low: int, high: int
+    ) -> bool:
         """
         >>> arr = [5,4,3,2,1]
-        >>> circle_sort_util(lst, 0, 2)
+        >>> circle_sort_util(arr, 0, 2)
         True
         >>> arr
         [3, 4, 5, 2, 1]
@@ -48,7 +70,7 @@ def circle_sort(collection: list) -> list:
         right = high
 
         while left < right:
-            if collection[left] > collection[right]:
+            if collection[right] < collection[left]:
                 collection[left], collection[right] = (
                     collection[right],
                     collection[left],
@@ -58,7 +80,7 @@ def circle_sort(collection: list) -> list:
             left += 1
             right -= 1
 
-        if left == right and collection[left] > collection[right + 1]:
+        if left == right and collection[right + 1] < collection[left]:
             collection[left], collection[right + 1] = (
                 collection[right + 1],
                 collection[left],

--- a/sorts/circle_sort.py
+++ b/sorts/circle_sort.py
@@ -50,9 +50,7 @@ def circle_sort[T: Comparable](
     if len(collection) < 2:
         return collection
 
-    def circle_sort_util(
-        collection: MutableSequence[T], low: int, high: int
-    ) -> bool:
+    def circle_sort_util(collection: MutableSequence[T], low: int, high: int) -> bool:
         """
         >>> arr = [5,4,3,2,1]
         >>> circle_sort_util(arr, 0, 2)

--- a/sorts/circle_sort.py
+++ b/sorts/circle_sort.py
@@ -9,14 +9,11 @@ python3 circle_sort.py
 """
 
 from collections.abc import MutableSequence
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol
 
 
 class Comparable(Protocol):
     def __lt__(self, other: Any, /) -> bool: ...
-
-
-T = TypeVar("T", bound=Comparable)
 
 
 def circle_sort[T: Comparable](

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -92,3 +92,8 @@ def test_sort_matches_builtin(sort, case):
 def test_binary_insertion_sort_rejects_non_comparable_items():
     with pytest.raises(TypeError):
         binary_insertion_sort([1, "a"])
+
+
+def test_circle_sort_rejects_non_comparable_items():
+    with pytest.raises(TypeError):
+        circle_sort([1, "a"])

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -97,6 +97,8 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_recursive,
         circle_sort,
         insertion_sort,
+        merge_sort,
+        selection_sort,
     ],
     ids=lambda f: f.__name__,
 )


### PR DESCRIPTION
## Description

Update `circle_sort` to support arbitrary comparable items instead of only integer-typed lists.

### Changes

- add a `Comparable` protocol and generic type parameter
- accept and return `MutableSequence[T]`
- use `<` consistently so the implementation matches the `Comparable` protocol
- add string and float doctest coverage
- add a regression test for non-comparable mixed values
- fix the existing `circle_sort_util` doctest variable typo

Related to #15234.

## Test

- `python -m doctest -v sorts/circle_sort.py`
- `python -m pytest tests/test_sorts.py -v`
- `ruff check sorts/circle_sort.py tests/test_sorts.py`
- `ruff format --check sorts/circle_sort.py tests/test_sorts.py`
- `git diff --check`
