### PR TITLE
ruff rule ANN204 missing-return-type-special-method

### DIFF
--- a/ciphers/xor_cipher.py
+++ b/ciphers/xor_cipher.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 
 class XORCipher:
-    def __init__(self, key: int = 0):
+    def __init__(self, key: int = 0) -> None:
         """
         simple constructor that receives a key or uses
         default key = 0

--- a/computer_vision/harris_corner.py
+++ b/computer_vision/harris_corner.py
@@ -8,7 +8,7 @@ https://en.wikipedia.org/wiki/Harris_Corner_Detector
 
 
 class HarrisCorner:
-    def __init__(self, k: float, window_size: int):
+    def __init__(self, k: float, window_size: int) -> None:
         """
         k : is an empirically determined constant in [0.04,0.06]
         window_size : neighbourhoods considered

--- a/data_compression/huffman.py
+++ b/data_compression/huffman.py
@@ -4,7 +4,7 @@ import sys
 
 
 class Letter:
-    def __init__(self, letter: str, freq: int):
+    def __init__(self, letter: str, freq: int) -> None:
         self.letter: str = letter
         self.freq: int = freq
         self.bitstring: dict[str, str] = {}
@@ -14,7 +14,9 @@ class Letter:
 
 
 class TreeNode:
-    def __init__(self, freq: int, left: Letter | TreeNode, right: Letter | TreeNode):
+    def __init__(
+        self, freq: int, left: Letter | TreeNode, right: Letter | TreeNode
+    ) -> None:
         self.freq: int = freq
         self.left: Letter | TreeNode = left
         self.right: Letter | TreeNode = right

--- a/data_structures/binary_tree/segment_tree.py
+++ b/data_structures/binary_tree/segment_tree.py
@@ -2,7 +2,7 @@ import math
 
 
 class SegmentTree:
-    def __init__(self, a):
+    def __init__(self, a) -> None:
         self.A = a
         self.N = len(self.A)
         self.st = [0] * (

--- a/data_structures/binary_tree/segment_tree_other.py
+++ b/data_structures/binary_tree/segment_tree_other.py
@@ -9,7 +9,7 @@ from queue import Queue
 
 
 class SegmentTreeNode:
-    def __init__(self, start, end, val, left=None, right=None):
+    def __init__(self, start, end, val, left=None, right=None) -> None:
         self.start = start
         self.end = end
         self.val = val
@@ -17,7 +17,7 @@ class SegmentTreeNode:
         self.left = left
         self.right = right
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"SegmentTreeNode(start={self.start}, end={self.end}, val={self.val})"
 
 
@@ -127,7 +127,7 @@ class SegmentTree:
     >>>
     """
 
-    def __init__(self, collection: Sequence, function):
+    def __init__(self, collection: Sequence, function) -> None:
         self.collection = collection
         self.fn = function
         if self.collection:

--- a/data_structures/binary_tree/treap.py
+++ b/data_structures/binary_tree/treap.py
@@ -9,7 +9,7 @@ class Node:
     Treap is a binary tree by value and heap by priority
     """
 
-    def __init__(self, value: int | None = None):
+    def __init__(self, value: int | None = None) -> None:
         self.value = value
         self.prior = random()
         self.left: Node | None = None

--- a/data_structures/hashing/double_hash.py
+++ b/data_structures/hashing/double_hash.py
@@ -21,7 +21,7 @@ class DoubleHash(HashTable):
     Hash Table example with open addressing and Double Hash
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def __hash_function_2(self, value, data):

--- a/data_structures/hashing/hash_table_with_linked_list.py
+++ b/data_structures/hashing/hash_table_with_linked_list.py
@@ -4,7 +4,7 @@ from .hash_table import HashTable
 
 
 class HashTableWithLinkedList(HashTable):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def _set_value(self, key, data):

--- a/data_structures/hashing/quadratic_probing.py
+++ b/data_structures/hashing/quadratic_probing.py
@@ -8,7 +8,7 @@ class QuadraticProbing(HashTable):
     Basic Hash Table example with open addressing using Quadratic Probing
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def _collision_resolution(self, key, data=None):  # noqa: ARG002

--- a/data_structures/heap/binomial_heap.py
+++ b/data_structures/heap/binomial_heap.py
@@ -12,7 +12,7 @@ class Node:
         - link to left, right and parent nodes
     """
 
-    def __init__(self, val):
+    def __init__(self, val) -> None:
         self.val = val
         # Number of nodes in left subtree
         self.left_tree_size = 0
@@ -123,7 +123,7 @@ class BinomialHeap:
     [17, 20, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 34]
     """
 
-    def __init__(self, bottom_root=None, min_node=None, heap_size=0):
+    def __init__(self, bottom_root=None, min_node=None, heap_size=0) -> None:
         self.size = heap_size
         self.bottom_root = bottom_root
         self.min_node = min_node
@@ -384,7 +384,7 @@ class BinomialHeap:
         else:
             preorder.append(("#", level))
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Overwriting str for a pre-order print of nodes in heap;
         Performance is poor, so use only for small examples

--- a/data_structures/heap/max_heap.py
+++ b/data_structures/heap/max_heap.py
@@ -16,7 +16,7 @@ class BinaryHeap:
     2
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__heap = [0]
         self.__size = 0
 
@@ -63,7 +63,7 @@ class BinaryHeap:
     def get_list(self):
         return self.__heap[1:]
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Length of the array"""
         return self.__size
 

--- a/data_structures/heap/min_heap.py
+++ b/data_structures/heap/min_heap.py
@@ -3,11 +3,11 @@
 
 
 class Node:
-    def __init__(self, name, val):
+    def __init__(self, name, val) -> None:
         self.name = name
         self.val = val
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name}, {self.val})"
 
     def __lt__(self, other):
@@ -31,7 +31,7 @@ class MinHeap:
     -17
     """
 
-    def __init__(self, array):
+    def __init__(self, array) -> None:
         self.idx_of_element = {}
         self.heap_dict = {}
         self.heap = self.build_heap(array)

--- a/data_structures/linked_list/deque_doubly.py
+++ b/data_structures/linked_list/deque_doubly.py
@@ -14,7 +14,7 @@ class _DoublyLinkedBase:
     class _Node:
         __slots__ = "_data", "_next", "_prev"
 
-        def __init__(self, link_p, element, link_n):
+        def __init__(self, link_p, element, link_n) -> None:
             self._prev = link_p
             self._data = element
             self._next = link_n
@@ -24,14 +24,14 @@ class _DoublyLinkedBase:
                 f" Prev -> {self._prev is not None}, Next -> {self._next is not None}"
             )
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._header = self._Node(None, None, None)
         self._trailer = self._Node(None, None, None)
         self._header._next = self._trailer
         self._trailer._prev = self._header
         self._size = 0
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._size
 
     def is_empty(self):

