### PR TITLE
fix: preserve integer precision in trailing zeroes

### DIFF
--- a/maths/trailing_zeroes.py
+++ b/maths/trailing_zeroes.py
@@ -30,7 +30,7 @@ def trailing_zeroes(num: int) -> int:
             ans += 1
         else:
             break
-        num /= 10
+        num //= 10
     return ans
 
 


### PR DESCRIPTION
### Describe your change

* [x] Fix a bug or typo in an existing algorithm?
* [ ] Add an algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in the same pull request.
* [ ] Documentation change?

### Checklist

* [x] I have read CONTRIBUTING.md.
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
* [x] All function parameters and return values are annotated with Python type hints.
* [x] All functions have doctests that pass the automated testing.

### Details

Use integer division while removing trailing digits so large integer inputs retain their precision and the function continues returning an integer count. Part of #15187.

### Validation

* `uv run pytest maths/trailing_zeroes.py --doctest-modules -q`
* `uv run ruff check maths/trailing_zeroes.py`
* `uv run --with ty ty check maths/trailing_zeroes.py --output-format=concise`
* `uvx pre-commit run --files maths/trailing_zeroes.py`