### PR TITLE
sorts: make quick sort support comparable items

### DIFF
--- a/sorts/quick_sort.py
+++ b/sorts/quick_sort.py
@@ -11,9 +11,14 @@ python3 quick_sort.py
 from __future__ import annotations
 
 from random import randrange
+from typing import Protocol
 
 
-def quick_sort(collection: list) -> list:
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def quick_sort[T: Comparable](collection: list[T]) -> list[T]:
     """A pure Python implementation of quicksort algorithm.
 
     :param collection: a mutable collection of comparable items
@@ -26,18 +31,26 @@ def quick_sort(collection: list) -> list:
     []
     >>> quick_sort([-2, 5, 0, -45])
     [-45, -2, 0, 5]
+    >>> quick_sort(["banana", "apple", "cherry"])
+    ['apple', 'banana', 'cherry']
+    >>> quick_sort([3.14, 1.5, 2.7])
+    [1.5, 2.7, 3.14]
+    >>> quick_sort([1, "two"])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    TypeError: '<' not supported between instances of ...
     """
     # Base case: if the collection has 0 or 1 elements, it is already sorted
     if len(collection) < 2:
         return collection
 
-    # Randomly select a pivot index and remove the pivot element from the collection
+    # Randomly select a pivot index and remove the pivot element
     pivot_index = randrange(len(collection))
     pivot = collection.pop(pivot_index)
 
-    # Partition the remaining elements into two groups: lesser or equal, and greater
-    lesser = [item for item in collection if item <= pivot]
-    greater = [item for item in collection if item > pivot]
+    # Partition the remaining elements using the less-than comparison
+    lesser = [item for item in collection if item < pivot]
+    greater = [item for item in collection if not item < pivot]
 
     # Recursively sort the lesser and greater groups, and combine with the pivot
     return [*quick_sort(lesser), pivot, *quick_sort(greater)]


### PR DESCRIPTION
Part of #15234

## Summary
- add a Comparable protocol and generic type hints to quick_sort
- use less-than comparisons so quick_sort works with comparable item types
- add doctests for strings, floats, and non-comparable mixed values

## Tests
- python -m doctest -v .\sorts\quick_sort.py
- python -m pytest tests/test_sorts.py
- python -m ruff check .\sorts\quick_sort.py