--- a/data_structures/linked_list/doubly_linked_list.py
+++ b/data_structures/linked_list/doubly_linked_list.py
@@ -8,17 +8,17 @@ from typing import Any
 
 
 class Node:
-    def __init__(self, data: Any):
+    def __init__(self, data: Any) -> None:
         self.data = data
         self.previous: Node | None = None
         self.next: Node | None = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.data}"
 
 
 class DoublyLinkedList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.head: Node | None = None
         self.tail: Node | None = None
 
@@ -36,7 +36,7 @@ class DoublyLinkedList:
             yield node.data
             node = node.next
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         >>> linked_list = DoublyLinkedList()
         >>> linked_list.insert_at_tail('a')
@@ -47,7 +47,7 @@ class DoublyLinkedList:
         """
         return "->".join([str(item) for item in self])
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         >>> linked_list = DoublyLinkedList()
         >>> for i in range(0, 5):

--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -26,7 +26,7 @@ class Node[DataType]:
 
 
 class LinkedListIterator:
-    def __init__(self, head):
+    def __init__(self, head) -> None:
         self.current = head
 
     def __iter__(self):
@@ -46,7 +46,7 @@ class LinkedList:
     head: Node | None = None  # First node in list
     tail: Node | None = None  # Last node in list
 
-    def __str__(self):
+    def __str__(self) -> str:
         current = self.head
         nodes = []
         while current is not None:
@@ -54,7 +54,7 @@ class LinkedList:
             current = current.next
         return " ".join(str(node) for node in nodes)
 
-    def __contains__(self, value: DataType):
+    def __contains__(self, value: DataType) -> bool:
         current = self.head
         while current:
             if current.data == value:

--- a/data_structures/linked_list/from_sequence.py
+++ b/data_structures/linked_list/from_sequence.py
@@ -5,11 +5,11 @@ print a string representation of it.
 
 
 class Node:
-    def __init__(self, data=None):
+    def __init__(self, data=None) -> None:
         self.data = data
         self.next = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a visual representation of the node and all its following nodes."""
         string_rep = ""
         temp = self

--- a/data_structures/linked_list/middle_element_of_linked_list.py
+++ b/data_structures/linked_list/middle_element_of_linked_list.py
@@ -8,7 +8,7 @@ class Node:
 
 
 class LinkedList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.head = None
 
     def push(self, new_data: int) -> int:

--- a/data_structures/linked_list/singly_linked_list.py
+++ b/data_structures/linked_list/singly_linked_list.py
@@ -38,7 +38,7 @@ class Node:
 
 
 class LinkedList:
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Create and initialize LinkedList class instance.
         >>> linked_list = LinkedList()

--- a/data_structures/linked_list/skip_list.py
+++ b/data_structures/linked_list/skip_list.py
@@ -14,7 +14,7 @@ VT = TypeVar("VT")
 
 
 class Node[KT, VT]:
-    def __init__(self, key: KT | str = "root", value: VT | None = None):
+    def __init__(self, key: KT | str = "root", value: VT | None = None) -> None:
         self.key = key
         self.value = value
         self.forward: list[Node[KT, VT]] = []
