### PR TITLE
Make gnome sort generic over comparable items

### DIFF
--- a/sorts/gnome_sort.py
+++ b/sorts/gnome_sort.py
@@ -12,8 +12,14 @@ For manual testing run:
 python3 gnome_sort.py
 """
 
+from typing import Protocol
 
-def gnome_sort(lst: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def gnome_sort[T: Comparable](lst: list[T]) -> list[T]:
     """
     Pure implementation of the gnome sort algorithm in Python
 
@@ -39,7 +45,7 @@ def gnome_sort(lst: list) -> list:
     i = 1
 
     while i < len(lst):
-        if lst[i - 1] <= lst[i]:
+        if not lst[i] < lst[i - 1]:
             i += 1
         else:
             lst[i - 1], lst[i] = lst[i], lst[i - 1]

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -96,6 +96,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_iterative,
         bubble_sort_recursive,
         circle_sort,
+        gnome_sort,
         insertion_sort,
         merge_sort,
         selection_sort,


### PR DESCRIPTION
Part of #15234

Updates `gnome_sort` to use a bounded comparable type instead of an untyped `list`.

Also adds `gnome_sort` to the shared test covering rejection of non-comparable mixed items.

Validation:
- `python -m doctest -v sorts/gnome_sort.py`
- `python -m pytest tests/test_sorts.py -k "gnome_sort or rejects_non_comparable"`
- `python -m ruff check sorts/gnome_sort.py tests/test_sorts.py`
- `python -m ruff format --check sorts/gnome_sort.py tests/test_sorts.py`
- `python -m compileall sorts/gnome_sort.py`