### PR TITLE
sorts: make odd_even_sort support comparable items

### DIFF
--- a/sorts/odd_even_sort.py
+++ b/sorts/odd_even_sort.py
@@ -4,8 +4,14 @@ Odd even sort implementation.
 https://en.wikipedia.org/wiki/Odd%E2%80%93even_sort
 """
 
+from typing import Protocol
 
-def odd_even_sort(input_list: list) -> list:
+
+class Comparable(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+
+
+def odd_even_sort[T: Comparable](input_list: list[T]) -> list[T]:
     """
     Sort input with odd even sort.
 
@@ -13,7 +19,7 @@ def odd_even_sort(input_list: list) -> list:
     but by first dividing in two phase (odd and even).
     Originally developed for use on parallel processors
     with local interconnections.
-    :param collection: mutable ordered sequence of elements
+    :param input_list: mutable ordered sequence of comparable elements
     :return: same collection in ascending order
     Examples:
     >>> odd_even_sort([5 , 4 ,3 ,2 ,1])
@@ -24,18 +30,26 @@ def odd_even_sort(input_list: list) -> list:
     [-10, -1, 2, 10]
     >>> odd_even_sort([1 ,2 ,3 ,4])
     [1, 2, 3, 4]
+    >>> odd_even_sort(["c", "a", "b"])
+    ['a', 'b', 'c']
+    >>> odd_even_sort([2.5, -1.0, 0.0])
+    [-1.0, 0.0, 2.5]
+    >>> odd_even_sort([1, "a"])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    TypeError: ...
     """
     is_sorted = False
     while is_sorted is False:  # Until all the indices are traversed keep looping
         is_sorted = True
         for i in range(0, len(input_list) - 1, 2):  # iterating over all even indices
-            if input_list[i] > input_list[i + 1]:
+            if input_list[i + 1] < input_list[i]:
                 input_list[i], input_list[i + 1] = input_list[i + 1], input_list[i]
                 # swapping if elements not in order
                 is_sorted = False
 
         for i in range(1, len(input_list) - 1, 2):  # iterating over all odd indices
-            if input_list[i] > input_list[i + 1]:
+            if input_list[i + 1] < input_list[i]:
                 input_list[i], input_list[i + 1] = input_list[i + 1], input_list[i]
                 # swapping if elements not in order
                 is_sorted = False

--- a/tests/test_sorts.py
+++ b/tests/test_sorts.py
@@ -121,6 +121,7 @@ def test_sort_matches_builtin(sort, case) -> None:
         gnome_sort,
         insertion_sort,
         merge_sort,
+        odd_even_sort,
         selection_sort,
     ],
     ids=lambda f: f.__name__,


### PR DESCRIPTION
Part of #15234

## Summary

- make `odd_even_sort` generic over comparable item types (`[T: Comparable]`)
- rewrite the two `>` comparisons as `<` so the algorithm only relies on `__lt__`, which is what the `Comparable` protocol guarantees
- add non-integer doctest coverage (`str`, `float`) and a `TypeError` doctest for mixed non-comparable items
- add `odd_even_sort` to `test_sort_rejects_non_comparable_items`
- fix the docstring `:param:` name, which did not match the actual argument

The algorithm itself is unchanged: same odd/even phase loop, same swap logic, same complexity.

## Tests

- `python -m doctest -v sorts/odd_even_sort.py`
- `python -m pytest tests/test_sorts.py`
- `ruff check sorts/odd_even_sort.py tests/test_sorts.py`
