### PR TITLE
machine_learning: add numeric doctests to gradient_descent

### DIFF
--- a/machine_learning/gradient_descent.py
+++ b/machine_learning/gradient_descent.py
@@ -24,6 +24,9 @@ def _error(example_no, data_set="train"):
     :param data_set: train data or test data
     :param example_no: example number whose error has to be checked
     :return: error in example pointed by example number.
+
+    >>> _error(0)  # hypothesis 39 minus train output 15
+    24
     """
     return calculate_hypothesis_value(example_no, data_set) - output(
         example_no, data_set
@@ -38,6 +41,9 @@ def _hypothesis_value(data_input_tuple):
     Note that there is an 'biased input' whose value is fixed as 1.
     It is not explicitly mentioned in input data.. But, ML hypothesis functions use it.
     So, we have to take care of it separately. Line 36 takes care of it.
+
+    >>> _hypothesis_value((5, 2, 3))  # 5*4 + 2*1 + 3*5 + bias 2
+    39
     """
     hyp_val = 0
     for i in range(len(parameter_vector) - 1):
@@ -51,6 +57,13 @@ def output(example_no, data_set):
     :param data_set: test data or train data
     :param example_no: example whose output is to be fetched
     :return: output for that example
+
+    >>> output(0, "train")
+    15
+    >>> output(1, "test")
+    150
+    >>> output(0, "unknown") is None
+    True
     """
     if data_set == "train":
         return train_data[example_no][1]
@@ -65,6 +78,13 @@ def calculate_hypothesis_value(example_no, data_set):
     :param data_set: test data or train_data
     :param example_no: example whose hypothesis value is to be calculated
     :return: hypothesis value for that example
+
+    >>> calculate_hypothesis_value(0, "train")
+    39
+    >>> calculate_hypothesis_value(0, "test")
+    2149
+    >>> calculate_hypothesis_value(0, "unknown") is None
+    True
     """
     if data_set == "train":
         return _hypothesis_value(train_data[example_no][0])
@@ -81,6 +101,11 @@ def summation_of_cost_derivative(index, end=m):
     :return: Returns the summation of cost derivative
     Note: If index is -1, this means we are calculating summation wrt to biased
         parameter.
+
+    >>> summation_of_cost_derivative(-1)  # sum of errors over all examples
+    243
+    >>> summation_of_cost_derivative(0)
+    2234
     """
     summation_value = 0
     for i in range(end):
@@ -97,6 +122,11 @@ def get_cost_derivative(index):
     :return: derivative wrt to that index
     Note: If index is -1, this means we are calculating summation wrt to biased
         parameter.
+
+    >>> get_cost_derivative(-1)  # 243 / 5 examples
+    48.6
+    >>> get_cost_derivative(0)  # 2234 / 5 examples
+    446.8
     """
     cost_derivative_value = summation_of_cost_derivative(index, m) / m
     return cost_derivative_value


### PR DESCRIPTION
Continues the per-file doctest effort from #13919 (after #15285 for `k_means_clust`).

### Describe your change:
Adds numeric doctests pinning the deterministic helper functions in `machine_learning/gradient_descent.py` on the module's fixed `train_data`/`test_data` and initial `parameter_vector = [2, 4, 1, 5]`:

- `output` — train/test lookup and the `None` fallback for an unknown data set
- `_hypothesis_value` / `calculate_hypothesis_value` — hypothesis value incl. bias term, plus the `None` fallback
- `summation_of_cost_derivative` and `get_cost_derivative` — bias (`index=-1`) and feature (`index=0`) cases

All values are computed from the file's own fixed data, so the tests are fully deterministic and don't touch the global-mutating `run_gradient_descent`. `python -m doctest` passes (12/12); `ruff check` and `ruff format` clean.

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one issue, please mention `Closes #{}`.