@@ -50,7 +50,7 @@ class Node[KT, VT]:
 
 
 class SkipList[KT, VT]:
-    def __init__(self, p: float = 0.5, max_level: int = 16):
+    def __init__(self, p: float = 0.5, max_level: int = 16) -> None:
         self.head: Node[KT, VT] = Node[KT, VT]()
         self.level = 0
         self.p = p

--- a/data_structures/queues/circular_queue.py
+++ b/data_structures/queues/circular_queue.py
@@ -4,7 +4,7 @@
 class CircularQueue:
     """Circular FIFO queue with a fixed capacity"""
 
-    def __init__(self, n: int):
+    def __init__(self, n: int) -> None:
         self.n = n
         self.array = [None] * self.n
         self.front = 0  # index of the first element

--- a/data_structures/queues/priority_queue_using_list.py
+++ b/data_structures/queues/priority_queue_using_list.py
@@ -66,7 +66,7 @@ class FixedPriorityQueue:
     Priority 2: []
     """  # noqa: E501
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.queues = [
             [],
             [],
@@ -146,7 +146,7 @@ class ElementPriorityQueue:
     []
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.queue = []
 
     def enqueue(self, data: int) -> None:

--- a/data_structures/queues/queue_on_pseudo_stack.py
+++ b/data_structures/queues/queue_on_pseudo_stack.py
@@ -4,11 +4,11 @@ from typing import Any
 
 
 class Queue:
-    def __init__(self):
+    def __init__(self) -> None:
         self.stack = []
         self.length = 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         printed = "<" + str(self.stack)[1:-1] + ">"
         return printed
 

--- a/data_structures/stacks/stack.py
+++ b/data_structures/stacks/stack.py
@@ -22,7 +22,7 @@ class Stack[T]:
     https://en.wikipedia.org/wiki/Stack_(abstract_data_type)
     """
 
-    def __init__(self, limit: int = 10):
+    def __init__(self, limit: int = 10) -> None:
         self.stack: list[T] = []
         self.limit = limit
 

--- a/data_structures/stacks/stack_with_doubly_linked_list.py
+++ b/data_structures/stacks/stack_with_doubly_linked_list.py
@@ -9,7 +9,7 @@ T = TypeVar("T")
 
 
 class Node[T]:
-    def __init__(self, data: T):
+    def __init__(self, data: T) -> None:
         self.data = data  # Assign data
         self.next: Node[T] | None = None  # Initialize next as null
         self.prev: Node[T] | None = None  # Initialize prev as null

--- a/data_structures/stacks/stack_with_singly_linked_list.py
+++ b/data_structures/stacks/stack_with_singly_linked_list.py
@@ -9,7 +9,7 @@ T = TypeVar("T")
 
 
 class Node[T]:
-    def __init__(self, data: T):
+    def __init__(self, data: T) -> None:
         self.data = data
         self.next: Node[T] | None = None
 

--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -16,7 +16,7 @@ class Burkes:
         * This implementation get RGB image and converts it to greyscale in runtime.
     """
 
-    def __init__(self, input_img, threshold: int):
+    def __init__(self, input_img, threshold: int) -> None:
         self.min_threshold = 0
         # max greyscale value for #FFFFFF
         self.max_threshold = int(self.get_greyscale(255, 255, 255))

--- a/digital_image_processing/histogram_equalization/histogram_stretch.py
+++ b/digital_image_processing/histogram_equalization/histogram_stretch.py
@@ -13,7 +13,7 @@ from matplotlib import pyplot as plt
 
 
 class ConstantStretch:
-    def __init__(self):
+    def __init__(self) -> None:
         self.img = ""
         self.original_image = ""
         self.last_list = []

--- a/digital_image_processing/index_calculation.py
+++ b/digital_image_processing/index_calculation.py
@@ -104,7 +104,9 @@ class IndexCalculation:
         #RGBIndex = ["GLI", "CI", "Hue", "I", "NGRDI", "RI", "S", "IF"]
     """
 
-    def __init__(self, red=None, green=None, blue=None, red_edge=None, nir=None):
+    def __init__(
+        self, red=None, green=None, blue=None, red_edge=None, nir=None
+    ) -> None:
         self.set_matricies(red=red, green=green, blue=blue, red_edge=red_edge, nir=nir)
 
     def set_matricies(self, red=None, green=None, blue=None, red_edge=None, nir=None):

--- a/digital_image_processing/resize/resize.py
+++ b/digital_image_processing/resize/resize.py
@@ -10,7 +10,7 @@ class NearestNeighbour:
     Source: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation
     """
 
-    def __init__(self, img, dst_width: int, dst_height: int):
+    def __init__(self, img, dst_width: int, dst_height: int) -> None:
         if dst_width < 0 or dst_height < 0:
             raise ValueError("Destination width/height should be > 0")
 

--- a/divide_and_conquer/convex_hull.py
+++ b/divide_and_conquer/convex_hull.py
@@ -45,7 +45,7 @@ class Point:
     ValueError: could not convert string to float: 'pi'
     """
 
