### PR TITLE
ci(hacktoberfest_prep): authenticate git push via gh credential helper

### DIFF
--- a/.github/workflows/hacktoberfest_prep.yml
+++ b/.github/workflows/hacktoberfest_prep.yml
@@ -80,6 +80,12 @@ jobs:
           fi
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          # `actions/checkout` runs with `persist-credentials: false`, so git has
+          # no token to authenticate the push below (it fails with
+          # `fatal: could not read Username for 'https://github.com'`). Wire the
+          # bundled `gh` in as git's credential helper so `git push` reuses
+          # GH_TOKEN — no third-party action and no token baked into the remote URL.
+          gh auth setup-git
           git switch -c "$BRANCH"
           git add docs/hacktober_2026_prep.md
           git commit -m "chore: refresh Hacktoberfest 2026 prep tracker"


### PR DESCRIPTION
### Describe your change

Fixes the `hacktoberfest_prep` scheduled/manual workflow, which has been failing on the **"Open or update the tracker pull request"** step ([example run](https://github.com/TheAlgorithms/Python/actions/runs/34416261919/job/102681709650)):

```
fatal: could not read Username for 'https://github.com': No such device or address
##[error]Process completed with exit code 128.
```

**Root cause:** the `actions/checkout` step runs with `persist-credentials: false`, so git is left with no stored token. The step then calls plain `git push`, which has nothing to authenticate with. `GH_TOKEN` is only wired into the `gh` CLI, not into git itself, so `gh pr create` would work but the `git push` before it never gets that far.

**Fix:** run `gh auth setup-git` before the push. That registers the already-bundled `gh` as git's credential helper (`credential.https://github.com.helper = !gh auth git-credential`), so `git push` reuses `GH_TOKEN`. No third-party action, and — unlike embedding the token in the remote URL — nothing secret is written into git config.

Keeping `persist-credentials: false` is deliberate (it's the safer default zizmor recommends); this just restores auth for the one push that needs it.

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm? — CI workflow fix
* [ ] Add or change tests?
* [ ] Documentation change?
