### PR TITLE
sorts: type six algorithms for comparable items

### DIFF
--- a/sorts/cocktail_shaker_sort.py
+++ b/sorts/cocktail_shaker_sort.py
@@ -4,8 +4,17 @@ An implementation of the cocktail shaker sort algorithm in pure Python.
 https://en.wikipedia.org/wiki/Cocktail_shaker_sort
 """
 
+from typing import Protocol
 
-def cocktail_shaker_sort(arr: list[int]) -> list[int]:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+
+
+
+def cocktail_shaker_sort[T: Comparable](arr: list[T]) -> list[T]:
     """
     Sorts a list using the Cocktail Shaker Sort algorithm.
 
@@ -28,7 +37,12 @@ def cocktail_shaker_sort(arr: list[int]) -> list[int]:
     Traceback (most recent call last):
         ...
     TypeError: 'tuple' object does not support item assignment
-    """
+    
+    >>> cocktail_shaker_sort(["elderberry", "banana", "date", "apple", "cherry"])
+    ['apple', 'banana', 'cherry', 'date', 'elderberry']
+    >>> cocktail_shaker_sort([3.2, -1.1, 2.4, 0.5])
+    [-1.1, 0.5, 2.4, 3.2]
+"""
     start, end = 0, len(arr) - 1
 
     while start < end:

--- a/sorts/comb_sort.py
+++ b/sorts/comb_sort.py
@@ -18,8 +18,17 @@ For manual testing run:
 python comb_sort.py
 """
 
+from typing import Protocol
 
-def comb_sort(data: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+
+
+
+def comb_sort[T: Comparable](data: list[T]) -> list[T]:
     """Pure implementation of comb sort algorithm in Python
     :param data: mutable collection with comparable items
     :return: the same collection in ascending order
@@ -32,7 +41,12 @@ def comb_sort(data: list) -> list:
     [-15, -7, 0, 2, 3, 8, 45, 99]
     >>> comb_sort([2, 0, 3, 4, 5, 6, 1])
     [0, 1, 2, 3, 4, 5, 6]
-    """
+    
+    >>> comb_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> comb_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     shrink_factor = 1.3
     gap = len(data)
     completed = False

--- a/sorts/cycle_sort.py
+++ b/sorts/cycle_sort.py
@@ -3,8 +3,17 @@ Code contributed by Honey Sharma
 Source: https://en.wikipedia.org/wiki/Cycle_sort
 """
 
+from typing import Protocol
 
-def cycle_sort(array: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+
+
+
+def cycle_sort[T: Comparable](array: list[T]) -> list[T]:
     """
     >>> cycle_sort([4, 3, 2, 1])
     [1, 2, 3, 4]
@@ -17,7 +26,12 @@ def cycle_sort(array: list) -> list:
 
     >>> cycle_sort([])
     []
-    """
+    
+    >>> cycle_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> cycle_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     array_len = len(array)
     for cycle_start in range(array_len - 1):
         item = array[cycle_start]

--- a/sorts/double_sort.py
+++ b/sorts/double_sort.py
@@ -1,7 +1,12 @@
-from typing import Any
+
+from typing import Protocol
 
 
-def double_sort(collection: list[Any]) -> list[Any]:
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def double_sort[T: Comparable](collection: list[T]) -> list[T]:
     """This sorting algorithm sorts an array using the principle of bubble sort,
     but does it both from left to right and right to left.
     Hence, it's called "Double sort"
@@ -16,7 +21,12 @@ def double_sort(collection: list[Any]) -> list[Any]:
     [-6, -5, -4, -3, -2, -1]
     >>> double_sort([-3, 10, 16, -42, 29]) == sorted([-3, 10, 16, -42, 29])
     True
-    """
+    
+    >>> double_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> double_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     no_of_elements = len(collection)
     for _ in range(
         int(((no_of_elements - 1) / 2) + 1)

--- a/sorts/exchange_sort.py
+++ b/sorts/exchange_sort.py
@@ -1,4 +1,11 @@
-def exchange_sort(numbers: list[int]) -> list[int]:
+from typing import Protocol
+
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def exchange_sort[T: Comparable](numbers: list[T]) -> list[T]:
     """
     Uses exchange sort to sort a list of numbers.
     Source: https://en.wikipedia.org/wiki/Sorting_algorithm#Exchange_sort
@@ -12,7 +19,12 @@ def exchange_sort(numbers: list[int]) -> list[int]:
     [-2, 0, 3, 5, 10]
     >>> exchange_sort([])
     []
-    """
+    
+    >>> exchange_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> exchange_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     numbers_length = len(numbers)
     for i in range(numbers_length):
         for j in range(i + 1, numbers_length):

--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -12,8 +12,17 @@ For manual testing run:
 python3 gnome_sort.py
 """
 
+from typing import Protocol
 
-def gnome_sort(lst: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+
+
+
+def gnome_sort[T: Comparable](lst: list[T]) -> list[T]:
     """
     Pure implementation of the gnome sort algorithm in Python
 
@@ -32,7 +41,12 @@ def gnome_sort(lst: list) -> list:
 
     >>> "".join(gnome_sort(list(set("Gnomes are stupid!"))))
     ' !Gadeimnoprstu'
-    """
+    
+    >>> gnome_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> gnome_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     if len(lst) <= 1:
         return lst
 

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -17,6 +17,12 @@ on a graph, and ``stalin_sort``/``wiggle_sort`` deliberately do not fully sort).
 import pytest
 
 from sorts.binary_insertion_sort import binary_insertion_sort
+from sorts.cocktail_shaker_sort import cocktail_shaker_sort
+from sorts.comb_sort import comb_sort
+from sorts.cycle_sort import cycle_sort
+from sorts.double_sort import double_sort
+from sorts.exchange_sort import exchange_sort
+from sorts.gnome_sort import gnome_sort
 from sorts.bubble_sort import bubble_sort_iterative, bubble_sort_recursive
 from sorts.circle_sort import circle_sort
 from sorts.cocktail_shaker_sort import cocktail_shaker_sort
@@ -48,6 +54,12 @@ def test_heap_sort():
 
 SORTS = (
     binary_insertion_sort,
+    cocktail_shaker_sort,
+    comb_sort,
+    cycle_sort,
+    double_sort,
+    exchange_sort,
+    gnome_sort,
     bubble_sort_iterative,
     circle_sort,
     cocktail_shaker_sort,
@@ -95,6 +107,12 @@ def test_sort_matches_builtin(sort, case):
         binary_insertion_sort,
         bubble_sort_iterative,
         bubble_sort_recursive,
+        cocktail_shaker_sort,
+        comb_sort,
+        cycle_sort,
+        double_sort,
+        exchange_sort,
+        gnome_sort,
         insertion_sort,
     ],
     ids=lambda f: f.__name__,


### PR DESCRIPTION
Part of #15234

Update six comparison sorts to use bounded `Comparable` type parameters and exercise non-integer comparable inputs.

Included algorithms:
- `cocktail_shaker_sort.py`
- `comb_sort.py`
- `cycle_sort.py`
- `double_sort.py`
- `exchange_sort.py`
- `gnome_sort.py`

Changes:
- Replace unbounded/int-only annotations with the `Comparable` protocol pattern.
- Add string and float doctests.
- Register the six algorithms in the shared sorting test suite.

Validation performed:
- All six modified modules pass their doctests.
- AST parsing succeeds for all modified sort modules.
- Direct runtime checks confirm string/float sorting and `TypeError` for mixed incomparable values.
