### PR TITLE
fix: return the sum of squared errors

### DIFF
--- a/machine_learning/linear_regression.py
+++ b/machine_learning/linear_regression.py
@@ -67,25 +67,22 @@ def run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta):
     return theta
 
 
-def sum_of_square_error(data_x, data_y, len_data, theta):
+def sum_of_square_error(data_x, data_y, theta):
     """Return sum of square error for error calculation
     :param data_x    : contains our dataset
     :param data_y    : contains the output (result vector)
-    :param len_data  : len of the dataset
     :param theta     : contains the feature vector
     :return          : sum of square error computed from given feature's
 
     Example:
     >>> vc_x = np.array([[1.1], [2.1], [3.1]])
     >>> vc_y = np.array([1.2, 2.2, 3.2])
-    >>> round(sum_of_square_error(vc_x, vc_y, 3, np.array([1])),3)
-    np.float64(0.005)
+    >>> round(sum_of_square_error(vc_x, vc_y, np.array([1])), 3)
+    np.float64(0.03)
     """
     prod = np.dot(theta, data_x.transpose())
     prod -= data_y.transpose()
-    sum_elem = np.sum(np.square(prod))
-    error = sum_elem / (2 * len_data)
-    return error
+    return np.sum(np.square(prod))
 
 
 def run_linear_regression(data_x, data_y):
@@ -104,7 +101,7 @@ def run_linear_regression(data_x, data_y):
 
     for i in range(iterations):
         theta = run_steep_gradient_descent(data_x, data_y, len_data, alpha, theta)
-        error = sum_of_square_error(data_x, data_y, len_data, theta)
+        error = sum_of_square_error(data_x, data_y, theta)
         print(f"At Iteration {i + 1} - Error is {error:.5f}")
 
     return theta


### PR DESCRIPTION
### Describe your change

`sum_of_square_error` was documented as returning the sum of squared errors, but it divided that sum by `2 * len_data`, returning half the mean squared error instead. This made the regression error report mathematically incorrect. The fix returns the actual sum of squared errors and removes the now-unused length argument.

Fixes #8847

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All functions in the changed file have passing doctests.
* [x] The change is limited to the existing algorithm and its doctest.