-    def __init__(self, x, y):
+    def __init__(self, x, y) -> None:
         self.x, self.y = float(x), float(y)
 
     def __eq__(self, other):
@@ -78,7 +78,7 @@ class Point:
             return self.y <= other.y
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"({self.x}, {self.y})"
 
     def __hash__(self):

--- a/dynamic_programming/bitmask.py
+++ b/dynamic_programming/bitmask.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 
 class AssignmentUsingBitmask:
-    def __init__(self, task_performed, total):
+    def __init__(self, task_performed, total) -> None:
         self.total_tasks = total  # total no of tasks (N)
 
         # DP table will have a dimension of (2^M)*N

--- a/dynamic_programming/edit_distance.py
+++ b/dynamic_programming/edit_distance.py
@@ -18,7 +18,7 @@ class EditDistance:
     editDistanceResult  = solver.solve(firstString, secondString)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.word1 = ""
         self.word2 = ""
         self.dp = []

--- a/dynamic_programming/floyd_warshall.py
+++ b/dynamic_programming/floyd_warshall.py
@@ -2,7 +2,7 @@ import math
 
 
 class Graph:
-    def __init__(self, n=0):  # a graph with Node 0,1,...,N-1
+    def __init__(self, n=0) -> None:  # a graph with Node 0,1,...,N-1
         self.n = n
         self.w = [
             [math.inf for j in range(n)] for i in range(n)

--- a/dynamic_programming/optimal_binary_search_tree.py
+++ b/dynamic_programming/optimal_binary_search_tree.py
@@ -23,11 +23,11 @@ from random import randint
 class Node:
     """Binary Search Tree Node"""
 
-    def __init__(self, key, freq):
+    def __init__(self, key, freq) -> None:
         self.key = key
         self.freq = freq
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         >>> str(Node(1, 2))
         'Node(key=1, freq=2)'

--- a/graphics/bezier_curve.py
+++ b/graphics/bezier_curve.py
@@ -12,7 +12,7 @@ class BezierCurve:
     This implementation works only for 2d coordinates in the xy plane.
     """
 
-    def __init__(self, list_of_points: list[tuple[float, float]]):
+    def __init__(self, list_of_points: list[tuple[float, float]]) -> None:
         """
         list_of_points: Control points in the xy plane on which to interpolate. These
             points control the behavior (shape) of the Bezier curve.

--- a/graphs/bidirectional_a_star.py
+++ b/graphs/bidirectional_a_star.py
@@ -91,7 +91,7 @@ class AStar:
      (4, 3), (4, 4), (5, 4), (5, 5), (6, 5), (6, 6)]
     """
 
-    def __init__(self, start: TPosition, goal: TPosition):
+    def __init__(self, start: TPosition, goal: TPosition) -> None:
         self.start = Node(start[1], start[0], goal[1], goal[0], 0, None)
         self.target = Node(goal[1], goal[0], goal[1], goal[0], 99999, None)
 

--- a/graphs/bidirectional_breadth_first_search.py
+++ b/graphs/bidirectional_breadth_first_search.py
@@ -24,7 +24,7 @@ delta = [[-1, 0], [0, -1], [1, 0], [0, 1]]  # up, left, down, right
 class Node:
     def __init__(
         self, pos_x: int, pos_y: int, goal_x: int, goal_y: int, parent: Node | None
-    ):
+    ) -> None:
         self.pos_x = pos_x
         self.pos_y = pos_y
         self.pos = (pos_y, pos_x)
@@ -52,7 +52,7 @@ class BreadthFirstSearch:
      (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (6, 5), (6, 6)]
     """
 
-    def __init__(self, start: tuple[int, int], goal: tuple[int, int]):
+    def __init__(self, start: tuple[int, int], goal: tuple[int, int]) -> None:
         self.start = Node(start[1], start[0], goal[1], goal[0], None)
         self.target = Node(goal[1], goal[0], goal[1], goal[0], None)
 
@@ -122,7 +122,7 @@ class BidirectionalBreadthFirstSearch:
      (2, 4), (3, 4), (3, 5), (3, 6), (4, 6), (5, 6), (6, 6)]
     """
 
-    def __init__(self, start, goal):
+    def __init__(self, start, goal) -> None:
         self.fwd_bfs = BreadthFirstSearch(start, goal)
         self.bwd_bfs = BreadthFirstSearch(goal, start)
         self.reached = False

--- a/graphs/breadth_first_search_zero_one_shortest_path.py
+++ b/graphs/breadth_first_search_zero_one_shortest_path.py
@@ -22,7 +22,7 @@ class Edge:
 class AdjacencyList:
     """Graph adjacency list."""
 
-    def __init__(self, size: int):
+    def __init__(self, size: int) -> None:
         self._graph: list[list[Edge]] = [[] for _ in range(size)]
         self._size = size
 

--- a/graphs/depth_first_search_2.py
+++ b/graphs/depth_first_search_2.py
@@ -4,7 +4,7 @@
 
 
 class Graph:
-    def __init__(self):
+    def __init__(self) -> None:
         self.vertex = {}
 
     # for printing the Graph vertices

--- a/graphs/dijkstra_algorithm.py
+++ b/graphs/dijkstra_algorithm.py
@@ -10,7 +10,7 @@ import sys
 
 class PriorityQueue:
     # Based on Min Heap
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Priority queue class constructor method.
 
@@ -211,7 +211,7 @@ class PriorityQueue:
 
 
 class Graph:
-    def __init__(self, num):
+    def __init__(self, num) -> None:
         """
         Graph class constructor
 

