### PR TITLE
sorts: type cocktail shaker sort for comparable items

### DIFF
--- a/sorts/cocktail_shaker_sort.py
+++ b/sorts/cocktail_shaker_sort.py
@@ -4,8 +4,14 @@ An implementation of the cocktail shaker sort algorithm in pure Python.
 https://en.wikipedia.org/wiki/Cocktail_shaker_sort
 """
 
+from typing import Protocol
 
-def cocktail_shaker_sort(arr: list[int]) -> list[int]:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def cocktail_shaker_sort[T: Comparable](arr: list[T]) -> list[T]:
     """
     Sorts a list using the Cocktail Shaker Sort algorithm.
 
@@ -28,6 +34,10 @@ def cocktail_shaker_sort(arr: list[int]) -> list[int]:
     Traceback (most recent call last):
         ...
     TypeError: 'tuple' object does not support item assignment
+    >>> cocktail_shaker_sort([1, "a"])  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
     """
     start, end = 0, len(arr) - 1
 

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -115,6 +115,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_iterative,
         bubble_sort_recursive,
         circle_sort,
+        cocktail_shaker_sort,
         gnome_sort,
         insertion_sort,
         merge_sort,


### PR DESCRIPTION
Part of #15234

### Describe your change

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Summary

Type cocktail_shaker_sort for mutually comparable values instead of only integers. The implementation is unchanged; its signature now preserves the element type, its doctest records the mixed-type TypeError contract, and the existing shared rejection test now covers it.

### Testing

* python3 -m doctest -v sorts/cocktail_shaker_sort.py: 8 passed
* uvx pytest sorts/cocktail_shaker_sort.py tests/test_sorts.py --doctest-modules: 231 passed
* uvx ruff check and uvx ruff format --check: passed
* uvx ty check sorts/cocktail_shaker_sort.py: passed
* uvx pre-commit run --all-files: passed

### Checklist

* [x] I have read CONTRIBUTING.md.
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [ ] This PR uses a closing keyword for #15234. This is intentionally unchecked because #15234 is a tracking issue that must remain open until all algorithms are completed.