### PR TITLE
fix(maths): defer Matrix type annotations so import does not NameError

### DIFF
--- a/maths/matrix_exponentiation.py
+++ b/maths/matrix_exponentiation.py
@@ -5,6 +5,8 @@ https://zobayer.blogspot.com/2010/11/matrix-exponentiation.html
 https://www.hackerearth.com/practice/notes/matrix-exponentiation-1/
 """
 
+from __future__ import annotations
+
 import timeit
 
 


### PR DESCRIPTION
### Describe your change

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [x] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".

### Why

Importing `maths/matrix_exponentiation.py` currently raises at import time on `master`:

```
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "maths/matrix_exponentiation.py", line 20, in Matrix
    def __mul__(self, b: Matrix) -> Matrix:
                         ^^^^^^
NameError: name 'Matrix' is not defined
```

`__mul__` and `modular_exponentiation` annotate with `Matrix` before the name is bound in the class body, and annotations evaluate eagerly.

### What

Two-line fix: add `from __future__ import annotations` to defer annotation evaluation — the same pattern already used across the repo. No behavior change.

This supersedes #15103 (closed; the branch was rebased so that PR could not be reopened).

### Verification (on current `master`)

- Before: `import matrix_exponentiation` -> `NameError: name 'Matrix' is not defined`
- After: import succeeds, `fibonacci_with_matrix_exponentiation(13, 0, 1) == 144`
- `python -m doctest maths/matrix_exponentiation.py` -> 10 passed, 0 failed
- `ruff check maths/matrix_exponentiation.py` -> All checks passed!

Rebased onto current `master` per @priya-sundaram-dev's request on #15103.