### PR TITLE
fix: correct argument order in fuzzy set union

### DIFF
--- a/fuzzy_logic/fuzzy_operations.py
+++ b/fuzzy_logic/fuzzy_operations.py
@@ -57,7 +57,7 @@ class FuzzySet:
 
     # Union Operations
     >>> siya.union(sheru)
-    FuzzySet(name='Siya U Sheru', left_boundary=0.4, peak=0.7, right_boundary=1.0)
+    FuzzySet(name='Siya U Sheru', left_boundary=0.4, peak=1.0, right_boundary=0.7)
     """
 
     name: str
@@ -147,13 +147,13 @@ class FuzzySet:
             FuzzySet: A new fuzzy set representing the union.
 
         >>> FuzzySet("a", 0.1, 0.2, 0.3).union(FuzzySet("b", 0.4, 0.5, 0.6))
-        FuzzySet(name='a U b', left_boundary=0.1, peak=0.6, right_boundary=0.35)
+        FuzzySet(name='a U b', left_boundary=0.1, peak=0.35, right_boundary=0.6)
         """
         return FuzzySet(
             f"{self.name} U {other.name}",
             min(self.left_boundary, other.left_boundary),
-            max(self.right_boundary, other.right_boundary),
             (self.peak + other.peak) / 2,
+            max(self.right_boundary, other.right_boundary),
         )
 
     def plot(self):


### PR DESCRIPTION
## Description

Fixes #11871 — the fuzzy `union` method passed constructor arguments in the wrong order.

`FuzzySet` is declared as `(name, left_boundary, peak, right_boundary)`, but `union` called `FuzzySet(name, min_left, max_right, avg_peak)`, so `peak` and `right_boundary` were swapped. This swaps the last two arguments and corrects both doctests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `python -m doctest fuzzy_logic/fuzzy_operations.py` passes (22 doctests, 0 failures).