### PR TITLE
sorts: type cycle sort for comparable items

### DIFF
--- a/sorts/cycle_sort.py
+++ b/sorts/cycle_sort.py
@@ -3,8 +3,14 @@ Code contributed by Honey Sharma
 Source: https://en.wikipedia.org/wiki/Cycle_sort
 """
 
+from typing import Protocol
 
-def cycle_sort(array: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def cycle_sort[T: Comparable](array: list[T]) -> list[T]:
     """
     >>> cycle_sort([4, 3, 2, 1])
     [1, 2, 3, 4]
@@ -17,7 +23,12 @@ def cycle_sort(array: list) -> list:
 
     >>> cycle_sort([])
     []
-    """
+
+    >>> cycle_sort(["d", "a", "c", "b"])
+    ['a', 'b', 'c', 'd']
+    >>> cycle_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+"""
     array_len = len(array)
     for cycle_start in range(array_len - 1):
         item = array[cycle_start]

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -96,6 +96,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_iterative,
         bubble_sort_recursive,
         insertion_sort,
+        cycle_sort,
     ],
     ids=lambda f: f.__name__,
 )


### PR DESCRIPTION
### Describe your change

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".

### Details

Type `cycle_sort` to accept comparable items rather than only integers.

- Adds `Comparable` typing.
- Adds comparable string/float doctests.
- Extends the existing mixed-type rejection test for `cycle_sort`.

Part of #15234. This intentionally contains one algorithm per pull request, following the issue guidance.
