### PR TITLE
fix(strings): avoid counting false matches in z-function search

### DIFF
--- a/strings/z_function.py
+++ b/strings/z_function.py
@@ -68,20 +68,15 @@ def find_pattern(pattern: str, input_str: str) -> int:
     4
     >>> find_pattern("xz", "zxxzxxz")
     2
+    >>> find_pattern("aa", "a")
+    0
     """
-    answer = 0
+    pattern_length = len(pattern)
     # concatenate 'pattern' and 'input_str' and call z_function
     # with concatenated string
     z_result = z_function(pattern + input_str)
 
-    for val in z_result:
-        # if value is greater then length of the pattern string
-        # that means this index is starting position of substring
-        # which is equal to pattern string
-        if val >= len(pattern):
-            answer += 1
-
-    return answer
+    return sum(value >= pattern_length for value in z_result[pattern_length:])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your change

`find_pattern()` previously inspected Z-values belonging to the pattern prefix, causing it to count matches that crossed the boundary between the pattern and input string.

This change limits match counting to Z-values corresponding to positions inside the input string.

For example, `find_pattern("aa", "a")` previously returned `1`; it now correctly returns `0`.

Fixes #15303

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have [doctests](https://docs.python.org/3/library/doctest.html) that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [x] If this pull request resolves one or more open issues, then the description above includes the issue number(s) with a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue): "Fixes #ISSUE-NUMBER".
