### PR TITLE
sorts: make comb_sort generic for comparable items

### DIFF
--- a/sorts/comb_sort.py
+++ b/sorts/comb_sort.py
@@ -18,8 +18,14 @@ For manual testing run:
 python comb_sort.py
 """
 
+from typing import Any, Protocol
 
-def comb_sort(data: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: Any, /) -> bool: ...
+
+
+def comb_sort[T: Comparable](data: list[T]) -> list[T]:
     """Pure implementation of comb sort algorithm in Python
     :param data: mutable collection with comparable items
     :return: the same collection in ascending order
@@ -32,6 +38,14 @@ def comb_sort(data: list) -> list:
     [-15, -7, 0, 2, 3, 8, 45, 99]
     >>> comb_sort([2, 0, 3, 4, 5, 6, 1])
     [0, 1, 2, 3, 4, 5, 6]
+    >>> comb_sort(["c", "a", "b"])
+    ['a', 'b', 'c']
+    >>> comb_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+    >>> comb_sort([1, "a"])
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
     """
     shrink_factor = 1.3
     gap = len(data)
@@ -47,7 +61,7 @@ def comb_sort(data: list) -> list:
 
         index = 0
         while index + gap < len(data):
-            if data[index] > data[index + gap]:
+            if data[index + gap] < data[index]:
                 # Swap values
                 data[index], data[index + gap] = data[index + gap], data[index]
                 completed = False

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -116,6 +116,7 @@ def test_sort_matches_builtin(sort, case):
         bubble_sort_recursive,
         circle_sort,
         cocktail_shaker_sort,
+        comb_sort,
         gnome_sort,
         insertion_sort,
         merge_sort,


### PR DESCRIPTION
Summary
. Make comb_sort generic over comparable item types
. Add doctest coverage for strings and floats
. Include comb_sort in the shared non-comparable-item rejection test

Part of #15234

AI assistance was used to help draft and review the implementation; I reviewed the changes before submission.


* [* ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [ ] This pull request is all my own work -- I have not plagiarized.
* [ *] I know that pull requests will not be merged if they fail the automated tests.
* [* ] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [* ] All new Python files are placed inside an existing directory.
* [* ] All filenames are in all lowercase characters with no spaces or dashes.
* [ *] All functions and variable names follow Python naming conventions.
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [ ] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