--- a/graphs/dinic.py
+++ b/graphs/dinic.py
@@ -2,7 +2,7 @@ INF = float("inf")
 
 
 class Dinic:
-    def __init__(self, n):
+    def __init__(self, n) -> None:
         self.lvl = [0] * n
         self.ptr = [0] * n
         self.q = [0] * n

--- a/graphs/directed_and_undirected_weighted_graph.py
+++ b/graphs/directed_and_undirected_weighted_graph.py
@@ -7,7 +7,7 @@ from time import time
 
 
 class DirectedGraph:
-    def __init__(self):
+    def __init__(self) -> None:
         self.graph = {}
 
     # adding vertices and edges
@@ -262,7 +262,7 @@ class DirectedGraph:
 
 
 class Graph:
-    def __init__(self):
+    def __init__(self) -> None:
         self.graph = {}
 
     # adding vertices and edges

--- a/graphs/edmonds_karp_multiple_source_and_sink.py
+++ b/graphs/edmonds_karp_multiple_source_and_sink.py
@@ -1,5 +1,5 @@
 class FlowNetwork:
-    def __init__(self, graph, sources, sinks):
+    def __init__(self, graph, sources, sinks) -> None:
         self.source_index = None
         self.sink_index = None
         self.graph = graph
@@ -58,7 +58,7 @@ class FlowNetwork:
 
 
 class FlowNetworkAlgorithmExecutor:
-    def __init__(self, flow_network):
+    def __init__(self, flow_network) -> None:
         self.flow_network = flow_network
         self.verticies_count = flow_network.verticesCount
         self.source_index = flow_network.sourceIndex
@@ -79,7 +79,7 @@ class FlowNetworkAlgorithmExecutor:
 
 
 class MaximumFlowAlgorithmExecutor(FlowNetworkAlgorithmExecutor):
-    def __init__(self, flow_network):
+    def __init__(self, flow_network) -> None:
         super().__init__(flow_network)
         # use this to save your result
         self.maximum_flow = -1
@@ -92,7 +92,7 @@ class MaximumFlowAlgorithmExecutor(FlowNetworkAlgorithmExecutor):
 
 
 class PushRelabelExecutor(MaximumFlowAlgorithmExecutor):
-    def __init__(self, flow_network):
+    def __init__(self, flow_network) -> None:
         super().__init__(flow_network)
 
         self.preflow = [[0] * self.verticies_count for i in range(self.verticies_count)]

--- a/graphs/greedy_best_first.py
+++ b/graphs/greedy_best_first.py
@@ -61,7 +61,7 @@ class Node:
         goal_y: int,
         g_cost: float,
         parent: Node | None,
-    ):
+    ) -> None:
         self.pos_x = pos_x
         self.pos_y = pos_y
         self.pos = (pos_y, pos_x)
@@ -106,7 +106,7 @@ class GreedyBestFirst:
 
     def __init__(
         self, grid: list[list[int]], start: tuple[int, int], goal: tuple[int, int]
-    ):
+    ) -> None:
         self.grid = grid
         self.start = Node(start[1], start[0], goal[1], goal[0], 0, None)
         self.target = Node(goal[1], goal[0], goal[1], goal[0], 99999, None)

--- a/graphs/markov_chain.py
+++ b/graphs/markov_chain.py
@@ -9,7 +9,7 @@ class MarkovChainGraphUndirectedUnweighted:
     Undirected Unweighted Graph for running Markov Chain Algorithm
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.connections = {}
 
     def add_node(self, node: str) -> None:

--- a/graphs/minimum_spanning_tree_boruvka.py
+++ b/graphs/minimum_spanning_tree_boruvka.py
@@ -3,7 +3,7 @@ class Graph:
     Data structure to store graphs (based on adjacency lists)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.num_vertices = 0
         self.num_edges = 0
         self.adjacency = {}
@@ -54,7 +54,7 @@ class Graph:
             self.adjacency[head][tail] = weight
             self.adjacency[tail][head] = weight
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Returns string representation of the graph
         """
@@ -103,11 +103,11 @@ class Graph:
         Disjoint set Union and Find for Boruvka's algorithm
         """
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.parent = {}
             self.rank = {}
 
-        def __len__(self):
+        def __len__(self) -> int:
             return len(self.parent)
 
         def make_set(self, item):

