### PR TITLE
sorts: type shell_sort for comparable items and add tests

### DIFF
--- a/sorts/shell_sort.py
+++ b/sorts/shell_sort.py
@@ -2,8 +2,15 @@
 https://en.wikipedia.org/wiki/Shellsort#Pseudocode
 """
 
+from collections.abc import MutableSequence
+from typing import Any, Protocol
 
-def shell_sort(collection: list[int]) -> list[int]:
+
+class Comparable(Protocol):
+    def __lt__(self, other: Any, /) -> bool: ...
+
+
+def shell_sort[T: Comparable](collection: MutableSequence[T]) -> MutableSequence[T]:
     """Pure implementation of shell sort algorithm in Python
     :param collection:  Some mutable ordered collection with heterogeneous
     comparable items inside
@@ -15,6 +22,15 @@ def shell_sort(collection: list[int]) -> list[int]:
     []
     >>> shell_sort([-2, -5, -45])
     [-45, -5, -2]
+    >>> shell_sort(["c", "a", "b"])
+    ['a', 'b', 'c']
+    >>> shell_sort([2.5, -1, 0.0])
+    [-1, 0.0, 2.5]
+    >>> shell_sort(["c", "a", "b"]) == sorted(["c", "a", "b"])
+    True
+    >>> import pytest
+    >>> with pytest.raises(TypeError):
+    ...     shell_sort([1, "a"])
     """
     # Marcin Ciura's gap sequence
 

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -121,6 +121,7 @@ def test_sort_matches_builtin(sort, case):
         insertion_sort,
         merge_sort,
         selection_sort,
+        shell_sort,
     ],
     ids=lambda f: f.__name__,
 )


### PR DESCRIPTION
## Summary

Update `shell_sort` so it is typed and tested for any mutually comparable items, not only `list[int]`.

Part of #15234

## Motivation

Issue #15234 asks for one comparison sort per PR:
- switch `list[int]` to a `Comparable` protocol + type parameter
- add succeed cases for non-int comparables
- assert `TypeError` when items are not comparable

`shell_sort.py` was still unchecked and unclaimed.

## Implementation

- Annotate `shell_sort` as `shell_sort[T: Comparable](collection: MutableSequence[T]) -> MutableSequence[T]` using the same `Comparable` protocol as `insertion_sort` / `selection_sort`.
- Leave the Marcin Ciura gap-sequence implementation unchanged.
- Add doctests for strings, mixed int/float values, and a `TypeError` on `[1, "a"]`.
- Include `shell_sort` in `test_sort_rejects_non_comparable_items` in `tests/test_sorts.py`. It was already in the shared `SORTS` battery.

## Testing

Ran locally against current `master`:

```
python3 -m doctest -v sorts/shell_sort.py
# 8 passed

python3 -m pytest tests/test_sorts.py -k "shell_sort or rejects" -q
# 22 passed, 210 deselected
```
