### PR TITLE
sorts: type comb sort for comparable items

### DIFF
--- a/sorts/comb_sort.py
+++ b/sorts/comb_sort.py
@@ -43,7 +43,7 @@ def comb_sort[T: Comparable](data: list[T]) -> list[T]:
     ['a', 'b', 'c', 'd']
     >>> comb_sort([2.5, -1.0, 0.0])
     [-1.0, 0.0, 2.5]
-"""
+    """
     shrink_factor = 1.3
     gap = len(data)
     completed = False

--- a/sorts/comb_sort.py
+++ b/sorts/comb_sort.py
@@ -18,8 +18,14 @@ For manual testing run:
 python comb_sort.py
 """
 
+from typing import Protocol
 
-def comb_sort(data: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def comb_sort[T: Comparable](data: list[T]) -> list[T]:
     """Pure implementation of comb sort algorithm in Python
     :param data: mutable collection with comparable items
     :return: the same collection in ascending order
@@ -32,7 +38,12 @@ def comb_sort(data: list) -> list:
     [-15, -7, 0, 2, 3, 8, 45, 99]
     >>> comb_sort([2, 0, 3, 4, 5, 6, 1])
     [0, 1, 2, 3, 4, 5, 6]
-    """
+
+    >>> comb_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> comb_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     shrink_factor = 1.3
     gap = len(data)
     completed = False

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -96,6 +96,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_iterative,
         bubble_sort_recursive,
         insertion_sort,
+        comb_sort,
     ],
     ids=lambda f: f.__name__,
 )


### PR DESCRIPTION
### Describe your change

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

### Details

Type `comb_sort` to accept comparable items rather than only integers.

- Adds `Comparable` typing.
- Adds comparable string/float doctests.
- Extends the existing mixed-type rejection test for `comb_sort`.

Part of #15234. This is intentionally one algorithm per pull request, following the issue guidance.
