### PR TITLE
sorts: type gnome sort for comparable items

### DIFF
--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -43,7 +43,7 @@ def gnome_sort[T: Comparable](lst: list[T]) -> list[T]:
     ['a', 'b', 'c', 'd']
     >>> gnome_sort([2.5, -1.0, 0.0])
     [-1.0, 0.0, 2.5]
-"""
+    """
     if len(lst) <= 1:
         return lst
 

--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -12,8 +12,14 @@ For manual testing run:
 python3 gnome_sort.py
 """
 
+from typing import Protocol
 
-def gnome_sort(lst: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def gnome_sort[T: Comparable](lst: list[T]) -> list[T]:
     """
     Pure implementation of the gnome sort algorithm in Python
 
@@ -32,7 +38,12 @@ def gnome_sort(lst: list) -> list:
 
     >>> "".join(gnome_sort(list(set("Gnomes are stupid!"))))
     ' !Gadeimnoprstu'
-    """
+
+    >>> gnome_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> gnome_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     if len(lst) <= 1:
         return lst
 

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -96,6 +96,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_iterative,
         bubble_sort_recursive,
         insertion_sort,
+        gnome_sort,
     ],
     ids=lambda f: f.__name__,
 )


### PR DESCRIPTION
### Describe your change

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".

### Details

Type `gnome_sort` to accept comparable items rather than only integers.

- Adds `Comparable` typing.
- Adds comparable string/float doctests.
- Extends the existing mixed-type rejection test for `gnome_sort`.

Part of #15234. This intentionally contains one algorithm per pull request, following the issue guidance.