--- a/graphs/minimum_spanning_tree_prims.py
+++ b/graphs/minimum_spanning_tree_prims.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 
 class Heap:
-    def __init__(self):
+    def __init__(self) -> None:
         self.node_position = []
 
     def get_position(self, vertex):

--- a/graphs/multi_heuristic_astar.py
+++ b/graphs/multi_heuristic_astar.py
@@ -7,7 +7,7 @@ TPos = tuple[int, int]
 
 
 class PriorityQueue:
-    def __init__(self):
+    def __init__(self) -> None:
         self.elements = []
         self.set = set()
 

--- a/graphs/page_rank.py
+++ b/graphs/page_rank.py
@@ -16,7 +16,7 @@ graph = [[0, 1, 1], [0, 0, 1], [1, 0, 0]]
 
 
 class Node:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
         self.inbound = []
         self.outbound = []
@@ -27,7 +27,7 @@ class Node:
     def add_outbound(self, node):
         self.outbound.append(node)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<node={self.name} inbound={self.inbound} outbound={self.outbound}>"
 
 

--- a/graphs/prim.py
+++ b/graphs/prim.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 class Vertex:
     """Class Vertex."""
 
-    def __init__(self, id_):
+    def __init__(self, id_) -> None:
         """
         Arguments:
             id - input an id to identify the vertex
@@ -31,7 +31,7 @@ class Vertex:
         """Comparison rule to < operator."""
         return self.key < other.key
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the vertex id."""
         return self.id
 

--- a/hashes/sha1.py
+++ b/hashes/sha1.py
@@ -38,7 +38,7 @@ class SHA1Hash:
     '872af2d8ac3d8695387e7c804bf0e02c18df9e6e'
     """
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         """
         Initiates the variables data and h. h is a list of 5 8-digit hexadecimal
         numbers corresponding to

--- a/machine_learning/astar.py
+++ b/machine_learning/astar.py
@@ -24,7 +24,7 @@ class Cell:
     g, h, f: Parameters used when calling our heuristic function.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.position = (0, 0)
         self.parent = None
         self.g = 0
@@ -50,7 +50,7 @@ class Gridworld:
     world_size: create a numpy array with the given world_size default is 5.
     """
 
-    def __init__(self, world_size=(5, 5)):
+    def __init__(self, world_size=(5, 5)) -> None:
         self.w = np.zeros(world_size)
         self.world_x_limit = world_size[0]
         self.world_y_limit = world_size[1]

--- a/machine_learning/decision_tree.py
+++ b/machine_learning/decision_tree.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 class DecisionTree:
-    def __init__(self, depth=5, min_leaf_size=5):
+    def __init__(self, depth=5, min_leaf_size=5) -> None:
         self.depth = depth
         self.decision_boundary = 0
         self.left = None

--- a/machine_learning/sequential_minimum_optimization.py
+++ b/machine_learning/sequential_minimum_optimization.py
@@ -54,7 +54,7 @@ class SmoSVM:
         b=0.0,
         tolerance=0.001,
         auto_norm=True,
-    ):
+    ) -> None:
         self._init = True
         self._auto_norm = auto_norm
         self._c = np.float64(cost)
@@ -402,7 +402,7 @@ class SmoSVM:
 
 
 class Kernel:
-    def __init__(self, kernel, degree=1.0, coef0=0.0, gamma=1.0):
+    def __init__(self, kernel, degree=1.0, coef0=0.0, gamma=1.0) -> None:
         self.degree = np.float64(degree)
         self.coef0 = np.float64(coef0)
         self.gamma = np.float64(gamma)
@@ -430,7 +430,7 @@ class Kernel:
     def __call__(self, v1, v2):
         return self._kernel(v1, v2)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self._kernel_name
 
 

--- a/maths/dual_number_automatic_differentiation.py
+++ b/maths/dual_number_automatic_differentiation.py
@@ -9,14 +9,14 @@ Note this only works for basic functions, f(x) where the power of x is positive.
 
 
 class Dual:
-    def __init__(self, real, rank):
+    def __init__(self, real, rank) -> None:
         self.real = real
         if isinstance(rank, int):
             self.duals = [1] * rank
         else:
             self.duals = rank
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = "+".join(f"{dual}E{n}" for n, dual in enumerate(self.duals, 1))
         return f"{self.real}+{s}"
 

--- a/maths/monte_carlo_dice.py
+++ b/maths/monte_carlo_dice.py
@@ -6,7 +6,7 @@ import random
 class Dice:
     NUM_SIDES = 6
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a six sided dice"""
         self.sides = list(range(1, Dice.NUM_SIDES + 1))
 

--- a/maths/pythagoras.py
+++ b/maths/pythagoras.py
@@ -4,7 +4,7 @@ import math
 
 
 class Point:
-    def __init__(self, x, y, z):
+    def __init__(self, x, y, z) -> None:
         self.x = x
         self.y = y
         self.z = z

