### PR TITLE
sorts: make cycle sort support comparable items

### DIFF
--- a/sorts/cycle_sort.py
+++ b/sorts/cycle_sort.py
@@ -3,26 +3,38 @@ Code contributed by Honey Sharma
 Source: https://en.wikipedia.org/wiki/Cycle_sort
 """
 
+from typing import Protocol
 
-def cycle_sort(array: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def cycle_sort[T: Comparable](array: list[T]) -> list[T]:
     """
     >>> cycle_sort([4, 3, 2, 1])
     [1, 2, 3, 4]
-
     >>> cycle_sort([-4, 20, 0, -50, 100, -1])
     [-50, -4, -1, 0, 20, 100]
-
     >>> cycle_sort([-.1, -.2, 1.3, -.8])
     [-0.8, -0.2, -0.1, 1.3]
-
     >>> cycle_sort([])
     []
+    >>> cycle_sort(["banana", "apple", "cherry"])
+    ['apple', 'banana', 'cherry']
+    >>> cycle_sort([3.14, 1.5, 2.7])
+    [1.5, 2.7, 3.14]
+    >>> cycle_sort([1, "two"])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    TypeError: ...
     """
     array_len = len(array)
+
     for cycle_start in range(array_len - 1):
         item = array[cycle_start]
-
         pos = cycle_start
+
         for i in range(cycle_start + 1, array_len):
             if array[i] < item:
                 pos += 1
@@ -34,8 +46,10 @@ def cycle_sort(array: list) -> list:
             pos += 1
 
         array[pos], item = item, array[pos]
+
         while pos != cycle_start:
             pos = cycle_start
+
             for i in range(cycle_start + 1, array_len):
                 if array[i] < item:
                     pos += 1


### PR DESCRIPTION
Part of #15234

## Summary
- add a Comparable protocol and generic type hints to cycle sort
- use less-than comparisons so cycle sort works with comparable item types
- add doctests for strings, floats, and non-comparable mixed values

## Tests
- python -m doctest -v .\sorts\cycle_sort.py
- python -m pytest tests/test_sorts.py
- python -m ruff check .\sorts\cycle_sort.py

### Describe your change

* [ ] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md)
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [ ] All new Python files are placed inside an existing directory.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a closing keyword: "Fixes #ISSUE-NUMBER".