### PR TITLE
sorts: make exchange_sort generic for comparable items

### DIFF
--- a/sorts/exchange_sort.py
+++ b/sorts/exchange_sort.py
@@ -1,4 +1,11 @@
-def exchange_sort(numbers: list[int]) -> list[int]:
+from typing import Any, Protocol
+
+
+class Comparable(Protocol):
+    def __lt__(self, other: Any, /) -> bool: ...
+
+
+def exchange_sort[T: Comparable](numbers: list[T]) -> list[T]:
     """
     Uses exchange sort to sort a list of numbers.
     Source: https://en.wikipedia.org/wiki/Sorting_algorithm#Exchange_sort
@@ -12,6 +19,14 @@ def exchange_sort(numbers: list[int]) -> list[int]:
     [-2, 0, 3, 5, 10]
     >>> exchange_sort([])
     []
+    >>> exchange_sort(["c", "a", "b"])
+    ['a', 'b', 'c']
+    >>> exchange_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+    >>> exchange_sort([1, "a"])  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+        ...
+    TypeError: '<' not supported between instances of 'str' and 'int'
     """
     numbers_length = len(numbers)
     for i in range(numbers_length):

--- a/sorts/exchange_sort.py
+++ b/sorts/exchange_sort.py
@@ -21,9 +21,9 @@ def exchange_sort[T: Comparable](numbers: list[T]) -> list[T]:
     []
     >>> exchange_sort(["c", "a", "b"])
     ['a', 'b', 'c']
-    >>> exchange_sort([2.5, -1.0, 0.0])
-    [-1.0, 0.0, 2.5]
-    >>> exchange_sort([1, "a"])  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> exchange_sort([2.5, -1, 0.0])
+    [-1, 0.0, 2.5]
+    >>> exchange_sort([1, "a"])
     Traceback (most recent call last):
         ...
     TypeError: '<' not supported between instances of 'str' and 'int'

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -117,6 +117,7 @@ def test_sort_matches_builtin(sort, case):
         circle_sort,
         cocktail_shaker_sort,
         comb_sort,
+        exchange_sort,
         gnome_sort,
         insertion_sort,
         merge_sort,


### PR DESCRIPTION
### Describe your change:

* [ ] Add an algorithm?
* [x] Fix a bug or typo in an existing algorithm?
* [x] Add or change doctests?
* [ ] Documentation change?

Make `exchange_sort()` generic over comparable element types while preserving its
in-place behavior and return element type.

Add doctests for strings, floats, and non-comparable mixed values, and include
`exchange_sort` in the shared `TypeError` test.

Part of #15234

### Checklist:

* [x] I have read `CONTRIBUTING.md`.
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [ ] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.
* [ ] All new algorithms include at least one URL that points to Wikipedia or another similar explanation.
* [ ] If this pull request resolves one or more open issues then the description above includes the issue number(s) with a closing keyword.