--- a/maths/radix2_fft.py
+++ b/maths/radix2_fft.py
@@ -49,7 +49,7 @@ class FFT:
     A*B = (-0-0j)*x^0 + (2+0j)*x^1 + (3-0j)*x^2 + (8-0j)*x^3 + (6+0j)*x^4 + (8+0j)*x^5
     """
 
-    def __init__(self, poly_a=None, poly_b=None):
+    def __init__(self, poly_a=None, poly_b=None) -> None:
         # Input as list
         self.polyA = list(poly_a or [0])[:]
         self.polyB = list(poly_b or [0])[:]
@@ -157,7 +157,7 @@ class FFT:
         return inverce_c
 
     # Overwrite __str__ for print(); Shows A, B and A*B
-    def __str__(self):
+    def __str__(self) -> str:
         a = "A = " + " + ".join(
             f"{coef}*x^{i}" for i, coef in enumerate(self.polyA[: self.len_A])
         )

--- a/matrix/matrix_class.py
+++ b/matrix/matrix_class.py
@@ -107,7 +107,7 @@ class Matrix:
      [414. 513. 612. 640.]]
     """
 
-    def __init__(self, rows: list[list[int]]):
+    def __init__(self, rows: list[list[int]]) -> None:
         error = TypeError(
             "Matrices must be formed from a list of zero or more lists containing at "
             "least one and the same number of values, each of which must be of type "

--- a/neural_network/back_propagation_neural_network.py
+++ b/neural_network/back_propagation_neural_network.py
@@ -33,7 +33,7 @@ class DenseLayer:
 
     def __init__(
         self, units, activation=None, learning_rate=None, is_input_layer=False
-    ):
+    ) -> None:
         """
         common connected layer of bp network
         :param units: numbers of neural units
@@ -101,7 +101,7 @@ class BPNN:
     Back Propagation Neural Network model
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.layers = []
         self.train_mse = []
         self.fig_loss = plt.figure()

--- a/neural_network/convolution_neural_network.py
+++ b/neural_network/convolution_neural_network.py
@@ -23,7 +23,7 @@ from matplotlib import pyplot as plt
 class CNN:
     def __init__(
         self, conv1_get, size_p1, bp_num1, bp_num2, bp_num3, rate_w=0.2, rate_t=0.2
-    ):
+    ) -> None:
         """
         :param conv1_get: [a,c,d], size, number, step of convolution kernel
         :param size_p1: pooling size

--- a/neural_network/input_data.py
+++ b/neural_network/input_data.py
@@ -132,7 +132,7 @@ class _DataSet:
         dtype=dtypes.float32,
         reshape=True,
         seed=None,
-    ):
+    ) -> None:
         """Construct a _DataSet.
 
         one_hot arg is used only if fake_data is true.  `dtype` can be either

--- a/other/graham_scan.py
+++ b/other/graham_scan.py
@@ -21,7 +21,7 @@ class Direction(Enum):
     straight = 2
     right = 3
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
 
 

--- a/other/greedy.py
+++ b/other/greedy.py
@@ -1,10 +1,10 @@
 class Things:
-    def __init__(self, name, value, weight):
+    def __init__(self, name, value, weight) -> None:
         self.name = name
         self.value = value
         self.weight = weight
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name}, {self.value}, {self.weight})"
 
     def get_value(self):

--- a/other/lfu_cache.py
+++ b/other/lfu_cache.py
@@ -16,7 +16,7 @@ class DoubleLinkedListNode[T, U]:
     Node: key: 1, val: 1, freq: 0, has next: False, has prev: False
     """
 
-    def __init__(self, key: T | None, val: U | None):
+    def __init__(self, key: T | None, val: U | None) -> None:
         self.key = key
         self.val = val
         self.freq: int = 0
@@ -196,7 +196,7 @@ class LFUCache[T, U]:
     CacheInfo(hits=196, misses=100, capacity=100, current_size=100)
     """
 
-    def __init__(self, capacity: int):
+    def __init__(self, capacity: int) -> None:
         self.list: DoubleLinkedList[T, U] = DoubleLinkedList()
         self.capacity = capacity
         self.num_keys = 0

--- a/other/linear_congruential_generator.py
+++ b/other/linear_congruential_generator.py
@@ -14,7 +14,7 @@ class LinearCongruentialGenerator:
     # called once per instance and it ensures that each instance will generate a unique
     # sequence of numbers.
 
-    def __init__(self, multiplier, increment, modulo, seed=int(time())):  # noqa: B008
+    def __init__(self, multiplier, increment, modulo, seed=int(time())) -> None:  # noqa: B008
         """
         These parameters are saved and used when nextNumber() is called.
 

--- a/other/lru_cache.py
+++ b/other/lru_cache.py
@@ -15,7 +15,7 @@ class DoubleLinkedListNode[T, U]:
     Node: key: 1, val: 1, has next: False, has prev: False
     """
 
-    def __init__(self, key: T | None, val: U | None):
+    def __init__(self, key: T | None, val: U | None) -> None:
         self.key = key
         self.val = val
         self.next: DoubleLinkedListNode[T, U] | None = None
@@ -209,7 +209,7 @@ class LRUCache[T, U]:
     CacheInfo(hits=194, misses=99, capacity=100, current size=99)
     """
 
