### PR TITLE
sorts: make heap sort support comparable items

### DIFF
--- a/sorts/heap_sort.py
+++ b/sorts/heap_sort.py
@@ -2,10 +2,16 @@
 A pure Python implementation of the heap sort algorithm.
 """
 
+from typing import Protocol
 
-def heapify(unsorted: list[int], index: int, heap_size: int) -> None:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def heapify[T: Comparable](unsorted: list[T], index: int, heap_size: int) -> None:
     """
-    :param unsorted: unsorted list containing integers numbers
+    :param unsorted: unsorted list containing comparable items
     :param index: index
     :param heap_size: size of the heap
     :return: None
@@ -20,10 +26,11 @@ def heapify(unsorted: list[int], index: int, heap_size: int) -> None:
     largest = index
     left_index = 2 * index + 1
     right_index = 2 * index + 2
-    if left_index < heap_size and unsorted[left_index] > unsorted[largest]:
+
+    if left_index < heap_size and unsorted[largest] < unsorted[left_index]:
         largest = left_index
 
-    if right_index < heap_size and unsorted[right_index] > unsorted[largest]:
+    if right_index < heap_size and unsorted[largest] < unsorted[right_index]:
         largest = right_index
 
     if largest != index:
@@ -31,11 +38,11 @@ def heapify(unsorted: list[int], index: int, heap_size: int) -> None:
         heapify(unsorted, largest, heap_size)
 
 
-def heap_sort(unsorted: list[int]) -> list[int]:
+def heap_sort[T: Comparable](unsorted: list[T]) -> list[T]:
     """
-    A pure Python implementation of the heap sort algorithm
+    A pure Python implementation of the heap sort algorithm.
 
-    :param collection: a mutable ordered collection of heterogeneous comparable items
+    :param unsorted: a mutable collection of comparable items
     :return: the same collection ordered by ascending
 
     Examples:
@@ -47,13 +54,24 @@ def heap_sort(unsorted: list[int]) -> list[int]:
     [-45, -5, -2]
     >>> heap_sort([3, 7, 9, 28, 123, -5, 8, -30, -200, 0, 4])
     [-200, -30, -5, 0, 3, 4, 7, 8, 9, 28, 123]
+    >>> heap_sort(["banana", "apple", "cherry"])
+    ['apple', 'banana', 'cherry']
+    >>> heap_sort([3.14, 1.5, 2.7])
+    [1.5, 2.7, 3.14]
+    >>> heap_sort([1, "two"])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    TypeError: ...
     """
     n = len(unsorted)
+
     for i in range(n // 2 - 1, -1, -1):
         heapify(unsorted, i, n)
+
     for i in range(n - 1, 0, -1):
         unsorted[0], unsorted[i] = unsorted[i], unsorted[0]
         heapify(unsorted, 0, i)
+
     return unsorted
 
 

--- a/sorts/heap_sort.py
+++ b/sorts/heap_sort.py
@@ -64,14 +64,11 @@ def heap_sort[T: Comparable](unsorted: list[T]) -> list[T]:
     TypeError: ...
     """
     n = len(unsorted)
-
     for i in range(n // 2 - 1, -1, -1):
         heapify(unsorted, i, n)
-
     for i in range(n - 1, 0, -1):
         unsorted[0], unsorted[i] = unsorted[i], unsorted[0]
         heapify(unsorted, 0, i)
-
     return unsorted
 
 


### PR DESCRIPTION
Part of #15234

## Summary
- add a Comparable protocol and generic type hints to heap sort
- use less-than comparisons so heap sort works with comparable item types
- add doctests for strings, floats, and non-comparable mixed values

## Tests
- python -m doctest -v .\sorts\heap_sort.py
- python -m pytest tests/test_sorts.py
- python -m ruff check .\sorts\heap_sort.py

### Describe your change

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md)
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".