### PR TITLE
fix: validate binary_and inputs

### DIFF
--- a/bit_manipulation/binary_and_operator.py
+++ b/bit_manipulation/binary_and_operator.py
@@ -22,18 +22,25 @@ def binary_and(a: int, b: int) -> str:
     >>> binary_and(0, -1)
     Traceback (most recent call last):
         ...
-    ValueError: the value of both inputs must be positive
+    ValueError: the value of both inputs must be non-negative
     >>> binary_and(0, 1.1)
     Traceback (most recent call last):
         ...
-    ValueError: Unknown format code 'b' for object of type 'float'
+    TypeError: both inputs must be integers
     >>> binary_and("0", "1")
     Traceback (most recent call last):
         ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
+    TypeError: both inputs must be integers
+    >>> binary_and(10, "1")
+    Traceback (most recent call last):
+        ...
+    TypeError: both inputs must be integers
     """
+    if type(a) is not int or type(b) is not int:
+        raise TypeError("both inputs must be integers")
+
     if a < 0 or b < 0:
-        raise ValueError("the value of both inputs must be positive")
+        raise ValueError("the value of both inputs must be non-negative")
 
     a_binary = format(a, "b")
     b_binary = format(b, "b")


### PR DESCRIPTION
## Description

This PR improves input validation in `binary_and()`.

### Changes

* Raise `TypeError` when either input is not an integer.
* Correct the negative-input error message from "positive" to "non-negative".
* Update doctests to verify the new validation behavior.
* Add a doctest covering an invalid second argument.

### Testing

* `python -m doctest -v bit_manipulation/binary_and_operator.py`
* `ruff check bit_manipulation/binary_and_operator.py`