-    def __init__(self, capacity: int):
+    def __init__(self, capacity: int) -> None:
         self.list: DoubleLinkedList[T, U] = DoubleLinkedList()
         self.capacity = capacity
         self.num_keys = 0

--- a/project_euler/problem_054/sol1.py
+++ b/project_euler/problem_054/sol1.py
@@ -324,10 +324,10 @@ class PokerHand:
         card_suit = {card[-1] for card in new_hand}
         return sorted(card_values, reverse=True), card_suit
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__}("{self._hand}")'
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._hand
 
     # Rich comparison operators (used in list.sort() and sorted() builtin functions)

--- a/searches/binary_tree_traversal.py
+++ b/searches/binary_tree_traversal.py
@@ -8,7 +8,7 @@ import queue
 
 
 class TreeNode:
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self.data = data
         self.right = None
         self.left = None

--- a/sorts/external_sort.py
+++ b/sorts/external_sort.py
@@ -10,7 +10,7 @@ import os
 class FileSplitter:
     BLOCK_FILENAME_FORMAT = "block_{0}.dat"
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         self.filename = filename
         self.block_filenames = []
 
@@ -57,7 +57,7 @@ class NWayMerge:
 
 
 class FilesArray:
-    def __init__(self, files):
+    def __init__(self, files) -> None:
         self.files = files
         self.empty = set()
         self.num_buffers = len(files)
@@ -87,7 +87,7 @@ class FilesArray:
 
 
 class FileMerger:
-    def __init__(self, merge_strategy):
+    def __init__(self, merge_strategy) -> None:
         self.merge_strategy = merge_strategy
 
     def merge(self, filenames, outfilename, buffer_size):
@@ -107,7 +107,7 @@ class FileMerger:
 
 
 class ExternalSort:
-    def __init__(self, block_size):
+    def __init__(self, block_size) -> None:
         self.block_size = block_size
 
     def sort(self, filename, sort_key=None):

--- a/strings/aho_corasick.py
+++ b/strings/aho_corasick.py
@@ -4,7 +4,7 @@ from collections import deque
 
 
 class Automaton:
-    def __init__(self, keywords: list[str]):
+    def __init__(self, keywords: list[str]) -> None:
         self.adlist: list[dict] = []
         self.adlist.append(
             {"value": "", "next_states": [], "fail_state": 0, "output": []}

--- a/strings/boyer_moore_search.py
+++ b/strings/boyer_moore_search.py
@@ -32,7 +32,7 @@ class BoyerMooreSearch:
     where 'positions' contain the locations where the pattern was matched.
     """
 
-    def __init__(self, text: str, pattern: str):
+    def __init__(self, text: str, pattern: str) -> None:
         self.text, self.pattern = text, pattern
         self.textLen, self.patLen = len(text), len(pattern)
 

--- a/web_programming/instagram_crawler.py
+++ b/web_programming/instagram_crawler.py
@@ -41,7 +41,7 @@ class InstagramUser:
     'Built for developers.'
     """
 
-    def __init__(self, username):
+    def __init__(self, username) -> None:
         self.url = f"https://www.instagram.com/{username}/"
         self.user_data = self.get_json()
 


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/missing-return-type-special-method/

@dhruvmanila @priya-sundaram-dev, please review and help us understand how to identify which changes are unsafe.

% `git checkout -b ruff-rule-ANN204-unsafe-fixes`

% `ruff check --select=ANN204 --statistics`
```
154	ANN204	missing-return-type-special-method
Found 154 errors.
No fixes available (121 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
% `ruff check --select=ANN204 --fix --unsafe-fixes --silent`

% `ruff check --select=ANN204 --statistics`
```
33	ANN204	missing-return-type-special-method
Found 33 errors.
```
% `git commit -am"ruff rule ANN204 missing-return-type-private-function" && git push`
```
% `ruff rule ANN204`
# missing-return-type-special-method (ANN204)

Derived from the **flake8-annotations** linter.

Fix is sometimes available.

## What it does
Checks that "special" methods, like `__init__`, `__new__`, and `__call__`, have
return type annotations.

## Why is this bad?
Type annotations are a good way to document the return types of functions. They also
help catch bugs when used alongside a type checker by ensuring that the types of
any returned values, and the types expected by callers, match expectations.

Note that type checkers often allow you to omit the return type annotation for
`__init__` methods, as long as at least one argument has a type annotation. To
opt in to this behavior, use the `mypy-init-return` setting in your `pyproject.toml`
or `ruff.toml` file:

```toml
[tool.ruff.lint.flake8-annotations]
mypy-init-return = true
```

## Example
```python
class Foo:
    def __init__(self, x: int):
        self.x = x
```

Use instead:
```python
class Foo:
    def __init__(self, x: int) -> None:
        self.x = x
```

## Options

- `lint.flake8-annotations.mypy-init-return`
